### PR TITLE
RTC終了時にログにエラーが出力される問題の修正

### DIFF
--- a/OpenRTM_aist/RTObject.py
+++ b/OpenRTM_aist/RTObject.py
@@ -5420,7 +5420,6 @@ class RTObject_impl:
       try:
         if not CORBA.is_nil(ec) and not ec._non_existent():
           ec.deactivate_component(self._comp)
-          ec.stop()
       except:
         print(OpenRTM_aist.Logger.print_exception())
 

--- a/OpenRTM_aist/RTObject.py
+++ b/OpenRTM_aist/RTObject.py
@@ -5419,7 +5419,10 @@ class RTObject_impl:
     def __call__(self, ec):
       try:
         if not CORBA.is_nil(ec) and not ec._non_existent():
-          ec.deactivate_component(self._comp)
+          if ec.get_component_state(self._comp) == RTC.ACTIVE_STATE:
+            ec.deactivate_component(self._comp)
+          elif ec.get_component_state(self._comp) == RTC.ERROR_STATE:
+            ec.reset_component(self._comp)
       except:
         print(OpenRTM_aist.Logger.print_exception())
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

1. ECを2回stopしたことによるエラー
2. RTCが非アクティブ、エラー状態でdeactivateすることによるエラー

## Description of the Change

1、2の修正を行った。
1の修正により外部ECを停止する処理も無くなった。
2の修正によりアクティブ状態の時はdeactivate、エラー状態の時はresetするようになった。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
