### PR TITLE
RTCのomniINSPOAでのdeactivate_objectを2回実行しないように修正

### DIFF
--- a/OpenRTM_aist/Manager.py
+++ b/OpenRTM_aist/Manager.py
@@ -1119,16 +1119,6 @@ class Manager:
       self._namingManager.unbindObject(name)
     self._listeners.naming_.postUnbind(comp, names)
 
-    try:
-      poa = self._orb.resolve_initial_references("omniINSPOA")
-      poa._get_the_POAManager().activate()
-      id = comp.getCategory() + "/" + comp.getInstanceName()
-      poa.deactivate_object(id)
-    except:
-      self._rtcout.RTC_DEBUG(OpenRTM_aist.Logger.print_exception())
-
-
-
     return True
 
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

RTCをomniINSPOAでactivate_objectした場合に、RTObjectとManagerで2回deactivate_objectを実行してしまう。

## Description of the Change

Mangerのdeactivate_objectに関する処理は必要ないため削除した。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
