### PR TITLE
CORBA_RTCUtilのget_default_rate関数、set_default_rate関数、get_current_rate関数、set_current_rate関数でECが取得できなかった場合にBAD_PARAMETERを返すようにする

### DIFF
--- a/OpenRTM_aist/CORBA_RTCUtil.py
+++ b/OpenRTM_aist/CORBA_RTCUtil.py
@@ -388,6 +388,8 @@ def is_in_error(rtc, ec_id=0):
 # @endif
 def get_default_rate(rtc):
   ec = get_actual_ec(rtc)
+  if CORBA.is_nil(ec):
+    return RTC.BAD_PARAMETER
   return ec.get_rate()
 
 
@@ -410,6 +412,8 @@ def get_default_rate(rtc):
 # @endif
 def set_default_rate(rtc, rate):
   ec = get_actual_ec(rtc)
+  if CORBA.is_nil(ec):
+    return RTC.BAD_PARAMETER
   return ec.set_rate(rate)
 
 
@@ -432,6 +436,8 @@ def set_default_rate(rtc, rate):
 # @endif
 def get_current_rate(rtc, ec_id):
   ec = get_actual_ec(rtc, ec_id)
+  if CORBA.is_nil(ec):
+    return RTC.BAD_PARAMETER
   return ec.get_rate()
 
 
@@ -455,6 +461,8 @@ def get_current_rate(rtc, ec_id):
 # @endif
 def set_current_rate(rtc, ec_id, rate):
   ec = get_actual_ec(rtc, ec_id)
+  if CORBA.is_nil(ec):
+    return RTC.BAD_PARAMETER
   return ec.set_rate(rate)
 
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

CORBA_RTCUtilの以下の関数について、指定IDのECが取得できなかった場合にNoneに設定した変数から関数を呼び出そうとしてします。

- get_default_rate関数
- set_default_rate関数
- get_current_rate関数
- set_current_rate関数


## Description of the Change

指定IDのECが取得できなかった場合を判定してBAD_PARAMETERを返すようにした。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
