### PR TITLE
[master] Shebang rewriting when creating rpm package. #12

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include setup.py
 include README
 recursive-include packages Makefile
 recursive-include packages/deb *.sh copyright changelog rules README* compat control control.* files
-recursive-include packages/rpm *.sh openrtm-aist.spec.in openrtm-aist_fc19.spec.in
+recursive-include packages/rpm *.sh openrtm-aist.spec.in openrtm-aist_py3.spec.in
 recursive-include OpenRTM_aist *.conf *.exe *.idl *.py *.pth *.sh
 recursive-include OpenRTM_aist *.bat *.exe *.sample README
 recursive-include OpenRTM_aist/docs *.css *.gif *.png *.html *.hhc *.hhk *.hhp Doxyfile_en.in Doxyfile_jp.in

--- a/packages/rpm/openrtm-aist_py3.spec.in
+++ b/packages/rpm/openrtm-aist_py3.spec.in
@@ -1,0 +1,127 @@
+#------------------------------------------------------------
+#
+# @file RPM spec file for OpenRTM-aist-Python
+# @author Noriaki Ando <n-ando@aist.go.jp>
+#
+# $Id$
+#
+
+%define pkgname OpenRTM-aist-Python
+%define version __VERSION__
+%define short_version __SHORT_VERSION__
+%define distname       __DISTNAME__
+%define builddir       %{_topdir}/BUILD/%{distname}
+%define pkgver         0
+%define _unpackaged_files_terminate_build   0
+%global debug_package %{nil}
+
+#------------------------------------------------------------
+# Package information
+Name: OpenRTM-aist-Python
+Version: %{version}
+Release: %{pkgver}.%{distname}
+Summary: Python modules for OpenRTM-aist
+Group: Applications/System
+License: LGPL
+URL: http://openrtm.org
+Source0: %{pkgname}-%{version}.tar.gz
+Vendor: AIST <n-ando@aist.go.jp>
+
+Prefix: %{_prefix}
+Buildroot: %{_tmppath}/%{pkgname}-%{version}-%{release}-root
+
+Requires: python3
+Requires: omniORBpy-devel
+
+BuildRequires: python3-devel
+
+%description
+OpenRTM-aist is a reference implementation of RTC (Robotic Technology
+Component Version 1.1, formal/12-09-01) specification which is OMG
+standard (http://www.omg.org/spec/RTC/). OpenRTM-aist includes
+RT-Middleware runtime environment and RTC framework. The OMG standard
+defines a component model and certain important infrastructure
+services applicable to the domain of robotics software
+development. OpenRTM-aist is being developed and distributed by
+National Institute of Advanced Industrial Science and Technology
+(AIST), Japan. Please see http://www.openrtm.org/ for more detail.
+
+#------------------------------------------------------------
+# doc package
+%package doc
+Summary: Documentation
+Group: Development/Libraries
+%description doc
+Class reference manual of OpenRTM-aist.
+
+#------------------------------------------------------------
+# example package
+%package example
+Summary: Example
+Group: Development/Libraries
+Requires: OpenRTM-aist-Python
+%description example
+Example components and sources of OpenRTM-aist.
+
+#------------------------------------------------------------
+# prep section
+%prep
+%{__rm} -rf %{buildroot}
+%setup
+
+#------------------------------------------------------------
+# build section
+%build
+%{__python3} setup.py build_core
+%{__python3} setup.py build_example
+
+#------------------------------------------------------------
+# install section
+%install
+%{__python3} setup.py install --root=%{buildroot} --record=INSTALLED_FILES
+
+#------------------------------------------------------------
+# clean section
+%clean
+#rm -rf %{buildroot}
+
+#------------------------------------------------------------
+# core files section
+%files
+%defattr(-,root,root)
+%{python3_sitelib}/OpenRTM-aist.pth
+%{python3_sitelib}/OpenRTM_aist_Python-%{version}-py%{python_version}.egg-info
+%{python3_sitelib}/OpenRTM_aist
+%attr(755,root,root) %{_bindir}/*
+
+#------------------------------------------------------------
+# doc package file list
+%files doc
+%defattr(-,root,root,-)
+%{_datadir}/openrtm-%{short_version}/doc/python/
+
+
+#------------------------------------------------------------
+# example package file list
+%files example
+%defattr(755,root,root,-)
+%{_datadir}/openrtm-%{short_version}/components/python/
+
+
+#------------------------------------------------------------
+# changelog section
+%changelog
+* Wed Nov 16 2016  <n-ando@aist.go.jp> 1.2.0-0._distname
+- 1.2.0-RELEASE
+
+* Tue Feb 23 2016  <n-ando@aist.go.jp> 1.1.2
+- 1.1.2-RELEASE
+
+* Wed Oct 21 2015  <n-ando@aist.go.jp> 1.1.1
+- 1.1.1-RELEASE
+
+* Wed May 01 2013  <n-ando@aist.go.jp> 1.1.0
+- 1.1.0-RELEASE
+
+* Thu Sep 27 2007 Noriaki Ando <n-ando@aist.go.jp> - 0.4.1-1._distname
+- The second public release version of OpenRTM-aist-0.4.1.


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #12 

## Identify the Bug

Link to #12

## Description of the Change
- シバンの書き換えは、*.pyファイルだけでなく、/usr/bin下にインストールするrtcd_pythonとrtcprof_pythonも対象にする

- 当初、シバンの書き換えは「env python」→「env python3」としていた。
処理の途中段階で、rpm/SOURCES/に出力するものは「#!/usr/bin/env python3」と
なっているのに、パーミッションで実行権限が付いている/usr/bin下にインストールするファイルは、最終的に「#!/usr/bin/python2」と書き換わっていると判明。

- 「python2」となる原因
  - specファイルで使っているマクロ%{__python}、%{python_sitelib} はpython2用だから
  - python3の場合は、%{__python3}、%{python3_sitelib}マクロを使用する。このマクロ使用のため、python3-develのインストールが必要で、specファイル内も「BuildRequires: python3-devel」の定義が必要。

- 対応
  - 従来の「openrtm-aist.spec.in」はpython2用として変更せず
  - python3用は新たに「openrtm-aist_py3.spec.in」を定義し、rpm_build.sh内で、Fedoraバージョンが29以上はpython3用を使うようにした

- 自動でシバンの「env」が除かれる件
  - 下記リンクのFedoraドキュメントによると、envは使ってはいけないとのこと　
「/usr/bin/python (as well as /usr/bin/env python and similar) MUST NOT be used in shebang lines or as a dependency of a package. 」
https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/
  - また、上記ドキュメントによると、Fedora30からはシバンの中にバージョン番号「2」or「３」が含まれていないとビルドエラーになるとのこと
  - このため、rpm_build.shでのシバンの書換えは、「#!/usr/bin/python3」としている


## Verification 

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
- Fedora28と29でrpmパッケージを作成して確認