### PR TITLE
DDS通信機能の実装

### DIFF
--- a/OpenRTM_aist/InPortBase.py
+++ b/OpenRTM_aist/InPortBase.py
@@ -101,6 +101,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
 
     self._rtcout.RTC_DEBUG("setting port.data_type: %s", data_type)
     self.addProperty("dataport.data_type", data_type)
+    self._properties.setProperty("data_type", data_type)
 
     self.addProperty("dataport.subscription_type", "Any")
     self._value = None

--- a/OpenRTM_aist/OutPortBase.py
+++ b/OpenRTM_aist/OutPortBase.py
@@ -283,6 +283,8 @@ class OutPortBase(OpenRTM_aist.PortBase,OpenRTM_aist.DataPortStatus):
     self._consumerTypes = ""
     self._connector_mutex = threading.RLock()
 
+    self._properties.setProperty("data_type", data_type)
+
     self._listeners = OpenRTM_aist.ConnectorListeners()
     return
 

--- a/OpenRTM_aist/RTM_IDL/BasicDataType.idl
+++ b/OpenRTM_aist/RTM_IDL/BasicDataType.idl
@@ -183,7 +183,28 @@ module RTC {
 	Time tm;
 	sequence<wstring> data;
   };
-  
+
+  #pragma keylist TimedState
+  #pragma keylist TimedShort
+  #pragma keylist TimedLong
+  #pragma keylist TimedUShort
+  #pragma keylist TimedULong
+  #pragma keylist TimedFloat
+  #pragma keylist TimedDouble
+  #pragma keylist TimedChar
+  #pragma keylist TimedBoolean
+  #pragma keylist TimedOctet
+  #pragma keylist TimedString
+  #pragma keylist TimedShortSeq
+  #pragma keylist TimedLongSeq
+  #pragma keylist TimedUShortSeq
+  #pragma keylist TimedULongSeq
+  #pragma keylist TimedFloatSeq
+  #pragma keylist TimedDoubleSeq
+  #pragma keylist TimedCharSeq
+  #pragma keylist TimedBooleanSeq
+  #pragma keylist TimedOctetSeq
+  #pragma keylist TimedStringSeq
 };
 
 #endif // end of BasicDataType_idl

--- a/OpenRTM_aist/RTM_IDL/ExtendedDataTypes.idl
+++ b/OpenRTM_aist/RTM_IDL/ExtendedDataTypes.idl
@@ -694,6 +694,34 @@ module RTC {
         Time tm;
         OAP data;
     };
+
+  #pragma keylist TimedRGBColour
+  #pragma keylist TimedPoint2D
+  #pragma keylist TimedVector2D
+  #pragma keylist TimedPose2D
+  #pragma keylist TimedVelocity2D
+  #pragma keylist TimedAcceleration2D
+  #pragma keylist TimedPoseVel2D
+  #pragma keylist TimedSize2D
+  #pragma keylist TimedGeometry2D
+  #pragma keylist TimedCovariance2D
+  #pragma keylist TimedPointCovariance2D
+  #pragma keylist TimedCarlike
+  #pragma keylist TimedSpeedHeading2D
+  #pragma keylist TimedPoint3D
+  #pragma keylist TimedVector3D
+  #pragma keylist TimedOrientation3D
+  #pragma keylist TimedPose3D
+  #pragma keylist TimedVelocity3D
+  #pragma keylist TimedAngularVelocity3D
+  #pragma keylist TimedAcceleration3D
+  #pragma keylist TimedAngularAcceleration3D
+  #pragma keylist TimedPoseVel3D
+  #pragma keylist TimedSize3D
+  #pragma keylist TimedGeometry3D
+  #pragma keylist TimedCovariance3D
+  #pragma keylist TimedSpeedHeading3D
+  #pragma keylist TimedOAP
 };
 
 #endif // ExtendedDataTypes_idl

--- a/OpenRTM_aist/RTM_IDL/InterfaceDataTypes.idl
+++ b/OpenRTM_aist/RTM_IDL/InterfaceDataTypes.idl
@@ -918,6 +918,28 @@ module RTC {
      * @typedef RFIDTagData
      */
     typedef sequence<octet> RFIDTagData;
+
+  #pragma keylist ActArrayActuatorPos
+  #pragma keylist ActArrayActuatorSpeed
+  #pragma keylist ActArrayActuatorCurrent
+  #pragma keylist ActArrayState
+  #pragma keylist CameraImage
+  #pragma keylist Fiducials
+  #pragma keylist GPSData
+  #pragma keylist GripperState
+  #pragma keylist INSData
+  #pragma keylist LimbState
+  #pragma keylist Hypotheses2D
+  #pragma keylist Hypotheses3D
+  #pragma keylist Features
+  #pragma keylist MultiCameraImages
+  #pragma keylist Path2D
+  #pragma keylist Path3D
+  #pragma keylist PointCloud
+  #pragma keylist PanTiltAngles
+  #pragma keylist PanTiltState
+  #pragma keylist RangeData
+  #pragma keylist IntensityData
 };
 
 #endif // InterfaceDataTypes_idl

--- a/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceInPort.py
+++ b/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceInPort.py
@@ -337,16 +337,12 @@ class SubListener(dds.Listener):
   #
   # @param self
   # @param sub OpenSpliceInPort
-  # @param sock ソケット
-  # @param uri 接続先のURI
   #
   # @else
   # @brief Constructor
   #
   # @param self
   # @param sub 
-  # @param sock 
-  # @param uri 
   #
   # @endif
   #

--- a/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceInPort.py
+++ b/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceInPort.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python
+# -*- coding: euc-jp -*-
+
+##
+# @file OpenSpliceInPort.py
+# @brief OpenSplice OutPort class
+# @date $Date$
+# @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+#
+# Copyright (C) 2019
+#     Noriaki Ando
+#     Robot Innovation Research Center,
+#     National Institute of
+#         Advanced Industrial Science and Technology (AIST), Japan
+#     All rights reserved.
+#
+# $Id$
+#
+
+import OpenRTM_aist
+from OpenSpliceTopicManager import OpenSpliceTopicManager
+import OpenSpliceMessageInfo
+import RTC
+import dds
+import threading
+
+
+##
+# @if jp
+# @class OpenSpliceInPort
+# @brief OpenSplice Subscriberに対応するクラス
+# InPortProviderオブジェクトとして使用する
+#
+# @else
+# @class OpenSpliceInPort
+# @brief 
+#
+#
+# @endif
+class OpenSpliceInPort(OpenRTM_aist.InPortProvider):
+  """
+  """
+
+  ##
+  # @if jp
+  # @brief コンストラクタ
+  #
+  # コンストラクタ
+  # ポートプロパティに以下の項目を設定する。
+  #  - インターフェースタイプ : opensplice
+  #  - データフロータイプ : Push
+  #
+  # @param self 
+  #
+  # @else
+  # @brief Constructor
+  #
+  # Constructor
+  # Set the following items to port properties
+  #  - Interface type : CORBA_Any
+  #  - Data flow type : Push, Pull
+  #
+  # @param self 
+  #
+  # @endif
+  #
+  def __init__(self):
+    OpenRTM_aist.InPortProvider.__init__(self)
+
+    # PortProfile setting
+    self.setInterfaceType("opensplice")
+
+
+    self._profile = None
+    self._listeners = None
+
+    self._dataType = RTC.TimedLong._NP_RepositoryId
+    self._topic = "chatter"
+    self._reader = None
+
+    self._mutex = threading.RLock()
+
+
+
+
+  ##
+  # @if jp
+  # @brief デストラクタ
+  #
+  # デストラクタ
+  #
+  # @param self 
+  #
+  # @else
+  # @brief Destructor
+  #
+  # Destructor
+  #
+  # @param self 
+  #
+  # @endif
+  #
+  def __del__(self):
+    return
+
+
+  ##
+  # @if jp
+  # @brief 終了処理
+  #
+  # @param self 
+  #
+  # @else
+  # @brief 
+  #
+  # @param self 
+  #
+  # @endif
+  #
+  def exit(self):
+    self._rtcout.RTC_PARANOID("exit()")
+    if self._reader:
+      self._reader.close()
+      self._rtcout.RTC_VERBOSE("remove reader")
+
+
+  ##
+  # @if jp
+  # @brief 初期化
+  #
+  # @param self 
+  # @param prop 接続設定
+  # marshaling_type シリアライザの種類 デフォルト：opensplice
+  # topic トピック名 デフォルト chatter
+  #
+  # @else
+  # @brief 
+  #
+  # @param self 
+  # @param prop
+  #
+  # @endif
+  #
+  ## virtual void init(coil::Properties& prop);
+  def init(self, prop):
+    self._rtcout.RTC_PARANOID("init()")
+
+    if len(prop.propertyNames()) == 0:
+      self._rtcout.RTC_DEBUG("Property is empty.")
+      return
+    
+    self._properties = prop
+
+    qosxml = prop.getProperty("QOSXML")
+    self._topicmgr = OpenSpliceTopicManager.instance(qosxml)
+
+    self._dataType = prop.getProperty("data_type", self._dataType)
+
+    self._topic = prop.getProperty("topic", "chatter")
+
+    topic = self._topicmgr.createTopic(self._dataType, self._topic)
+
+    self._rtcout.RTC_VERBOSE("data type: %s", self._dataType)
+    self._rtcout.RTC_VERBOSE("topic name: %s", self._topic)
+
+    self._writer = self._topicmgr.createReader(topic, SubListener(self))
+
+
+  ## virtual void setBuffer(BufferBase<cdrMemoryStream>* buffer);
+  def setBuffer(self, buffer):
+    return
+
+  ##
+  # @if jp
+  # @brief コネクタリスナの設定
+  #
+  # @param info 接続情報
+  # @param listeners リスナ
+  #
+  # @else
+  # @brief 
+  #
+  # @param info 
+  # @param listeners 
+  #
+  # @endif
+  #
+  # void setListener(ConnectorInfo& info,
+  #                  ConnectorListeners* listeners);
+  def setListener(self, info, listeners):
+    self._profile = info
+    self._listeners = listeners
+    return
+
+
+  ##
+  # @if jp
+  # @brief バッファにデータを書き込む
+  #
+  # 設定されたバッファにデータを書き込む。
+  #
+  # @param data 書込対象データ
+  #
+  # @else
+  # @brief Write data into the buffer
+  #
+  # Write data into the specified buffer.
+  #
+  # @param data The target data for writing
+  #
+  # @endif
+  #
+  def put(self, data):
+    guard = OpenRTM_aist.Guard.ScopedLock(self._mutex)
+    try:
+      self._rtcout.RTC_PARANOID("OpenSpliceInPort.put()")
+      if not self._connector:
+        self.onReceiverError(data)
+        return OpenRTM.PORT_ERROR
+
+      self.onReceived(data)
+
+      ret = self._connector.write(data)
+
+      self.convertReturn(ret, data)
+
+    except:
+      self._rtcout.RTC_TRACE(OpenRTM_aist.Logger.print_exception())
+      
+
+
+
+  def convertReturn(self, status, data):
+    if status == OpenRTM_aist.BufferStatus.BUFFER_OK:
+      self.onBufferWrite(data)
+      return
+            
+    elif status == OpenRTM_aist.BufferStatus.BUFFER_ERROR:
+      self.onReceiverError(data)
+      return
+
+    elif status == OpenRTM_aist.BufferStatus.BUFFER_FULL:
+      self.onBufferFull(data)
+      self.onReceiverFull(data)
+      return
+
+    elif status == OpenRTM_aist.BufferStatus.BUFFER_EMPTY:
+      return
+
+    elif status == OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET:
+      self.onReceiverError(data)
+      return
+
+    elif status == OpenRTM_aist.BufferStatus.TIMEOUT:
+      self.onBufferWriteTimeout(data)
+      self.onReceiverTimeout(data)
+      return
+
+    else:
+      self.onReceiverError(data)
+      return
+        
+
+  ##
+  # @brief Connector data listener functions
+  #
+  # inline void onBufferWrite(const cdrMemoryStream& data)
+  def onBufferWrite(self, data):
+    if self._listeners is not None and self._profile is not None:
+      self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(self._profile, data)
+    return
+
+
+  ## inline void onBufferFull(const cdrMemoryStream& data)
+  def onBufferFull(self, data):
+    if self._listeners is not None and self._profile is not None:
+      self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(self._profile, data)
+    return
+
+
+  ## inline void onBufferWriteTimeout(const cdrMemoryStream& data)
+  def onBufferWriteTimeout(self, data):
+    if self._listeners is not None and self._profile is not None:
+      self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(self._profile, data)
+    return
+
+  ## inline void onBufferWriteOverwrite(const cdrMemoryStream& data)
+  def onBufferWriteOverwrite(self, data):
+    if self._listeners is not None and self._profile is not None:
+      self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(self._profile, data)
+    return
+
+
+  ## inline void onReceived(const cdrMemoryStream& data)
+  def onReceived(self, data):
+    if self._listeners is not None and self._profile is not None:
+      self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(self._profile, data)
+    return
+
+
+  ## inline void onReceiverFull(const cdrMemoryStream& data)
+  def onReceiverFull(self, data):
+    if self._listeners is not None and self._profile is not None:
+      self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(self._profile, data)
+    return
+
+
+  ## inline void onReceiverTimeout(const cdrMemoryStream& data)
+  def onReceiverTimeout(self, data):
+    if self._listeners is not None and self._profile is not None:
+      self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(self._profile, data)
+    return
+
+
+  ## inline void onReceiverError(const cdrMemoryStream& data)
+  def onReceiverError(self, data):
+    if self._listeners is not None and self._profile is not None:
+      self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(self._profile, data)
+    return
+
+##
+# @if jp
+# @class SubListener
+# @brief OpenSplice Subscriberのデータ受信時のリスナ
+# 
+#
+# @else
+# @class SubListener
+# @brief 
+#
+#
+# @endif
+class SubListener(dds.Listener):
+  ##
+  # @if jp
+  # @brief コンストラクタ
+  #
+  # @param self
+  # @param sub OpenSpliceInPort
+  # @param sock ソケット
+  # @param uri 接続先のURI
+  #
+  # @else
+  # @brief Constructor
+  #
+  # @param self
+  # @param sub 
+  # @param sock 
+  # @param uri 
+  #
+  # @endif
+  #
+  def __init__(self, subscriber):
+    dds.Listener.__init__(self)
+    self._sub = subscriber
+
+  ##
+  # @if jp
+  # @brief 受信処理
+  #
+  # @param self
+  # @param entity
+  #
+  # @else
+  # @brief 
+  #
+  # @param self
+  # @param entity
+  #
+  # @endif
+  #
+  def on_data_available(self, entity):
+    l = entity.read(10)
+    for (sd, _) in l:
+      self._sub.put(sd)
+
+
+##
+# @if jp
+# @brief モジュール登録関数
+#
+#
+# @else
+# @brief 
+#
+#
+# @endif
+#
+def OpenSpliceInPortInit():
+  factory = OpenRTM_aist.InPortProviderFactory.instance()
+  factory.addFactory("opensplice",
+                     OpenSpliceInPort,
+                     OpenRTM_aist.Delete)

--- a/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceMessageInfo.py
+++ b/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceMessageInfo.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python
+# -*- coding: euc-jp -*-
+
+##
+# @file OpenSpliceMessageInfo.py
+# @brief OpenSplice Message Info class
+# @date $Date$
+# @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+#
+# Copyright (C) 2019
+#     Noriaki Ando
+#     Robot Innovation Research Center,
+#     National Institute of
+#         Advanced Industrial Science and Technology (AIST), Japan
+#     All rights reserved.
+#
+# $Id$
+#
+
+import OpenRTM_aist
+
+##
+# @if jp
+# @class OpenSpliceMessageInfoBase
+# @brief OpenSpliceメッセージ情報格納オブジェクトの基底クラス
+# OpenSpliceデータ型名、IDLファイルパスを登録する
+#
+# @else
+# @class OpenSpliceOutPort
+# @brief 
+#
+#
+# @endif
+class OpenSpliceMessageInfoBase(object):
+  ##
+  # @if jp
+  # @brief コンストラクタ
+  #
+  # コンストラクタ
+  #
+  # @param self
+  #
+  # @else
+  # @brief Constructor
+  #
+  # @param self
+  #
+  # @endif
+  def __init__(self):
+    pass
+  ##
+  # @if jp
+  # @brief デストラクタ
+  #
+  # デストラクタ
+  #
+  # @param self
+  #
+  # @else
+  # @brief Destructor
+  #
+  # Destructor
+  #
+  # @param self
+  #
+  # @endif
+  #
+  def __del__(self):
+    pass
+
+  ##
+  # @if jp
+  # @brief データの型名を取得
+  #
+  # @param self
+  # @return 型名
+  #
+  # @else
+  # @brief 
+  #
+  #
+  # @param self
+  # @return
+  #
+  # @endif
+  #
+  def datatype(self):
+    return ""
+
+  ##
+  # @if jp
+  # @brief IDLファイルのパスを取得
+  #
+  # @param self
+  # @return IDLファイルのパス
+  #
+  # @else
+  # @brief 
+  #
+  #
+  # @param self
+  # @return
+  #
+  # @endif
+  #
+  def idlFile(self):
+    return ""
+
+  
+
+##
+# @if jp
+# @brief メッセージの情報格納オブジェクト生成関数
+#
+# @param data_class OpenSpliceデータ型
+# @return メッセージの情報格納オブジェクト
+#
+# @else
+# @brief 
+#
+# @param data_class 
+# @return 
+#
+# @endif
+#
+def opensplice_message_info(datatype, idlfile):
+  ##
+  # @if jp
+  # @class OpenSpliceMessageInfo
+  # @brief メッセージの情報格納クラス
+  #
+  #
+  # @else
+  # @class OpenSpliceMessageInfo
+  # @brief 
+  #
+  #
+  # @endif
+  class OpenSpliceMessageInfo(OpenSpliceMessageInfoBase):
+    """
+    """
+
+    ##
+    # @if jp
+    # @brief コンストラクタ
+    #
+    # コンストラクタ
+    #
+    # @param self
+    #
+    # @else
+    # @brief Constructor
+    #
+    # @param self
+    #
+    # @endif
+    def __init__(self):
+      super(OpenSpliceMessageInfo, self).__init__()
+      
+
+    ##
+    # @if jp
+    # @brief デストラクタ
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @brief self
+    #
+    # @endif
+    def __del__(self):
+      pass
+
+    ##
+    # @if jp
+    # @brief メッセージの型名を取得
+    #
+    # @param self
+    # @return 型名
+    #
+    # @else
+    # @brief 
+    #
+    #
+    # @param self
+    # @return
+    #
+    # @endif
+    #
+    def datatype(self):
+      return datatype
+
+    ##
+    # @if jp
+    # @brief IDLファイルのパスを取得
+    #
+    # @param self
+    # @return IDLファイルのパス
+    #
+    # @else
+    # @brief 
+    #
+    #
+    # @param self
+    # @return
+    #
+    # @endif
+    #
+    def idlFile(self):
+      return idlfile
+
+  return OpenSpliceMessageInfo
+
+
+
+opensplicemessageinfofactory = None
+
+
+##
+# @if jp
+# @class OpenSpliceMessageInfoFactory
+# @brief OpenSpliceメッセージ情報格納オブジェクト生成ファクトリ
+#
+# @else
+# @class OpenSpliceMessageInfoFactory
+# @brief 
+#
+#
+# @endif
+class OpenSpliceMessageInfoFactory(OpenRTM_aist.Factory,OpenSpliceMessageInfoBase):
+  ##
+  # @if jp
+  # @brief コンストラクタ
+  #
+  # コンストラクタ
+  #
+  # @param self
+  #
+  # @else
+  # @brief Constructor
+  #
+  # @param self
+  #
+  # @endif
+  def __init__(self):
+    OpenRTM_aist.Factory.__init__(self)
+
+  ##
+  # @if jp
+  # @brief デストラクタ
+  #
+  # デストラクタ
+  #
+  # @param self
+  #
+  # @else
+  # @brief Destructor
+  #
+  # Destructor
+  #
+  # @param self
+  #
+  # @endif
+  #
+  def __del__(self):
+    pass
+
+  ##
+  # @if jp
+  # @brief インスタンス取得
+  #
+  #
+  # @return インスタンス
+  #
+  # @else
+  # @brief 
+  #
+  #
+  # @return
+  #
+  # @endif
+  #
+  def instance():
+    global opensplicemessageinfofactory
+
+    if opensplicemessageinfofactory is None:
+      opensplicemessageinfofactory = OpenSpliceMessageInfoFactory()
+
+    return opensplicemessageinfofactory
+
+  instance = staticmethod(instance)
+

--- a/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceOutPort.py
+++ b/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceOutPort.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python
+# -*- coding: euc-jp -*-
+
+##
+# @file OpenSpliceOutPort.py
+# @brief OpenSplice OutPort class
+# @date $Date$
+# @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+#
+# Copyright (C) 2019
+#     Noriaki Ando
+#     Robot Innovation Research Center,
+#     National Institute of
+#         Advanced Industrial Science and Technology (AIST), Japan
+#     All rights reserved.
+#
+# $Id$
+#
+
+import OpenRTM_aist
+from OpenSpliceTopicManager import OpenSpliceTopicManager
+import OpenSpliceMessageInfo
+import RTC
+
+
+
+##
+# @if jp
+# @class OpenSpliceOutPort
+# @brief OpenSplice Publisherに対応するクラス
+# InPortConsumerオブジェクトとして使用する
+#
+# @else
+# @class OpenSpliceOutPort
+# @brief 
+#
+#
+# @endif
+class OpenSpliceOutPort(OpenRTM_aist.InPortConsumer):
+  """
+  """
+
+  ##
+  # @if jp
+  # @brief コンストラクタ
+  #
+  # コンストラクタ
+  #
+  # @param self
+  #
+  # @else
+  # @brief Constructor
+  #
+  # @param self
+  #
+  # @endif
+  def __init__(self):
+    OpenRTM_aist.InPortConsumer.__init__(self)
+    self._rtcout = OpenRTM_aist.Manager.instance().getLogbuf("OpenSpliceOutPort")
+    self._properties = None
+    self._dataType = RTC.TimedLong._NP_RepositoryId
+    self._topic = "chatter"
+    self._writer = None
+
+
+  ##
+  # @if jp
+  # @brief デストラクタ
+  #
+  # デストラクタ
+  #
+  # @param self
+  #
+  # @else
+  # @brief Destructor
+  #
+  # Destructor
+  #
+  # @param self
+  #
+  # @endif
+  #
+  def __del__(self):
+    self._rtcout.RTC_PARANOID("~OpenSpliceOutPort()")
+    
+  ##
+  # @if jp
+  # @brief 設定初期化
+  #
+  # InPortConsumerの各種設定を行う
+  #
+  # @param self
+  # @param prop 接続設定
+  # marshaling_type シリアライザの種類 デフォルト：OpenSplice
+  # topic トピック名 デフォルト chatter
+  #
+  # @else
+  # @brief Initializing configuration
+  #
+  # This operation would be called to configure this consumer
+  # in initialization.
+  #
+  # @param self
+  # @param prop
+  #
+  # @endif
+  #
+  # virtual void init(coil::Properties& prop);
+  def init(self, prop):
+    self._rtcout.RTC_PARANOID("init()")
+    
+    if len(prop.propertyNames()) == 0:
+      self._rtcout.RTC_DEBUG("Property is empty.")
+      return
+    
+    self._properties = prop
+
+    qosxml = prop.getProperty("QOSXML")
+    self._topicmgr = OpenSpliceTopicManager.instance(qosxml)
+
+    self._dataType = prop.getProperty("data_type", self._dataType)
+
+    self._topic = prop.getProperty("topic", "chatter")
+
+    topic = self._topicmgr.createTopic(self._dataType, self._topic)
+
+    self._rtcout.RTC_VERBOSE("data type: %s", self._dataType)
+    self._rtcout.RTC_VERBOSE("topic name: %s", self._topic)
+
+    self._writer = self._topicmgr.createWriter(topic)
+
+  ##
+  # @if jp
+  # @brief 接続先へのデータ送信
+  #
+  # 接続先のポートへデータを送信するための純粋仮想関数。
+  # 
+  # この関数は、以下のリターンコードを返す。
+  #
+  # - PORT_OK:       正常終了。
+  # - PORT_ERROR:    データ送信の過程で何らかのエラーが発生した。
+  # - SEND_FULL:     データを送信したが、相手側バッファがフルだった。
+  # - SEND_TIMEOUT:  データを送信したが、相手側バッファがタイムアウトした。
+  # - UNKNOWN_ERROR: 原因不明のエラー
+  #
+  # @param data 送信するデータ
+  # @return リターンコード
+  #
+  # @else
+  # @brief Send data to the destination port
+  #
+  # Pure virtual function to send data to the destination port.
+  #
+  # This function might the following return codes
+  #
+  # - PORT_OK:       Normal return
+  # - PORT_ERROR:    Error occurred in data transfer process
+  # - SEND_FULL:     Buffer full although OutPort tried to send data
+  # - SEND_TIMEOUT:  Timeout although OutPort tried to send data
+  # - UNKNOWN_ERROR: Unknown error
+  #
+  # @endif
+  #
+  # virtual ReturnCode put(const cdrMemoryStream& data);
+  def put(self, data):
+    self._rtcout.RTC_PARANOID("put()")
+
+    if self._writer:
+      try:
+        self._writer.write(data)
+        return self.PORT_OK
+      except:
+        self._rtcout.RTC_ERROR("write error")
+        return self.CONNECTION_LOST
+    else:
+      return self.CONNECTION_LOST
+        
+
+
+  ##
+  # @if jp
+  # @brief InterfaceProfile情報を公開する
+  #
+  # InterfaceProfile情報を公開する。
+  # 引数で指定するプロパティ情報内の NameValue オブジェクトの
+  # dataport.interface_type 値を調べ、当該ポートに設定されている
+  # インターフェースタイプと一致する場合のみ情報を取得する。
+  #
+  # @param properties InterfaceProfile情報を受け取るプロパティ
+  #
+  # @else
+  # @brief Publish InterfaceProfile information
+  #
+  # Publish interfaceProfile information.
+  # Check the dataport.interface_type value of the NameValue object 
+  # specified by an argument in property information and get information
+  # only when the interface type of the specified port is matched.
+  #
+  # @param properties Properties to get InterfaceProfile information
+  #
+  # @endif
+  #
+  # virtual void publishInterfaceProfile(SDOPackage::NVList& properties);
+  def publishInterfaceProfile(self, properties):
+    pass
+
+  ##
+  # @if jp
+  # @brief データ送信通知への登録
+  #
+  # 指定されたプロパティに基づいて、データ送出通知の受け取りに登録する。
+  #
+  # @param properties 登録情報
+  #
+  # @return 登録処理結果(登録成功:true、登録失敗:false)
+  #
+  # @else
+  # @brief Subscribe to the data sending notification
+  #
+  # Subscribe to the data sending notification based on specified 
+  # property information.
+  #
+  # @param properties Information for subscription
+  #
+  # @return Subscription result (Successful:true, Failed:false)
+  #
+  # @endif
+  #
+  # virtual bool subscribeInterface(const SDOPackage::NVList& properties);
+  def subscribeInterface(self, properties):
+    return True
+    
+  ##
+  # @if jp
+  # @brief データ送信通知からの登録解除
+  #
+  # データ送出通知の受け取りから登録を解除する。
+  #
+  # @param properties 登録解除情報
+  #
+  # @else
+  # @brief Unsubscribe the data send notification
+  #
+  # Unsubscribe the data send notification.
+  #
+  # @param properties Information for unsubscription
+  #
+  # @endif
+  #
+  # virtual void unsubscribeInterface(const SDOPackage::NVList& properties);
+  def unsubscribeInterface(self, properties):
+    if self._writer:
+      self._writer.close()
+      self._rtcout.RTC_VERBOSE("remove writer")
+
+
+
+
+##
+# @if jp
+# @brief モジュール登録関数
+#
+#
+# @else
+# @brief 
+#
+#
+# @endif
+#
+def OpenSpliceOutPortInit():
+  factory = OpenRTM_aist.InPortConsumerFactory.instance()
+  factory.addFactory("opensplice",
+                     OpenSpliceOutPort,
+                     OpenRTM_aist.Delete)
+

--- a/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceSerializer.py
+++ b/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceSerializer.py
@@ -178,10 +178,10 @@ class OpenSpliceSerializer(OpenRTM_aist.ByteDataStreamBase):
 
   ##
   # @if jp
-  # @brief データの符号化
+  # @brief データの変換(omniORB->OpenSplice)
   #
   # 
-  # @param data 符号化前のデータ
+  # @param data omniORB定義のデータ
   # @return ret、value
   # ret：SERIALIZE_OK：成功、SERIALIZE_ERROR：失敗、SERIALIZE_NOTFOUND：指定のシリアライザがない
   # value：OpenSplice定義のデータ
@@ -216,19 +216,19 @@ class OpenSpliceSerializer(OpenRTM_aist.ByteDataStreamBase):
 
   ##
   # @if jp
-  # @brief データの復号化
+  # @brief データの変換(OpenSplice->omniORB)
   #
   # @param bdata OpenSplice定義のデータ
   # @param data_type omniORB定義のデータ型
   # @return ret、value
   # ret：SERIALIZE_OK：成功、SERIALIZE_ERROR：失敗、SERIALIZE_NOTFOUND：指定のシリアライザがない
-  # value：復号化後のデータ
+  # value：omniORB定義のデータ
   #
   # @else
   #
   # @brief 
   #
-  # @param cdr
+  # @param bdata
   # @param data_type 
   # @return 
   #

--- a/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceSerializer.py
+++ b/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceSerializer.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python
+# -*- coding: euc-jp -*-
+
+##
+# @file OpenSpliceSerializer.py
+# @brief OpenSplice Serializer class
+# @date $Date$
+# @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+#
+# Copyright (C) 2019
+#     Noriaki Ando
+#     Robot Innovation Research Center,
+#     National Institute of
+#         Advanced Industrial Science and Technology (AIST), Japan
+#     All rights reserved.
+#
+# $Id$
+#
+
+import OpenRTM_aist
+import omniORB
+
+import struct
+import OpenSpliceMessageInfo
+import RTC
+import ddsutil
+import os
+import site
+import sys
+
+
+##
+# @if jp
+# @brief omniORBのデータからOpenSpliceのデータに変換
+# omniORBのデータ型の情報は_NP_RepositoryIdから取得し、
+# 定義された要素名に値を格納していく
+#
+# @param self
+# @param data 変換前のデータ(omniORB)
+# @param gen_info OpenSpliceのデータ型Infoオブジェクト
+# @return 変換後のデータ(OpenSplice)
+# 
+#
+# @else
+# @brief 
+#
+# @param self
+# @param data 
+# @param gen_info 
+# @return 
+#
+# @endif
+def OmniDataToDDSData(data, gen_info):
+  desc=omniORB.findType(data._NP_RepositoryId)
+  if desc[0] == omniORB.tcInternal.tv_struct:
+    arg = {}
+    for i in  range(4, len(desc), 2):
+      attr = desc[i]
+      attr_type = desc[i+1]
+      if isinstance(attr_type, int):
+        arg[attr] = data.__dict__[attr]
+      else:
+        cdata = data.__dict__[attr]
+        data_name = cdata._NP_RepositoryId
+        data_name = data_name.split(":")[1]
+        data_name = data_name.replace("/","::")
+        datatype = gen_info.get_class(data_name)
+        cv = OmniDataToDDSData(cdata, gen_info)
+        arg[attr] = datatype(**cv)
+        return arg
+    return None
+
+if sys.version_info[0] == 3:
+    long = int
+
+
+##
+# @if jp
+# @brief OpenSpliceのデータからomniORBのデータに変換
+# OpenSpliceのデータはxml.etree.ElementTreeで定義されており、
+# ElementTreeから要素名を取得して値を格納する
+#
+# @param self
+# @param ddsdata 変換前のデータ(OpenSplice)
+# @param omnidata 変更対象のデータ(omniORB)
+# 
+#
+# @else
+# @brief 
+#
+# @param self
+# @param ddsdata 
+# @param omnidata 
+#
+# @endif
+def DDSDataToOmniData(ddsdata, omnidata):
+  for k in ddsdata._members.keys():
+    v = ddsdata.__dict__[k]
+    if isinstance(v, int):
+      omnidata.__dict__[k] = v
+    elif isinstance(v, long):
+      omnidata.__dict__[k] = v
+    elif isinstance(v, float):
+      omnidata.__dict__[k] = v
+    elif isinstance(v, str):
+      omnidata.__dict__[k] = v
+    else:
+      DDSDataToOmniData(v, omnidata.__dict__[k])
+
+
+
+##
+# @if jp
+# @class OpenSpliceSerializer
+# @brief OpenSplice用シリアライザ
+#
+# @else
+# @class OpenSpliceSerializer
+# @brief 
+#
+#
+# @endif
+class OpenSpliceSerializer(OpenRTM_aist.ByteDataStreamBase):
+  """
+  """
+
+  ##
+  # @if jp
+  # @brief コンストラクタ
+  #
+  # コンストラクタ
+  #
+  # @param self
+  #
+  # @else
+  # @brief Constructor
+  #
+  # @param self
+  #
+  # @endif
+  def __init__(self):
+    pass
+
+  ##
+  # @if jp
+  # @brief デストラクタ
+  #
+  #
+  # @param self
+  #
+  # @else
+  #
+  # @brief self
+  #
+  # @endif
+  def __del__(self):
+    pass
+
+  ##
+  # @if jp
+  # @brief 設定初期化
+  #
+  # 
+  # @param prop 設定情報
+  #
+  # @else
+  #
+  # @brief Initializing configuration
+  #
+  #
+  # @param prop Configuration information
+  #
+  # @endif
+  ## virtual ReturnCode init(coil::Properties& prop) = 0;
+  def init(self, prop):
+    pass
+
+
+  ##
+  # @if jp
+  # @brief データの符号化
+  #
+  # 
+  # @param data 符号化前のデータ
+  # @return ret、value
+  # ret：SERIALIZE_OK：成功、SERIALIZE_ERROR：失敗、SERIALIZE_NOTFOUND：指定のシリアライザがない
+  # value：OpenSplice定義のデータ
+  #
+  # @else
+  #
+  # @brief 
+  #
+  #
+  # @param data 
+  # @return
+  #
+  # @endif
+  def serialize(self, data):
+    factory = OpenSpliceMessageInfo.OpenSpliceMessageInfoFactory.instance()
+    info = factory.createObject(data._NP_RepositoryId)
+    if info:
+      datatype = info.datatype()
+      idlFile = info.idlFile()
+      factory.deleteObject(info)
+      try:
+        gen_info = ddsutil.get_dds_classes_from_idl(idlFile, datatype)
+        osdata = gen_info.topic_data_class(**OmniDataToDDSData(data, gen_info))
+        if osdata:
+          return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK, osdata
+        else:
+          return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR, osdata
+      except:
+        return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR, None
+    else:
+      return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOTFOUND, None
+
+  ##
+  # @if jp
+  # @brief データの復号化
+  #
+  # @param bdata OpenSplice定義のデータ
+  # @param data_type omniORB定義のデータ型
+  # @return ret、value
+  # ret：SERIALIZE_OK：成功、SERIALIZE_ERROR：失敗、SERIALIZE_NOTFOUND：指定のシリアライザがない
+  # value：復号化後のデータ
+  #
+  # @else
+  #
+  # @brief 
+  #
+  # @param cdr
+  # @param data_type 
+  # @return 
+  #
+  # @endif
+  def deserialize(self, bdata, data_type):
+    try:
+      DDSDataToOmniData(bdata, data_type)
+      return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK, data_type
+    except:
+      return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR, data_type
+
+##
+# @if jp
+# @brief OpenSpliceで使用するデータ型を追加する
+# OpenSpliceとomniORBは同一のIDLファイルで定義したデータ型を使用するが、
+# omniORBのデータ型からどのIDLファイルで定義したデータ型なのかを取得することはできないため、
+# omniORBのデータ型名、OpenSpliceのデータ型名、IDLファイル名を関連付ける情報を登録する
+#
+# @param datatype omniORB定義のデータ型名
+# @param idlfile IDLファイルのパス
+#
+# @else
+#
+# @brief 
+#
+# @param datatype 
+# @param idlfile 
+#
+# @endif
+def addDataType(datatype, idlfile):
+  name = datatype._NP_RepositoryId
+  data_name = name.split(":")[1]
+  data_name = data_name.replace("/","::")
+  OpenSpliceMessageInfo.OpenSpliceMessageInfoFactory.instance().addFactory(name,
+                                                      OpenSpliceMessageInfo.opensplice_message_info(data_name, idlfile),
+                                                      OpenRTM_aist.Delete)
+
+
+
+
+##
+# @if jp
+# @brief シリアライザ初期化、データ型情報登録
+#
+#
+# @else
+# @brief 
+#
+#
+# @endif
+#
+def OpenSpliceSerializerInit():
+  OpenRTM_aist.SerializerFactory.instance().addFactory("opensplice",
+                                                      OpenSpliceSerializer,
+                                                      OpenRTM_aist.Delete)
+
+  site_dirs = site.getsitepackages()
+  OpenRTM_dir = ""
+  for site_dir in site_dirs:
+    d = os.path.join(site_dir, "OpenRTM_aist")
+    if os.path.exists(d):
+      OpenRTM_dir = d
+      break
+
+  idl_dir = os.path.join(OpenRTM_dir, "RTM_IDL")
+  basicdatatypefile = os.path.join(idl_dir, "BasicDataType.idl")
+  extendeddatatypes = os.path.join(idl_dir, "ExtendedDataTypes.idl")
+  interfacedataTypes = os.path.join(idl_dir, "InterfaceDataTypes.idl")
+  addDataType(RTC.TimedState, basicdatatypefile)
+  addDataType(RTC.TimedShort, basicdatatypefile)
+  addDataType(RTC.TimedLong, basicdatatypefile)
+  addDataType(RTC.TimedUShort, basicdatatypefile)
+  addDataType(RTC.TimedULong, basicdatatypefile)
+  addDataType(RTC.TimedFloat, basicdatatypefile)
+  addDataType(RTC.TimedDouble, basicdatatypefile)
+  addDataType(RTC.TimedChar, basicdatatypefile)
+  addDataType(RTC.TimedWChar, basicdatatypefile)
+  addDataType(RTC.TimedBoolean, basicdatatypefile)
+  addDataType(RTC.TimedOctet, basicdatatypefile)
+  addDataType(RTC.TimedString, basicdatatypefile)
+  addDataType(RTC.TimedWString, basicdatatypefile)
+  addDataType(RTC.TimedShortSeq, basicdatatypefile)
+  addDataType(RTC.TimedLongSeq, basicdatatypefile)
+  addDataType(RTC.TimedUShortSeq, basicdatatypefile)
+  addDataType(RTC.TimedULongSeq, basicdatatypefile)
+  addDataType(RTC.TimedFloatSeq, basicdatatypefile)
+  addDataType(RTC.TimedDoubleSeq, basicdatatypefile)
+  addDataType(RTC.TimedCharSeq, basicdatatypefile)
+  addDataType(RTC.TimedWCharSeq, basicdatatypefile)
+  addDataType(RTC.TimedBooleanSeq, basicdatatypefile)
+  addDataType(RTC.TimedOctetSeq, basicdatatypefile)
+  addDataType(RTC.TimedStringSeq, basicdatatypefile)
+  addDataType(RTC.TimedWStringSeq, basicdatatypefile)
+  addDataType(RTC.TimedRGBColour, extendeddatatypes)
+  addDataType(RTC.TimedPoint2D, extendeddatatypes)
+  addDataType(RTC.TimedVector2D, extendeddatatypes)
+  addDataType(RTC.TimedPose2D, extendeddatatypes)
+  addDataType(RTC.TimedVelocity2D, extendeddatatypes)
+  addDataType(RTC.TimedAcceleration2D, extendeddatatypes)
+  addDataType(RTC.TimedPoseVel2D, extendeddatatypes)
+  addDataType(RTC.TimedSize2D, extendeddatatypes)
+  addDataType(RTC.TimedGeometry2D, extendeddatatypes)
+  addDataType(RTC.TimedCovariance2D, extendeddatatypes)
+  addDataType(RTC.TimedPointCovariance2D, extendeddatatypes)
+  addDataType(RTC.TimedCarlike, extendeddatatypes)
+  addDataType(RTC.TimedSpeedHeading2D, extendeddatatypes)
+  addDataType(RTC.TimedPoint3D, extendeddatatypes)
+  addDataType(RTC.TimedVector3D, extendeddatatypes)
+  addDataType(RTC.TimedOrientation3D, extendeddatatypes)
+  addDataType(RTC.TimedPose3D, extendeddatatypes)
+  addDataType(RTC.TimedVelocity3D, extendeddatatypes)
+  addDataType(RTC.TimedAngularVelocity3D, extendeddatatypes)
+  addDataType(RTC.TimedAcceleration3D, extendeddatatypes)
+  addDataType(RTC.TimedAngularAcceleration3D, extendeddatatypes)
+  addDataType(RTC.TimedPoseVel3D, extendeddatatypes)
+  addDataType(RTC.TimedSize3D, extendeddatatypes)
+  addDataType(RTC.TimedGeometry3D, extendeddatatypes)
+  addDataType(RTC.TimedCovariance3D, extendeddatatypes)
+  addDataType(RTC.TimedSpeedHeading3D, extendeddatatypes)
+  addDataType(RTC.TimedOAP, extendeddatatypes)
+  addDataType(RTC.ActArrayActuatorPos, interfacedataTypes)
+  addDataType(RTC.ActArrayActuatorSpeed, interfacedataTypes)
+  addDataType(RTC.ActArrayActuatorCurrent, interfacedataTypes)
+  addDataType(RTC.ActArrayState, interfacedataTypes)
+  addDataType(RTC.CameraImage, interfacedataTypes)
+  addDataType(RTC.Fiducials, interfacedataTypes)
+  addDataType(RTC.GPSData, interfacedataTypes)
+  addDataType(RTC.GripperState, interfacedataTypes)
+  addDataType(RTC.INSData, interfacedataTypes)
+  addDataType(RTC.LimbState, interfacedataTypes)
+  addDataType(RTC.Hypotheses2D, interfacedataTypes)
+  addDataType(RTC.Hypotheses3D, interfacedataTypes)
+  addDataType(RTC.Features, interfacedataTypes)
+  addDataType(RTC.MultiCameraImages, interfacedataTypes)
+  addDataType(RTC.Path2D, interfacedataTypes)
+  addDataType(RTC.Path3D, interfacedataTypes)
+  addDataType(RTC.PointCloud, interfacedataTypes)
+  addDataType(RTC.PanTiltAngles, interfacedataTypes)
+  addDataType(RTC.PanTiltState, interfacedataTypes)
+  addDataType(RTC.RangeData, interfacedataTypes)
+  addDataType(RTC.IntensityData, interfacedataTypes)
+

--- a/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceTopicManager.py
+++ b/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceTopicManager.py
@@ -1,0 +1,380 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+##
+# @file OpenSpliceTopicManager.py
+# @brief OpenSplice Topic Manager class
+# @date $Date$
+# @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+#
+# Copyright (C) 2019
+#     Noriaki Ando
+#     Robot Innovation Research Center,
+#     National Institute of
+#         Advanced Industrial Science and Technology (AIST), Japan
+#     All rights reserved.
+#
+# $Id$
+#
+
+import OpenRTM_aist
+import OpenSpliceMessageInfo
+import dds
+import ddsutil
+import threading
+
+
+
+manager = None
+mutex = threading.RLock()
+
+##
+# @if jp
+# @class OpenSpliceTopicManager
+# @brief OpenSpliceトピックを管理するクラス
+#
+#
+# @else
+# @class OpenSpliceTopicManager
+# @brief 
+#
+#
+# @endif
+class OpenSpliceTopicManager(object):
+  """
+  """
+
+  ##
+  # @if jp
+  # @brief コンストラクタ
+  #
+  # コンストラクタ
+  #
+  # @param self
+  #
+  # @else
+  # @brief Constructor
+  #
+  # @param self
+  #
+  # @endif
+  def __init__(self):
+    self._qosProfile = None
+    self._domainParticipant = None
+    self._topic = {}
+    self._info = {}
+
+    #mgr = OpenRTM_aist.Manager.instance()
+    #mgr.addManagerActionListener(ManagerActionListener(self))
+    #self._rtcout = mgr.getLogbuf("OpenSpliceTopicManager")
+
+
+  ##
+  # @if jp
+  # @brief デストラクタ
+  #
+  #
+  # @param self
+  #
+  # @else
+  #
+  # @brief self
+  #
+  # @endif
+  def __del__(self):
+    pass
+
+
+  ##
+  # @if jp
+  # @brief ドメインパティシパント、パブリッシャー、サブスクライバー初期化
+  #
+  # @param self
+  # @param qosxml QOS設定XMLファイル
+  # DDS_DefaultQoS_All.xml、DDS_VolatileQoS_All.xml等の設定ファイルを指定する
+  # 指定しない場合は以下のデフォルトのQOSに設定する
+  # DurabilityQosPolicy: TRANSIENT
+  # DeadlineQosPolicy: 500
+  # LatencyBudgetQosPolicy 3000
+  # LivelinessQosPolicy: MANUAL_BY_PARTICIPANT
+  # ReliabilityQosPolicy: RELIABLE, infinity
+  # DestinationOrderQosPolicy: BY_SOURCE_TIMESTAMP
+  # HistoryQosPolicy: KEEP_ALL
+  # ResourceLimitsQosPolicy: 10,10,10
+  # TransportPriorityQosPolicy: 700
+  # LifespanQosPolicy:10, 500
+  # OwnershipQosPolicy: EXCLUSIVE
+  # OwnershipStrengthQosPolicy 100
+  # WriterDataLifecycleQosPolicy: False
+  # ReaderDataLifecycleQosPolicy: 3,3
+  #
+  # @else
+  #
+  # @brief 
+  #
+  # @param self
+  # @param qosxml
+  #
+  # @endif
+  def start(self, qosxml):
+    if qosxml:
+      self._qosProfile = dds.QosProfile(qosxml, 'DDS DefaultQosProfile')
+      self._domainParticipant = dds.DomainParticipant(qos = self._qosProfile.get_participant_qos())
+      self._publisher = self._domainParticipant.create_publisher(qos=self._qosProfile.get_publisher_qos())
+      self._subscriber = self._domainParticipant.create_subscriber(qos=self._qosProfile.get_subscriber_qos())
+    else:
+      self._domainParticipant = dds.DomainParticipant()
+      self._publisher = self._domainParticipant.create_publisher()
+      self._subscriber = self._domainParticipant.create_subscriber()
+      
+
+    
+  ##
+  # @if jp
+  # @brief 終了処理
+  #
+  # @param self
+  #
+  # @else
+  #
+  # @brief 
+  #
+  # @param self
+  #
+  # @endif
+  def shutdown(self):
+    for _,v in self._topic.items():
+      v.close()
+    if self._publisher:
+      self._publisher.close()
+    if self._subscriber:
+      self._subscriber.close()
+    if self._domainParticipant:
+      self._domainParticipant.close()
+
+  ##
+  # @if jp
+  # @brief 指定データ型のロード、Infoオブジェクト生成
+  #
+  # @param self
+  # @param datatype データ型名
+  # @return Infoオブジェクト
+  #
+  # @else
+  #
+  # @brief 
+  #
+  # @param self
+  # @param datatype
+  # @return
+  #
+  # @endif
+  def genInfo(self, datatype):
+    if datatype in self._info:
+      return self._info[datatype]
+    factory = OpenSpliceMessageInfo.OpenSpliceMessageInfoFactory.instance()
+    datainfo = factory.createObject(datatype)
+    if datainfo:
+      datatype = datainfo.datatype()
+      idlfile = datainfo.idlFile()
+      factory.deleteObject(datainfo)
+      self._info[datatype] = ddsutil.get_dds_classes_from_idl(idlfile,
+                                                datatype)
+      return self._info[datatype]
+    return None
+
+  ##
+  # @if jp
+  # @brief Writerオブジェクト生成
+  #
+  # @param self
+  # @param topic トピックオブジェクト
+  # @return Writerオブジェクト
+  #
+  # @else
+  #
+  # @brief 
+  #
+  # @param self
+  # @param topic
+  # @return
+  #
+  # @endif
+  def createWriter(self, topic):
+    if self._qosProfile:
+      return self._publisher.create_datawriter(topic, self._qosProfile.get_writer_qos())
+    else:
+      writer_qos = dds.Qos([dds.DurabilityQosPolicy(dds.DDSDurabilityKind.TRANSIENT),
+                      dds.DeadlineQosPolicy(dds.DDSDuration(500)),
+                      dds.LatencyBudgetQosPolicy(dds.DDSDuration(3000)),
+                      dds.LivelinessQosPolicy(dds.DDSLivelinessKind.MANUAL_BY_PARTICIPANT),
+                      dds.ReliabilityQosPolicy(dds.DDSReliabilityKind.RELIABLE, dds.DDSDuration.infinity()),
+                      dds.DestinationOrderQosPolicy(dds.DDSDestinationOrderKind.BY_SOURCE_TIMESTAMP),
+                      dds.HistoryQosPolicy(dds.DDSHistoryKind.KEEP_ALL),
+                      dds.ResourceLimitsQosPolicy(10,10,10),
+                      dds.TransportPriorityQosPolicy(700),
+                      dds.LifespanQosPolicy(dds.DDSDuration(10, 500)),
+                      dds.OwnershipQosPolicy(dds.DDSOwnershipKind.EXCLUSIVE),
+                      dds.OwnershipStrengthQosPolicy(100),
+                      dds.WriterDataLifecycleQosPolicy(False)
+                      ])
+      return self._publisher.create_datawriter(topic, writer_qos)
+
+  ##
+  # @if jp
+  # @brief Readerオブジェクト生成
+  #
+  # @param self
+  # @param topic トピックオブジェクト
+  # @return Readerオブジェクト
+  #
+  # @else
+  #
+  # @brief 
+  #
+  # @param self
+  # @param topic
+  # @return
+  #
+  # @endif
+  def createReader(self, topic, listener):
+    if self._qosProfile:
+      return self._subscriber.create_datareader(topic, self._qosProfile.get_reader_qos(), listener)
+    else:
+      reader_qos = dds.Qos([dds.DurabilityQosPolicy(dds.DDSDurabilityKind.TRANSIENT),
+                      dds.DeadlineQosPolicy(dds.DDSDuration(500)),
+                      dds.LatencyBudgetQosPolicy(dds.DDSDuration(3000)),
+                      dds.LivelinessQosPolicy(dds.DDSLivelinessKind.MANUAL_BY_PARTICIPANT),
+                      dds.ReliabilityQosPolicy(dds.DDSReliabilityKind.RELIABLE, dds.DDSDuration.infinity()),
+                      dds.DestinationOrderQosPolicy(dds.DDSDestinationOrderKind.BY_SOURCE_TIMESTAMP),
+                      dds.HistoryQosPolicy(dds.DDSHistoryKind.KEEP_ALL),
+                      dds.ResourceLimitsQosPolicy(10,10,10),
+                      dds.OwnershipQosPolicy(dds.DDSOwnershipKind.EXCLUSIVE),
+                      dds.TimeBasedFilterQosPolicy(dds.DDSDuration(2, 500)),
+                      dds.ReaderDataLifecycleQosPolicy(dds.DDSDuration(3), dds.DDSDuration(5))
+                      ])
+      return self._subscriber.create_datareader(topic, reader_qos, listener)
+
+  ##
+  # @if jp
+  # @brief Topicオブジェクト生成
+  #
+  # @param self
+  # @param datatype データ型名
+  # @param topicname トピック名
+  # @return Topicオブジェクト
+  #
+  # @else
+  #
+  # @brief 
+  #
+  # @param self
+  # @param datatype 
+  # @param topicname 
+  # @return 
+  #
+  # @endif
+  def createTopic(self, datatype, topicname):
+    if topicname in self._topic:
+      return self._topic[topicname]
+    else:
+      geninfo = self.genInfo(datatype)
+      if geninfo:
+        if self._qosProfile:
+          self._topic[topicname] = geninfo.register_topic(self._domainParticipant, topicname, self._qosProfile.get_topic_qos())
+        else:
+          topic_qos = dds.Qos([dds.DurabilityQosPolicy(dds.DDSDurabilityKind.TRANSIENT),
+                     dds.DurabilityServiceQosPolicy(dds.DDSDuration(2, 500), dds.DDSHistoryKind.KEEP_ALL, 2, 100, 100, 100),
+                     dds.DeadlineQosPolicy(dds.DDSDuration(500)),
+                     dds.LatencyBudgetQosPolicy(dds.DDSDuration(3000)),
+                     dds.LivelinessQosPolicy(dds.DDSLivelinessKind.MANUAL_BY_PARTICIPANT),
+                     dds.ReliabilityQosPolicy(dds.DDSReliabilityKind.RELIABLE, dds.DDSDuration.infinity()),
+                     dds.DestinationOrderQosPolicy(dds.DDSDestinationOrderKind.BY_SOURCE_TIMESTAMP),
+                     dds.HistoryQosPolicy(dds.DDSHistoryKind.KEEP_ALL),
+                     dds.ResourceLimitsQosPolicy(10,10,10),
+                     dds.TransportPriorityQosPolicy(700),
+                     dds.LifespanQosPolicy(dds.DDSDuration(10, 500)),
+                     dds.OwnershipQosPolicy(dds.DDSOwnershipKind.EXCLUSIVE)
+                     ])
+          self._topic[topicname] = geninfo.register_topic(self._domainParticipant, topicname, topic_qos)
+        return self._topic[topicname]
+      return None
+
+
+  ##
+  # @if jp
+  # @brief インスタンス取得
+  #
+  # @return インスタンス
+  #
+  # @else
+  #
+  # @brief 
+  #
+  # @return インスタンス
+  #
+  # @endif
+  def instance(qosxml=""):
+    global manager
+    global mutex
+    
+    guard = OpenRTM_aist.ScopedLock(mutex)
+    if manager is None:
+      manager = OpenSpliceTopicManager()
+      manager.start(qosxml)
+
+    return manager
+  
+  instance = staticmethod(instance)
+
+
+##
+# @if jp
+# @class ManagerActionListener
+# @brief OpenSpliceTopicManagerに関するマネージャアクションリスナ
+#
+#
+# @else
+# @class ManagerActionListener
+# @brief 
+#
+#
+# @endif
+class ManagerActionListener:
+  ##
+  # @if jp
+  # @brief コンストラクタ
+  #
+  #
+  # @param self
+  #
+  # @else
+  #
+  # @brief self
+  #
+  # @endif
+  def __init__(self, topic_manager):
+    self._topic_manager = topic_manager
+
+  def preShutdown(self):
+    pass
+  ##
+  # @if jp
+  # @brief RTMマネージャ終了後にOpenSpliceTopicManagerの終了処理を実行
+  #
+  #
+  # @param self
+  #
+  # @else
+  #
+  # @brief self
+  #
+  # @endif
+  def postShutdown(self):
+    self._topic_manager.shutdown()
+
+  def preReinit(self):
+    pass
+
+  def postReinit(self):
+    pass

--- a/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceTransport.py
+++ b/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceTransport.py
@@ -1,0 +1,42 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+##
+# @file OpenSpliceTransport.py
+# @brief OpenSplice Transport class
+# @date $Date$
+# @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+#
+# Copyright (C) 2019
+#     Noriaki Ando
+#     Robot Innovation Research Center,
+#     National Institute of
+#         Advanced Industrial Science and Technology (AIST), Japan
+#     All rights reserved.
+#
+# $Id$
+#
+
+import OpenRTM_aist
+import OpenSpliceInPort
+import OpenSpliceOutPort
+import OpenSpliceSerializer
+
+
+
+##
+# @if jp
+# @brief モジュール登録関数
+#
+#
+# @else
+# @brief 
+#
+#
+# @endif
+#
+def OpenSpliceTransportInit(mgr):
+  OpenSpliceInPort.OpenSpliceInPortInit()
+  OpenSpliceOutPort.OpenSpliceOutPortInit()
+  OpenSpliceSerializer.OpenSpliceSerializerInit()
+

--- a/OpenRTM_aist/ext/transport/OpenSplice/rtc.conf
+++ b/OpenRTM_aist/ext/transport/OpenSplice/rtc.conf
@@ -1,0 +1,8 @@
+logger.enable: YES
+logger.file_name: stdout
+logger.log_level: ERROR
+
+manager.modules.load_path: .
+manager.modules.preload: OpenSpliceTransport.py
+manager.components.preconnect: ConsoleOut0.in?interface_type=opensplice&marshaling_type=opensplice, ConsoleIn0.out?interface_type=opensplice&marshaling_type=opensplice
+manager.components.preactivation: ConsoleOut0, ConsoleIn0

--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSOutPort.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSOutPort.py
@@ -36,8 +36,8 @@ import time
 ##
 # @if jp
 # @class ROSOutPort
-# @brief ROS Publisherã«å¯¾å¿œã™ã‚‹ã‚¯ãƒ©ã‚¹
-# InPortConsumerã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã¨ã—ã¦ä½¿ç”¨ã™ã‚‹
+# @brief ROS Publisher¤ËÂĞ±ş¤¹¤ë¥¯¥é¥¹
+# InPortConsumer¥ª¥Ö¥¸¥§¥¯¥È¤È¤·¤Æ»ÈÍÑ¤¹¤ë
 #
 # @else
 # @class ROSOutPort
@@ -51,9 +51,9 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
 
   ##
   # @if jp
-  # @brief ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
+  # @brief ¥³¥ó¥¹¥È¥é¥¯¥¿
   #
-  # ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
+  # ¥³¥ó¥¹¥È¥é¥¯¥¿
   #
   # @param self
   #
@@ -77,9 +77,9 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
 
   ##
   # @if jp
-  # @brief ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
+  # @brief ¥Ç¥¹¥È¥é¥¯¥¿
   #
-  # ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
+  # ¥Ç¥¹¥È¥é¥¯¥¿
   #
   # @param self
   #
@@ -97,16 +97,16 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
     
   ##
   # @if jp
-  # @brief è¨­å®šåˆæœŸåŒ–
+  # @brief ÀßÄê½é´ü²½
   #
-  # InPortConsumerã®å„ç¨®è¨­å®šã‚’è¡Œã†
+  # InPortConsumer¤Î³Æ¼ïÀßÄê¤ò¹Ô¤¦
   #
   # @param self
-  # @param prop æ¥ç¶šè¨­å®š
-  # marshaling_type ã‚·ãƒªã‚¢ãƒ©ã‚¤ã‚¶ã®ç¨®é¡ ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆï¼šROSFloat32
-  # topic ãƒˆãƒ”ãƒƒã‚¯å ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆ chatter
-  # roscore_host roscoreã®ãƒ›ã‚¹ãƒˆå ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆï¼šlocalhost
-  # roscore_port roscoreã®ãƒãƒ¼ãƒˆç•ªå· ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆï¼š11311
+  # @param prop ÀÜÂ³ÀßÄê
+  # marshaling_type ¥·¥ê¥¢¥é¥¤¥¶¤Î¼ïÎà ¥Ç¥Õ¥©¥ë¥È¡§ROSFloat32
+  # topic ¥È¥Ô¥Ã¥¯Ì¾ ¥Ç¥Õ¥©¥ë¥È chatter
+  # roscore_host roscore¤Î¥Û¥¹¥ÈÌ¾ ¥Ç¥Õ¥©¥ë¥È¡§localhost
+  # roscore_port roscore¤Î¥İ¡¼¥ÈÈÖ¹æ ¥Ç¥Õ¥©¥ë¥È¡§11311
   #
   # @else
   # @brief Initializing configuration
@@ -162,10 +162,10 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
 
   ##
   # @if jp
-  # @brief ãƒˆãƒ”ãƒƒã‚¯åå–å¾—
+  # @brief ¥È¥Ô¥Ã¥¯Ì¾¼èÆÀ
   #
   #
-  # @return ãƒˆãƒ”ãƒƒã‚¯å
+  # @return ¥È¥Ô¥Ã¥¯Ì¾
   #
   # @else
   # @brief get topic name
@@ -180,12 +180,12 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
 
   ##
   # @if jp
-  # @brief Subscriberã¨ã®æ¥ç¶š
+  # @brief Subscriber¤È¤ÎÀÜÂ³
   #
   #
   # @param self
-  # @param client_sock ã‚½ã‚±ãƒƒãƒˆ
-  # @param addr æ¥ç¶šå…ˆã®URI
+  # @param client_sock ¥½¥±¥Ã¥È
+  # @param addr ÀÜÂ³Àè¤ÎURI
   #
   # @else
   # @brief 
@@ -269,20 +269,20 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
 
   ##
   # @if jp
-  # @brief æ¥ç¶šå…ˆã¸ã®ãƒ‡ãƒ¼ã‚¿é€ä¿¡
+  # @brief ÀÜÂ³Àè¤Ø¤Î¥Ç¡¼¥¿Á÷¿®
   #
-  # æ¥ç¶šå…ˆã®ãƒãƒ¼ãƒˆã¸ãƒ‡ãƒ¼ã‚¿ã‚’é€ä¿¡ã™ã‚‹ãŸã‚ã®ç´”ç²‹ä»®æƒ³é–¢æ•°ã€‚
+  # ÀÜÂ³Àè¤Î¥İ¡¼¥È¤Ø¥Ç¡¼¥¿¤òÁ÷¿®¤¹¤ë¤¿¤á¤Î½ã¿è²¾ÁÛ´Ø¿ô¡£
   # 
-  # ã“ã®é–¢æ•°ã¯ã€ä»¥ä¸‹ã®ãƒªã‚¿ãƒ¼ãƒ³ã‚³ãƒ¼ãƒ‰ã‚’è¿”ã™ã€‚
+  # ¤³¤Î´Ø¿ô¤Ï¡¢°Ê²¼¤Î¥ê¥¿¡¼¥ó¥³¡¼¥É¤òÊÖ¤¹¡£
   #
-  # - PORT_OK:       æ­£å¸¸çµ‚äº†ã€‚
-  # - PORT_ERROR:    ãƒ‡ãƒ¼ã‚¿é€ä¿¡ã®éç¨‹ã§ä½•ã‚‰ã‹ã®ã‚¨ãƒ©ãƒ¼ãŒç™ºç”Ÿã—ãŸã€‚
-  # - SEND_FULL:     ãƒ‡ãƒ¼ã‚¿ã‚’é€ä¿¡ã—ãŸãŒã€ç›¸æ‰‹å´ãƒãƒƒãƒ•ã‚¡ãŒãƒ•ãƒ«ã ã£ãŸã€‚
-  # - SEND_TIMEOUT:  ãƒ‡ãƒ¼ã‚¿ã‚’é€ä¿¡ã—ãŸãŒã€ç›¸æ‰‹å´ãƒãƒƒãƒ•ã‚¡ãŒã‚¿ã‚¤ãƒ ã‚¢ã‚¦ãƒˆã—ãŸã€‚
-  # - UNKNOWN_ERROR: åŸå› ä¸æ˜ã®ã‚¨ãƒ©ãƒ¼
+  # - PORT_OK:       Àµ¾ï½ªÎ»¡£
+  # - PORT_ERROR:    ¥Ç¡¼¥¿Á÷¿®¤Î²áÄø¤Ç²¿¤é¤«¤Î¥¨¥é¡¼¤¬È¯À¸¤·¤¿¡£
+  # - SEND_FULL:     ¥Ç¡¼¥¿¤òÁ÷¿®¤·¤¿¤¬¡¢Áê¼êÂ¦¥Ğ¥Ã¥Õ¥¡¤¬¥Õ¥ë¤À¤Ã¤¿¡£
+  # - SEND_TIMEOUT:  ¥Ç¡¼¥¿¤òÁ÷¿®¤·¤¿¤¬¡¢Áê¼êÂ¦¥Ğ¥Ã¥Õ¥¡¤¬¥¿¥¤¥à¥¢¥¦¥È¤·¤¿¡£
+  # - UNKNOWN_ERROR: ¸¶°øÉÔÌÀ¤Î¥¨¥é¡¼
   #
-  # @param data é€ä¿¡ã™ã‚‹ãƒ‡ãƒ¼ã‚¿
-  # @return ãƒªã‚¿ãƒ¼ãƒ³ã‚³ãƒ¼ãƒ‰
+  # @param data Á÷¿®¤¹¤ë¥Ç¡¼¥¿
+  # @return ¥ê¥¿¡¼¥ó¥³¡¼¥É
   #
   # @else
   # @brief Send data to the destination port
@@ -319,14 +319,14 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
 
   ##
   # @if jp
-  # @brief InterfaceProfileæƒ…å ±ã‚’å…¬é–‹ã™ã‚‹
+  # @brief InterfaceProfile¾ğÊó¤ò¸ø³«¤¹¤ë
   #
-  # InterfaceProfileæƒ…å ±ã‚’å…¬é–‹ã™ã‚‹ã€‚
-  # å¼•æ•°ã§æŒ‡å®šã™ã‚‹ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£æƒ…å ±å†…ã® NameValue ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã®
-  # dataport.interface_type å€¤ã‚’èª¿ã¹ã€å½“è©²ãƒãƒ¼ãƒˆã«è¨­å®šã•ã‚Œã¦ã„ã‚‹
-  # ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ãƒ¼ã‚¹ã‚¿ã‚¤ãƒ—ã¨ä¸€è‡´ã™ã‚‹å ´åˆã®ã¿æƒ…å ±ã‚’å–å¾—ã™ã‚‹ã€‚
+  # InterfaceProfile¾ğÊó¤ò¸ø³«¤¹¤ë¡£
+  # °ú¿ô¤Ç»ØÄê¤¹¤ë¥×¥í¥Ñ¥Æ¥£¾ğÊóÆâ¤Î NameValue ¥ª¥Ö¥¸¥§¥¯¥È¤Î
+  # dataport.interface_type ÃÍ¤òÄ´¤Ù¡¢Åö³º¥İ¡¼¥È¤ËÀßÄê¤µ¤ì¤Æ¤¤¤ë
+  # ¥¤¥ó¥¿¡¼¥Õ¥§¡¼¥¹¥¿¥¤¥×¤È°ìÃ×¤¹¤ë¾ì¹ç¤Î¤ß¾ğÊó¤ò¼èÆÀ¤¹¤ë¡£
   #
-  # @param properties InterfaceProfileæƒ…å ±ã‚’å—ã‘å–ã‚‹ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£
+  # @param properties InterfaceProfile¾ğÊó¤ò¼õ¤±¼è¤ë¥×¥í¥Ñ¥Æ¥£
   #
   # @else
   # @brief Publish InterfaceProfile information
@@ -346,13 +346,13 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
 
   ##
   # @if jp
-  # @brief ãƒ‡ãƒ¼ã‚¿é€ä¿¡é€šçŸ¥ã¸ã®ç™»éŒ²
+  # @brief ¥Ç¡¼¥¿Á÷¿®ÄÌÃÎ¤Ø¤ÎÅĞÏ¿
   #
-  # æŒ‡å®šã•ã‚ŒãŸãƒ—ãƒ­ãƒ‘ãƒ†ã‚£ã«åŸºã¥ã„ã¦ã€ãƒ‡ãƒ¼ã‚¿é€å‡ºé€šçŸ¥ã®å—ã‘å–ã‚Šã«ç™»éŒ²ã™ã‚‹ã€‚
+  # »ØÄê¤µ¤ì¤¿¥×¥í¥Ñ¥Æ¥£¤Ë´ğ¤Å¤¤¤Æ¡¢¥Ç¡¼¥¿Á÷½ĞÄÌÃÎ¤Î¼õ¤±¼è¤ê¤ËÅĞÏ¿¤¹¤ë¡£
   #
-  # @param properties ç™»éŒ²æƒ…å ±
+  # @param properties ÅĞÏ¿¾ğÊó
   #
-  # @return ç™»éŒ²å‡¦ç†çµæœ(ç™»éŒ²æˆåŠŸ:trueã€ç™»éŒ²å¤±æ•—:false)
+  # @return ÅĞÏ¿½èÍı·ë²Ì(ÅĞÏ¿À®¸ù:true¡¢ÅĞÏ¿¼ºÇÔ:false)
   #
   # @else
   # @brief Subscribe to the data sending notification
@@ -372,11 +372,11 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
     
   ##
   # @if jp
-  # @brief ãƒ‡ãƒ¼ã‚¿é€ä¿¡é€šçŸ¥ã‹ã‚‰ã®ç™»éŒ²è§£é™¤
+  # @brief ¥Ç¡¼¥¿Á÷¿®ÄÌÃÎ¤«¤é¤ÎÅĞÏ¿²ò½ü
   #
-  # ãƒ‡ãƒ¼ã‚¿é€å‡ºé€šçŸ¥ã®å—ã‘å–ã‚Šã‹ã‚‰ç™»éŒ²ã‚’è§£é™¤ã™ã‚‹ã€‚
+  # ¥Ç¡¼¥¿Á÷½ĞÄÌÃÎ¤Î¼õ¤±¼è¤ê¤«¤éÅĞÏ¿¤ò²ò½ü¤¹¤ë¡£
   #
-  # @param properties ç™»éŒ²è§£é™¤æƒ…å ±
+  # @param properties ÅĞÏ¿²ò½ü¾ğÊó
   #
   # @else
   # @brief Unsubscribe the data send notification
@@ -413,7 +413,7 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
 
 ##
 # @if jp
-# @brief ãƒ¢ã‚¸ãƒ¥ãƒ¼ãƒ«ç™»éŒ²é–¢æ•°
+# @brief ¥â¥¸¥å¡¼¥ëÅĞÏ¿´Ø¿ô
 #
 #
 # @else

--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSOutPort.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSOutPort.py
@@ -68,7 +68,7 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
     self._rtcout = OpenRTM_aist.Manager.instance().getLogbuf("ROSOutPort")
     self._properties = None
     self._callerid = ""
-    self._messageType = "Float32"
+    self._messageType = "ROSFloat32"
     self._topic = "/chatter"
     self._roscorehost = "localhost"
     self._roscoreport = "11311"

--- a/setup.py
+++ b/setup.py
@@ -192,6 +192,7 @@ openrtm_ext_packages = [
   "OpenRTM_aist.ext.ssl",
   "OpenRTM_aist.ext.logger.fluentbit_stream",
   "OpenRTM_aist.ext.transport.ROSTransport",
+  "OpenRTM_aist.ext.transport.OpenSplice",
   ]
 openrtm_utils_packages = [
   "OpenRTM_aist.utils",


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

データポートにDDS通信インターフェースを実装する。


## Description of the Change

一部ファイルがコミットできていなかったため、一旦draftに設定します。

### 使用するDDS実装の選定

- Fast-RTPs
- DDS for TAO
Pythonの実装がない。

- rticonnextdds-connector-py
サンプルではXMLファイルでデータ型を定義している。
IDLファイルで定義可能かは要調査。

- OpenSplice
IDLファイルでデータ型を定義しており、omnoORBと使用方法は近い。
ただし、どのIDLファイルがどのデータ型を定義しているのか知る必要があるため工夫が必要。

上記の理由によりOpenSpliceで実装。

### OpenRTM-aist本体の変更
Topic、Publisher、Subscriber初期化時にデータ型に関する情報が必要なため、コネクタプロファイルにデータ型名を格納するようにした。

### OpenSplice通信機能の実装

- OpenSpliceInPort.py
Subscriber側の実装。OpenSpliceのReaderを生成し、コールバック関数を設定する。
- OpenSpliceOutPort.py
Publisher側の実装。OpenSpliceのWriterを生成し、put関数実行時にデータを書き込む。

- OpenSpliceTopicManager.py
DomainParticipant、publisher、subscriberの初期化などを定義。
DomainParticipantは一度しか初期化しないため、QOSの設定は最初に生成したコネクタのプロファイルが反映される。

- OpenSpliceSerializer.py
OpenSpliceのPythonラッパーライブラリにはCDRバイト列を書き込む関数などはない。
このため、一旦omniORBの変数からOpenSpliceの変数に値を移すようにしている。
- OpenSpliceMessageInfo.py
IDLファイルで定義したデータ型を格納する変数について、OpenSpliceでは初期化にIDLファイル自体が必要になる。このためIDLファイルのパスを入力する必要があるが、どのIDLファイルがどのデータ型を定義しているかを関連付ける必要がある。
OpenSpliceMessageInfoFactoryではデータ型とIDLファイルを格納した情報を登録する。
- OpenSpliceTransport.py
OpenSpliceInPort、OpenSpliceOutPort、OpenSpliceSerializerを登録する。

### 使用方法

まずはOpenSpliceを以下からダウンロードして適当な場所に展開してください。

- https://github.com/ADLINK-IST/opensplice/releases

以下のように`OpenSpliceTransport.py`をロード後、インターフェース型に`opensplice`を指定して起動します。

```
manager.modules.load_path: .
manager.modules.preload: OpenSpliceTransport.py
manager.components.preconnect: ConsoleOut0.in?interface_type=opensplice&marshaling_type=opensplice, ConsoleIn0.out?interface_type=opensplice&marshaling_type=opensplice
```

またコネクタで以下の設定ができる。

- QOSXML
QOSの設定を記述したXMLファイルのパス
- topic
トピック名

ただし、RTC起動前に以下のバッチファイルを実行する必要があります。

```
C:\workspace\HDE\x86_64.win64\release.bat
```

## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
