### PR TITLE
[master]Default font of Tk has been set. #13

### DIFF
--- a/OpenRTM_aist/examples/Slider_and_Motor/slider.py
+++ b/OpenRTM_aist/examples/Slider_and_Motor/slider.py
@@ -24,6 +24,7 @@ class SliderMulti(Frame):
 		self._channels = channels
 		self.var = []
 		self.scales = []
+		self.option_add('*font', 'system 9')
 		
 		i = 0
 		for channel in self._channels:

--- a/OpenRTM_aist/examples/TkJoyStick/tkjoystick.py
+++ b/OpenRTM_aist/examples/TkJoyStick/tkjoystick.py
@@ -62,12 +62,14 @@ class CanvasText(ToggleItem):
         self.text = text
         self.x = x
         self.y = y
+        self.font = ('system', 9)
         self.draw_text(x, y, text)
 
     def draw(self):
         if self.active == False: return
         self.delete()
-        self.id = self.canvas.create_text(self.x, self.y, text=self.text)
+        self.id = self.canvas.create_text(self.x, self.y, text=self.text,
+                                          font=self.font)
 
     def draw_text(self, x, y, text):
         self.x = x
@@ -88,6 +90,7 @@ class CanvasAxis(ToggleItem):
         self.height = height
         self.canvas = canvas
         self.id = [None] * 4
+        self.font = ('system', 9)
         self.draw()
 
     def draw(self):
@@ -97,11 +100,11 @@ class CanvasAxis(ToggleItem):
                                              self.width, self.height/2)
         self.id[1] = self.canvas.create_text(self.width - 10,
                                              self.height/2 + 10,
-                                             text="x")
+                                             text="x", font=self.font)
         self.id[2] = self.canvas.create_line(self.width/2, 0, 
                                              self.width/2, self.height)
         self.id[3] = self.canvas.create_text(self.width/2 + 10,
-                                             + 10, text="y")
+                                             + 10, text="y", font=self.font)
         return
 
     def delete(self):
@@ -373,6 +376,7 @@ class TkJoystick(Frame):
     def init(self):
         self.canvas = Canvas(self, bg="white", \
                                  width = self.width, height = self.height)
+        self.canvas.option_add('*font', 'system 9')
         self.canvas.pack(side=LEFT)
 
         # coaxial pattern

--- a/OpenRTM_aist/examples/TkLRFViewer/TkLRFViewer.py
+++ b/OpenRTM_aist/examples/TkLRFViewer/TkLRFViewer.py
@@ -539,6 +539,7 @@ class TkLRFViewer(Frame):
   def init(self):
     self.canvas = Canvas(self, bg="#000000",
                          width = self.width, height = self.height)
+    self.canvas.option_add('*font', 'system 9')
     self.canvas.pack(side=LEFT)
 
     self.can_grid = CanvasGrid(self.canvas, self.x0, self.y0,


### PR DESCRIPTION
close #13 
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #13


## Description of the Change
- Tkinterのデフォルトフォントを、下記3ファイルとも 'system 9' とした
- TkJoyStick/tkjoystick.py
  - デフォルトフォント指定だけでは画面右半分の文字しか表示されなかったため、左半分は個別にフォントを指定している

![tkjoystick_ 13](https://user-images.githubusercontent.com/19547996/52323181-75c97300-2a1f-11e9-9ecf-f3e373084877.png)

- Slider_and_Motor/slider.py

![slider_ 13](https://user-images.githubusercontent.com/19547996/52323504-980fc080-2a20-11e9-889c-a5fad46caec2.png)

- TkLRFViewer/TkLRFViewer.py

![tklrfviewer_ 13](https://user-images.githubusercontent.com/19547996/52323529-b4abf880-2a20-11e9-909b-a4c3c92a858e.png)

## Verification 

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
- 修正動作をFedora29とUbuntu16.04で確認（上図参照）