### PR TITLE
put、get関数で毎回_narrow関数を呼ばないようにする

### DIFF
--- a/OpenRTM_aist/InPortCorbaCdrConsumer.py
+++ b/OpenRTM_aist/InPortCorbaCdrConsumer.py
@@ -71,7 +71,7 @@ class InPortCorbaCdrConsumer(OpenRTM_aist.InPortConsumer,OpenRTM_aist.CorbaConsu
   # @endif
   #
   def __init__(self):
-    OpenRTM_aist.CorbaConsumer.__init__(self)
+    OpenRTM_aist.CorbaConsumer.__init__(self, OpenRTM.InPortCdr)
     self._rtcout = OpenRTM_aist.Manager.instance().getLogbuf("InPortCorbaCdrConsumer")
     self._properties = None
     return
@@ -151,9 +151,8 @@ class InPortCorbaCdrConsumer(OpenRTM_aist.InPortConsumer,OpenRTM_aist.CorbaConsu
     self._rtcout.RTC_PARANOID("put()")
 
     try:
-      ref_ = self.getObject()
-      if ref_:
-        inportcdr = ref_._narrow(OpenRTM.InPortCdr)
+      inportcdr = self._ptr()
+      if inportcdr:
         return self.convertReturnCode(inportcdr.put(data))
       return self.CONNECTION_LOST
     except:

--- a/OpenRTM_aist/InPortDSConsumer.py
+++ b/OpenRTM_aist/InPortDSConsumer.py
@@ -70,7 +70,7 @@ class InPortDSConsumer(OpenRTM_aist.InPortConsumer,OpenRTM_aist.CorbaConsumer):
   # @endif
   #
   def __init__(self):
-    OpenRTM_aist.CorbaConsumer.__init__(self)
+    OpenRTM_aist.CorbaConsumer.__init__(self, RTC.DataPushService)
     self._rtcout = OpenRTM_aist.Manager.instance().getLogbuf("InPortDSConsumer")
     self._properties = None
     return
@@ -150,10 +150,9 @@ class InPortDSConsumer(OpenRTM_aist.InPortConsumer,OpenRTM_aist.CorbaConsumer):
     self._rtcout.RTC_PARANOID("put()")
 
     try:
-      ref_ = self.getObject()
-      if ref_:
-        ds = ref_._narrow(RTC.DataPushService)
-        return self.convertReturnCode(ds.push(data))
+      dataservice = self._ptr()
+      if dataservice:
+        return self.convertReturnCode(dataservice.push(data))
       return self.CONNECTION_LOST
     except:
       self._rtcout.RTC_ERROR(OpenRTM_aist.Logger.print_exception())

--- a/OpenRTM_aist/InPortSHMConsumer.py
+++ b/OpenRTM_aist/InPortSHMConsumer.py
@@ -57,14 +57,13 @@ class InPortSHMConsumer(OpenRTM_aist.InPortCorbaCdrConsumer):
   #
   def __init__(self):
     OpenRTM_aist.InPortCorbaCdrConsumer.__init__(self)
+    OpenRTM_aist.CorbaConsumer.__init__(self, OpenRTM__POA.PortSharedMemory)
     self._rtcout = OpenRTM_aist.Manager.instance().getLogbuf("InPortSHMConsumer")
     self._properties = None
     
     self._shm_address = str(OpenRTM_aist.uuid1())
     
     self._shmem = OpenRTM_aist.SharedMemory()
-    
-    
 
     self._mutex = threading.RLock()
       
@@ -152,12 +151,9 @@ class InPortSHMConsumer(OpenRTM_aist.InPortCorbaCdrConsumer):
 
   def setObject(self, obj):
     if OpenRTM_aist.CorbaConsumer.setObject(self, obj):
-      ref_ = self.getObject()
-      if ref_:
-        inportcdr = ref_._narrow(OpenRTM__POA.PortSharedMemory)
-        if inportcdr is None:
-          return False
-        self._shmem.setInterface(inportcdr)
+      portshmem = self._ptr()
+      if portshmem:
+        self._shmem.setInterface(portshmem)
 
         return True
     return False
@@ -190,9 +186,8 @@ class InPortSHMConsumer(OpenRTM_aist.InPortCorbaCdrConsumer):
     self._rtcout.RTC_PARANOID("put()")
 
     try:
-      ref_ = self.getObject()
-      if ref_:
-        inportcdr = ref_._narrow(OpenRTM__POA.PortSharedMemory)
+      portshmem = self._ptr()
+      if portshmem:
         
         guard = OpenRTM_aist.ScopedLock(self._mutex)
         
@@ -201,7 +196,7 @@ class InPortSHMConsumer(OpenRTM_aist.InPortCorbaCdrConsumer):
         self._shmem.write(data)
         
         
-        ret = inportcdr.put()
+        ret = portshmem.put()
         del guard
         return self.convertReturnCode(ret)
       return self.CONNECTION_LOST

--- a/OpenRTM_aist/OutPortCorbaCdrConsumer.py
+++ b/OpenRTM_aist/OutPortCorbaCdrConsumer.py
@@ -70,7 +70,7 @@ class OutPortCorbaCdrConsumer(OpenRTM_aist.OutPortConsumer,OpenRTM_aist.CorbaCon
   # @endif
   #
   def __init__(self):
-    OpenRTM_aist.CorbaConsumer.__init__(self)
+    OpenRTM_aist.CorbaConsumer.__init__(self, OpenRTM.OutPortCdr)
     self._rtcout = OpenRTM_aist.Manager.instance().getLogbuf("OutPortCorbaCdrConsumer")
     self._buffer = None
     self._profile = None
@@ -196,7 +196,7 @@ class OutPortCorbaCdrConsumer(OpenRTM_aist.OutPortConsumer,OpenRTM_aist.CorbaCon
     self._rtcout.RTC_PARANOID("get()")
 
     try:
-      outportcdr = self.getObject()._narrow(OpenRTM.OutPortCdr)
+      outportcdr = self._ptr()
       ret,cdr_data = outportcdr.get()
       
       if ret == OpenRTM.PORT_OK:

--- a/OpenRTM_aist/OutPortDSConsumer.py
+++ b/OpenRTM_aist/OutPortDSConsumer.py
@@ -69,7 +69,7 @@ class OutPortDSConsumer(OpenRTM_aist.OutPortConsumer,OpenRTM_aist.CorbaConsumer)
   # @endif
   #
   def __init__(self):
-    OpenRTM_aist.CorbaConsumer.__init__(self)
+    OpenRTM_aist.CorbaConsumer.__init__(self, RTC.DataPullService)
     self._rtcout = OpenRTM_aist.Manager.instance().getLogbuf("OutPortDSConsumer")
     self._buffer = None
     self._profile = None
@@ -195,8 +195,8 @@ class OutPortDSConsumer(OpenRTM_aist.OutPortConsumer,OpenRTM_aist.CorbaConsumer)
     self._rtcout.RTC_PARANOID("get()")
 
     try:
-      ds = self.getObject()._narrow(RTC.DataPullService)
-      ret,cdr_data = ds.pull()
+      dataservice = self._ptr()
+      ret,cdr_data = dataservice.pull()
       
       if ret == RTC.PORT_OK:
         self._rtcout.RTC_DEBUG("get() successful")


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#38 

## Description of the Change

そもそもCorbaConsumerのsetObjectで_narrow関数を呼ぶため、インターフェース型を設定していればput、getでいちいち_narrow関数を呼ぶ必要は無かったため修正した。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
