### PR TITLE
ComponentObserverのバグ修正(1.2)

### DIFF
--- a/OpenRTM_aist/ext/sdo/observer/ComponentObserverConsumer.py
+++ b/OpenRTM_aist/ext/sdo/observer/ComponentObserverConsumer.py
@@ -188,7 +188,7 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
              "PORT_PROFILE",
              "CONFIGURATION",
              "HEARTBEAT"]
-    if kind._v < OpenRTM.STATUS_KIND_NUM._v:
+    if kind._v < len(kinds):
       return kinds[kind._v]
     return ""
 
@@ -603,7 +603,7 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
                                                        self._ecaction.ecAttached)
 
     if self._ecaction.ecDetached:
-      self._rtobj.removeExecutionContextActionListener(ectype_.EC_ATTACHED,
+      self._rtobj.removeExecutionContextActionListener(ectype_.EC_DETACHED,
                                                        self._ecaction.ecDetached)
 
     pcaltype_ = OpenRTM_aist.PostComponentActionListenerType


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
## Description of the Change

ComponentObserverにC++版の以下のバグと同様の問題があったため修正した。

https://github.com/OpenRTM/OpenRTM-aist/pull/183


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
