### PR TITLE
サービスポート接続時にコネクタのコールバック関数が呼ばれない問題の修正

### DIFF
--- a/OpenRTM_aist/RTObject.py
+++ b/OpenRTM_aist/RTObject.py
@@ -2606,6 +2606,8 @@ class RTObject_impl:
         self._properties.getNode(propkey).mergeProperties(self._properties.getNode("port.corba"))
       port.init(self._properties.getNode(propkey))
       port.setOwner(self.getObjRef())
+      port.setPortConnectListenerHolder(self._portconnListeners)
+      self.onAddPort(port.getPortProfile())
 
     elif isinstance(port, OpenRTM_aist.PortBase):
       self._rtcout.RTC_TRACE("addPort(PortBase)")


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

サービスポート接続時にaddPortConnectRetListenerなどで設定したコールバック関数が呼ばれない。
このためコンポーネントオブザーバーによる通知も行われず、RTSE上でポートが接続されていないように見える。


## Description of the Change

サービスポート接続時にもコールバック関数が呼ばれるようにした。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
