### PR TITLE
シリアライザ生成ファクトリの実装 #21

### DIFF
--- a/OpenRTM_aist/ByteDataStreamBase.py
+++ b/OpenRTM_aist/ByteDataStreamBase.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+# -*- coding: euc-jp -*-
+
+##
+# @file ByteDataStreamBase.py
+# @brief ByteData Stream Base class
+# @date $Date$
+# @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+#
+# Copyright (C) 2019
+#     Noriaki Ando
+#     Robot Innovation Research Center,
+#     National Institute of
+#         Advanced Industrial Science and Technology (AIST), Japan
+#     All rights reserved.
+#
+# $Id$
+#
+
+import OpenRTM_aist
+
+
+##
+# @if jp
+# @class 
+#
+#
+# @else
+# @brief 
+#
+#
+# @endif
+class ByteDataStreamBase:
+  """
+  """
+  SERIALIZE_OK = 0
+  SERIALIZE_ERROR = 1
+  SERIALIZE_NOTFOUND = 2
+  SERIALIZE_NOT_SUPPORT_ENDIAN = 3
+
+
+  ##
+  # @if jp
+  # @brief 設定初期化
+  #
+  # 
+  # @param prop 設定情報
+  #
+  # @else
+  #
+  # @brief Initializing configuration
+  #
+  #
+  # @param prop Configuration information
+  #
+  # @endif
+  ## virtual ReturnCode init(coil::Properties& prop) = 0;
+  def init(self, prop):
+    pass
+
+
+
+  ##
+  # @if jp
+  # @brief エンディアンの設定
+  #
+  # 
+  # @param little_endian リトルエンディアン(True)、ビッグエンディアン(False)
+  #
+  # @else
+  #
+  # @brief 
+  #
+  #
+  # @param little_endian 
+  #
+  # @endif
+  ## virtual void isLittleEndian(bool little_endian) = 0;
+  def isLittleEndian(self, little_endian):
+    pass
+
+
+  ##
+  # @if jp
+  # @brief データの符号化
+  #
+  # 
+  # @param data 符号化前のデータ
+  # @return SERIALIZE_OK：成功、SERIALIZE_ERROR：失敗、SERIALIZE_NOTFOUND：指定のシリアライザがない
+  #
+  # @else
+  #
+  # @brief 
+  #
+  #
+  # @param data 
+  # @return
+  #
+  # @endif
+  ## virtual bool serialize(const DataType& data) = 0;
+  def serialize(self, data):
+    return ByteDataStreamBase.SERIALIZE_NOTFOUND
+
+
+  ##
+  # @if jp
+  # @brief データの復号化
+  #
+  # 
+  # @param data_type データ型
+  # @return ret、value
+  # ret：SERIALIZE_OK：成功、SERIALIZE_ERROR：失敗、SERIALIZE_NOTFOUND：指定のシリアライザがない
+  # value：復号化後のデータ
+  #
+  # @else
+  #
+  # @brief 
+  #
+  #
+  # @param data_type 
+  # @return 
+  #
+  # @endif
+  ## virtual bool deserialize(DataType& data) = 0;
+  def deserialize(self, data_type):
+    return ByteDataStreamBase.SERIALIZE_NOTFOUND
+
+
+
+
+serializerfactory = None
+
+class SerializerFactory(OpenRTM_aist.Factory,ByteDataStreamBase):
+  def __init__(self):
+    OpenRTM_aist.Factory.__init__(self)
+    pass
+
+
+  def __del__(self):
+    pass
+
+
+  def instance():
+    global serializerfactory
+
+    if serializerfactory is None:
+      serializerfactory = SerializerFactory()
+
+    return serializerfactory
+
+  instance = staticmethod(instance)

--- a/OpenRTM_aist/ByteDataStreamBase.py
+++ b/OpenRTM_aist/ByteDataStreamBase.py
@@ -99,14 +99,14 @@ class ByteDataStreamBase:
   # @endif
   ## virtual bool serialize(const DataType& data) = 0;
   def serialize(self, data):
-    return ByteDataStreamBase.SERIALIZE_NOTFOUND
+    return ByteDataStreamBase.SERIALIZE_NOTFOUND, ""
 
 
   ##
   # @if jp
   # @brief データの復号化
   #
-  # 
+  # @param cdr バイト列
   # @param data_type データ型
   # @return ret、value
   # ret：SERIALIZE_OK：成功、SERIALIZE_ERROR：失敗、SERIALIZE_NOTFOUND：指定のシリアライザがない
@@ -116,14 +116,14 @@ class ByteDataStreamBase:
   #
   # @brief 
   #
-  #
+  # @param cdr
   # @param data_type 
   # @return 
   #
   # @endif
   ## virtual bool deserialize(DataType& data) = 0;
-  def deserialize(self, data_type):
-    return ByteDataStreamBase.SERIALIZE_NOTFOUND
+  def deserialize(self, cdr, data_type):
+    return ByteDataStreamBase.SERIALIZE_NOTFOUND, data_type
 
 
 

--- a/OpenRTM_aist/CORBA_CdrMemoryStream.py
+++ b/OpenRTM_aist/CORBA_CdrMemoryStream.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+# -*- coding: euc-jp -*-
+
+##
+# @file CORBA_CdrMemoryStream.py
+# @brief CORBA Cdr Memory Stream class
+# @date $Date$
+# @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+#
+# Copyright (C) 2019
+#     Noriaki Ando
+#     Robot Innovation Research Center,
+#     National Institute of
+#         Advanced Industrial Science and Technology (AIST), Japan
+#     All rights reserved.
+#
+# $Id$
+#
+
+import OpenRTM_aist
+from omniORB import cdrMarshal
+from omniORB import cdrUnmarshal
+from omniORB import any
+
+##
+# @if jp
+# @class 
+#
+#
+# @else
+# @brief 
+#
+#
+# @endif
+class CORBA_CdrMemoryStream(OpenRTM_aist.ByteDataStreamBase):
+  """
+  """
+
+  ##
+  # @if jp
+  # @brief コンストラクタ
+  #
+  # コンストラクタ
+  #
+  # @param self
+  #
+  # @else
+  # @brief Constructor
+  #
+  # @param self
+  #
+  # @endif
+  def __init__(self):
+    self._endian = None
+
+  ##
+  # @if jp
+  # @brief デストラクタ
+  #
+  #
+  # @param self
+  #
+  # @else
+  #
+  # @brief self
+  #
+  # @endif
+  def __del__(self):
+    pass
+
+  ##
+  # @if jp
+  # @brief 設定初期化
+  #
+  # 
+  # @param prop 設定情報
+  #
+  # @else
+  #
+  # @brief Initializing configuration
+  #
+  #
+  # @param prop Configuration information
+  #
+  # @endif
+  ## virtual ReturnCode init(coil::Properties& prop) = 0;
+  def init(self, prop):
+    pass
+
+  ##
+  # @if jp
+  # @brief エンディアンの設定
+  #
+  # 
+  # @param little_endian リトルエンディアン(True)、ビッグエンディアン(False)
+  #
+  # @else
+  #
+  # @brief 
+  #
+  #
+  # @param little_endian 
+  #
+  # @endif
+  ## virtual void isLittleEndian(bool little_endian) = 0;
+  def isLittleEndian(self, little_endian):
+    self._endian = little_endian
+
+
+  ##
+  # @if jp
+  # @brief データの符号化
+  #
+  # 
+  # @param data 符号化前のデータ
+  # @return ret、value
+  # ret：SERIALIZE_OK：成功、SERIALIZE_ERROR：失敗、SERIALIZE_NOTFOUND：指定のシリアライザがない
+  # cdr：バイト列
+  #
+  # @else
+  #
+  # @brief 
+  #
+  #
+  # @param data 
+  # @return
+  #
+  # @endif
+  ## virtual bool serialize(const DataType& data) = 0;
+  def serialize(self, data):
+    if self._endian is not None:
+      cdr = cdrMarshal(any.to_any(data).typecode(), data, self._endian)
+      return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK, cdr
+    else:
+      return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN, ""
+
+
+  ##
+  # @if jp
+  # @brief データの復号化
+  #
+  # @param cdr バイト列
+  # @param data_type データ型
+  # @return ret、value
+  # ret：SERIALIZE_OK：成功、SERIALIZE_ERROR：失敗、SERIALIZE_NOTFOUND：指定のシリアライザがない
+  # value：復号化後のデータ
+  #
+  # @else
+  #
+  # @brief 
+  #
+  # @param cdr
+  # @param data_type 
+  # @return 
+  #
+  # @endif
+  ## virtual bool deserialize(DataType& data) = 0;
+  def deserialize(self, cdr, data_type):
+    if self._endian is not None:
+      data = cdrUnmarshal(any.to_any(data_type).typecode(), cdr ,self._endian)
+      return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK, data
+    else:
+      return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN, data_type
+
+
+
+def CORBA_CdrMemoryStreamInit():
+  OpenRTM_aist.SerializerFactory.instance().addFactory("corba",
+                                                      OpenRTM_aist.CORBA_CdrMemoryStream,
+                                                      OpenRTM_aist.Delete)
+

--- a/OpenRTM_aist/ConnectorListener.py
+++ b/OpenRTM_aist/ConnectorListener.py
@@ -334,11 +334,11 @@ class ConnectorDataListenerT(ConnectorDataListener):
     else:
       endian = True
 
-    marshalling_type = info.properties.getProperty("marshalling_type", "corba")
-    marshalling_type = marshalling_type.strip()
+    marshaling_type = info.properties.getProperty("marshaling_type", "corba")
+    marshaling_type = marshaling_type.strip()
 
 
-    serializer = OpenRTM_aist.SerializerFactory.instance().createObject(marshalling_type)
+    serializer = OpenRTM_aist.SerializerFactory.instance().createObject(marshaling_type)
 
     serializer.isLittleEndian(endian)
     ret, _data = serializer.deserialize(cdrdata, data)

--- a/OpenRTM_aist/ConnectorListener.py
+++ b/OpenRTM_aist/ConnectorListener.py
@@ -15,8 +15,6 @@
 #         Advanced Industrial Science and Technology (AIST), Japan
 #     All rights reserved.
 
-from omniORB import cdrUnmarshal
-from omniORB import any
 
 import OpenRTM_aist
 import OpenRTM_aist.Guard
@@ -336,7 +334,17 @@ class ConnectorDataListenerT(ConnectorDataListener):
     else:
       endian = True
 
-    _data = cdrUnmarshal(any.to_any(data).typecode(), cdrdata, endian)
+    marshalling_type = info.properties.getProperty("marshalling_type", "corba")
+    marshalling_type = marshalling_type.strip()
+
+
+    serializer = OpenRTM_aist.SerializerFactory.instance().createObject(marshalling_type)
+
+    serializer.isLittleEndian(endian)
+    ret, _data = serializer.deserialize(cdrdata, data)
+
+    OpenRTM_aist.SerializerFactory.instance().deleteObject(serializer)
+
     return _data
 
 

--- a/OpenRTM_aist/FactoryInit.py
+++ b/OpenRTM_aist/FactoryInit.py
@@ -51,4 +51,5 @@ def FactoryInit():
     OpenRTM_aist.OutPortDSConsumerInit()
     OpenRTM_aist.InPortDSProviderInit()
     OpenRTM_aist.InPortDSConsumerInit()
+    OpenRTM_aist.CORBA_CdrMemoryStreamInit()
     ComponentObserverConsumer.ComponentObserverConsumerInit()

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -142,10 +142,10 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
     self._consumer.setListener(info, self._listeners)
     self.onConnect()
 
-    self._marshalling_type = info.properties.getProperty("marshalling_type", "corba")
-    self._marshalling_type = self._marshalling_type.strip()
+    self._marshaling_type = info.properties.getProperty("marshaling_type", "corba")
+    self._marshaling_type = self._marshaling_type.strip()
 
-    self._serializer = OpenRTM_aist.SerializerFactory.instance().createObject(self._marshalling_type)
+    self._serializer = OpenRTM_aist.SerializerFactory.instance().createObject(self._marshaling_type)
     
     return
 

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -238,6 +238,9 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
     ret = self._consumer.get(cdr_data)
 
     if ret == self.PORT_OK:
+      if len(data) == 0:
+        self._rtcout.RTC_ERROR("argument is invalid")
+        return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET
       
       self._serializer.isLittleEndian(self._endian)
       ser_ret, data[0] = self._serializer.deserialize(cdr_data[0], data[0])

--- a/OpenRTM_aist/InPortPushConnector.py
+++ b/OpenRTM_aist/InPortPushConnector.py
@@ -257,22 +257,23 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
 
     if not self._dataType:
       return self.PRECONDITION_NOT_MET
-    self._serializer.isLittleEndian(self._endian)
-    ser_ret, _data = self._serializer.deserialize(cdr[0], self._dataType)
 
-    if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK:
-      if ret == OpenRTM_aist.BufferStatus.BUFFER_OK:
+    if ret == OpenRTM_aist.BufferStatus.BUFFER_OK:
+      self._serializer.isLittleEndian(self._endian)
+      ser_ret, _data = self._serializer.deserialize(cdr[0], self._dataType)
+
+      if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK:
         if type(data) == list:
           data[0] = _data
-    elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:
-      self._rtcout.RTC_ERROR("unknown endian from connector")
-      return self.PRECONDITION_NOT_MET
-    elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR:
-      self._rtcout.RTC_ERROR("unknown error")
-      return self.PRECONDITION_NOT_MET
-    elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOTFOUND:
-      self._rtcout.RTC_ERROR("unknown serializer from connector")
-      return self.PRECONDITION_NOT_MET
+      elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:
+        self._rtcout.RTC_ERROR("unknown endian from connector")
+        return self.PRECONDITION_NOT_MET
+      elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR:
+        self._rtcout.RTC_ERROR("unknown error")
+        return self.PRECONDITION_NOT_MET
+      elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOTFOUND:
+        self._rtcout.RTC_ERROR("unknown serializer from connector")
+        return self.PRECONDITION_NOT_MET
     
 
 

--- a/OpenRTM_aist/InPortPushConnector.py
+++ b/OpenRTM_aist/InPortPushConnector.py
@@ -156,10 +156,10 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
     self._readcompleted_worker = InPortPushConnector.WorkerThreadCtrl()
     self._readready_worker = InPortPushConnector.WorkerThreadCtrl()
 
-    self._marshalling_type = info.properties.getProperty("marshalling_type", "corba")
-    self._marshalling_type = self._marshalling_type.strip()
+    self._marshaling_type = info.properties.getProperty("marshaling_type", "corba")
+    self._marshaling_type = self._marshaling_type.strip()
 
-    self._serializer = OpenRTM_aist.SerializerFactory.instance().createObject(self._marshalling_type)
+    self._serializer = OpenRTM_aist.SerializerFactory.instance().createObject(self._marshaling_type)
     
 
     return

--- a/OpenRTM_aist/OutPortPullConnector.py
+++ b/OpenRTM_aist/OutPortPullConnector.py
@@ -152,10 +152,10 @@ class OutPortPullConnector(OpenRTM_aist.OutPortConnector):
     self._readcompleted_worker = OutPortPullConnector.WorkerThreadCtrl()
     self._readready_worker = OutPortPullConnector.WorkerThreadCtrl()
     
-    self._marshalling_type = info.properties.getProperty("marshalling_type", "corba")
-    self._marshalling_type = self._marshalling_type.strip()
+    self._marshaling_type = info.properties.getProperty("marshaling_type", "corba")
+    self._marshaling_type = self._marshaling_type.strip()
 
-    self._serializer = OpenRTM_aist.SerializerFactory.instance().createObject(self._marshalling_type)
+    self._serializer = OpenRTM_aist.SerializerFactory.instance().createObject(self._marshaling_type)
     
     
     return
@@ -210,7 +210,7 @@ class OutPortPullConnector(OpenRTM_aist.OutPortConnector):
       self._rtcout.RTC_ERROR("unkown error.")
       return self.UNKNOWN_ERROR
     elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOTFOUND:
-      self._rtcout.RTC_ERROR("write(): serializer %s is not support.",self._marshalling_type)
+      self._rtcout.RTC_ERROR("write(): serializer %s is not support.",self._marshaling_type)
       return self.UNKNOWN_ERROR
 
     if self._buffer:

--- a/OpenRTM_aist/OutPortPullConnector.py
+++ b/OpenRTM_aist/OutPortPullConnector.py
@@ -17,8 +17,6 @@
 #     All rights reserved.
 #
 
-from omniORB import cdrMarshal
-from omniORB import any
 
 import OpenRTM_aist
 import threading
@@ -154,6 +152,12 @@ class OutPortPullConnector(OpenRTM_aist.OutPortConnector):
     self._readcompleted_worker = OutPortPullConnector.WorkerThreadCtrl()
     self._readready_worker = OutPortPullConnector.WorkerThreadCtrl()
     
+    self._marshalling_type = info.properties.getProperty("marshalling_type", "corba")
+    self._marshalling_type = self._marshalling_type.strip()
+
+    self._serializer = OpenRTM_aist.SerializerFactory.instance().createObject(self._marshalling_type)
+    
+    
     return
 
 
@@ -197,12 +201,18 @@ class OutPortPullConnector(OpenRTM_aist.OutPortConnector):
     if self._directMode:
       return self.PORT_OK
     # data -> (conversion) -> CDR stream
-    cdr_data = None
-    if self._endian is not None:
-      cdr_data = cdrMarshal(any.to_any(data).typecode(), data, self._endian)
-    else:
+    self._serializer.isLittleEndian(self._endian)
+    ser_ret, cdr_data = self._serializer.serialize(data)
+    if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:
       self._rtcout.RTC_ERROR("write(): endian %s is not support.",self._endian)
       return self.UNKNOWN_ERROR
+    elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR:
+      self._rtcout.RTC_ERROR("unkown error.")
+      return self.UNKNOWN_ERROR
+    elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOTFOUND:
+      self._rtcout.RTC_ERROR("write(): serializer %s is not support.",self._marshalling_type)
+      return self.UNKNOWN_ERROR
+
     if self._buffer:
       if self._sync_readwrite:
         self._readready_worker._cond.acquire()
@@ -287,13 +297,17 @@ class OutPortPullConnector(OpenRTM_aist.OutPortConnector):
     if self._provider:
       OpenRTM_aist.OutPortProviderFactory.instance().deleteObject(self._provider)
       self._provider.exit()
-    self._provider = 0
+    self._provider = None
 
     # delete buffer
     if self._buffer:
       OpenRTM_aist.CdrBufferFactory.instance().deleteObject(self._buffer)
-    self._buffer = 0
+    self._buffer = None
 
+
+    if self._serializer:
+      OpenRTM_aist.SerializerFactory.instance().deleteObject(self._serializer)
+    self._serializer = None
 
 
     return self.PORT_OK

--- a/OpenRTM_aist/OutPortPushConnector.py
+++ b/OpenRTM_aist/OutPortPushConnector.py
@@ -169,10 +169,10 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
     self._publisher.setBuffer(self._buffer)
     self._publisher.setListener(self._profile, self._listeners)
 
-    self._marshalling_type = info.properties.getProperty("marshalling_type", "corba")
-    self._marshalling_type = self._marshalling_type.strip()
+    self._marshaling_type = info.properties.getProperty("marshaling_type", "corba")
+    self._marshaling_type = self._marshaling_type.strip()
 
-    self._serializer = OpenRTM_aist.SerializerFactory.instance().createObject(self._marshalling_type)
+    self._serializer = OpenRTM_aist.SerializerFactory.instance().createObject(self._marshaling_type)
     
 
     self.onConnect()
@@ -270,7 +270,7 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
       self._rtcout.RTC_ERROR("unkown error.")
       return self.UNKNOWN_ERROR
     elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOTFOUND:
-      self._rtcout.RTC_ERROR("write(): serializer %s is not support.",self._marshalling_type)
+      self._rtcout.RTC_ERROR("write(): serializer %s is not support.",self._marshaling_type)
       return self.UNKNOWN_ERROR
 
     return self._publisher.write(cdr_data, -1, 0)

--- a/OpenRTM_aist/OutPortPushConnector.py
+++ b/OpenRTM_aist/OutPortPushConnector.py
@@ -17,8 +17,6 @@
 #     All rights reserved.
 #
 
-from omniORB import cdrMarshal
-from omniORB import any
 
 import OpenRTM_aist
 
@@ -171,6 +169,12 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
     self._publisher.setBuffer(self._buffer)
     self._publisher.setListener(self._profile, self._listeners)
 
+    self._marshalling_type = info.properties.getProperty("marshalling_type", "corba")
+    self._marshalling_type = self._marshalling_type.strip()
+
+    self._serializer = OpenRTM_aist.SerializerFactory.instance().createObject(self._marshalling_type)
+    
+
     self.onConnect()
     return
 
@@ -257,11 +261,16 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
       self._rtcout.RTC_TRACE("callback called in direct mode.")
       return self.PORT_OK
     # data -> (conversion) -> CDR stream
-    cdr_data = None
-    if self._endian is not None:
-      cdr_data = cdrMarshal(any.to_any(data).typecode(), data, self._endian)
-    else:
+    self._serializer.isLittleEndian(self._endian)
+    ser_ret, cdr_data = self._serializer.serialize(data)
+    if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:
       self._rtcout.RTC_ERROR("write(): endian %s is not support.",self._endian)
+      return self.UNKNOWN_ERROR
+    elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR:
+      self._rtcout.RTC_ERROR("unkown error.")
+      return self.UNKNOWN_ERROR
+    elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOTFOUND:
+      self._rtcout.RTC_ERROR("write(): serializer %s is not support.",self._marshalling_type)
       return self.UNKNOWN_ERROR
 
     return self._publisher.write(cdr_data, -1, 0)
@@ -309,6 +318,13 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
       bfactory.deleteObject(self._buffer)
 
     self._buffer = None
+
+    if self._serializer:
+      self._rtcout.RTC_DEBUG("delete serializer")
+      OpenRTM_aist.SerializerFactory.instance().deleteObject(self._serializer)
+    self._serializer = None
+
+
     self._rtcout.RTC_TRACE("disconnect() done")
 
     return self.PORT_OK

--- a/OpenRTM_aist/__init__.py
+++ b/OpenRTM_aist/__init__.py
@@ -131,4 +131,5 @@ import Macho
 from Timestamp import *
 from MultilayerCompositeEC import *
 #from MultilayerCompositeChildEC import *
-
+from ByteDataStreamBase import *
+from CORBA_CdrMemoryStream import *


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#21 


## Description of the Change

シリアライザの基底クラスとして**ByteDataStreamBase**クラスを定義した。
シリアライザは**ByteDataStreamBase**クラスを継承して**init**関数、**isLittleEndian**関数、**serialize**関数、**deserialize**関数を実装する必要がある。

以下の実装例を示す。

```CPP
#!/usr/bin/env python
# -*- coding: euc-jp -*-


import OpenRTM_aist
import RTC



class testSerializer(OpenRTM_aist.ByteDataStreamBase):

  def __init__(self):
    self._endian = None


  def __del__(self):
    pass

  def init(self, prop):
    pass


  def isLittleEndian(self, little_endian):
    pass



  def serialize(self, data):
    if data._NP_RepositoryId == RTC.TimedLong._NP_RepositoryId:
        return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK, ""
    else:
        return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR, ""



  def deserialize(self, cdr, data_type):
    if data_type._NP_RepositoryId == RTC.TimedLong._NP_RepositoryId:
        data_type.data = 444
        return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK, data_type
    else:
        return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR, data_type



def testSerializerInit(mgr):
  OpenRTM_aist.SerializerFactory.instance().addFactory("test",
                                                      testSerializer,
                                                      OpenRTM_aist.Delete)
```

データの符号化は**serialize**関数により行う。
**serialize**関数はリターンコードと符号化後のデータを返す必要がある。

以下にリターンコードの一覧を掲載する。

|名前|意味|
|---|---|
|SERIALIZE_OK|問題なし|
|SERIALIZE_NOTFOUND|データ型に対応したシリアライザが存在しない|
|SERIALIZE_NOT_SUPPORT_ENDIAN|対応していないエンディアンを設定した|
|SERIALIZE_ERROR|上記以外のエラー|

データ型による分岐が必要な場合は`data._NP_RepositoryId == RTC.TimedLong._NP_RepositoryId`のようにIDから判別を行い分岐するようにする。

データの復号化は**deserialize**関数により行う。
**deserialize**関数はリターンコードと復号後のデータを返す必要がある。

シリアライザを追加する場合は、rtc.confに設定を記述する。
```
manager.modules.load_path: ./
manager.modules.preload: testSerializer
```

使用する場合はコネクタ接続時に`dataport.marshaling_type`のプロパティを設定することで使用できる。


またCORBAのCDRのシリアライザとして**CORBA_CdrMemoryStream**クラスを実装した。
デフォルトではCORBAのCDRシリアライザを使用するようになっている。

## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
