### PR TITLE
同一プロセス内でインターフェース型shared_memoryでデータポートを接続するとエラーが発生する問題の修正

### DIFF
--- a/OpenRTM_aist/SharedMemory.py
+++ b/OpenRTM_aist/SharedMemory.py
@@ -202,7 +202,7 @@ class SharedMemory(OpenRTM__POA.PortSharedMemory):
         self.rt.close( self.fd )
 
       
-      if not CORBA.is_nil(self._smInterface):
+      if self._smInterface is not None:
           self._smInterface.open_memory(self._memory_size, self._shm_address)
 
 
@@ -274,7 +274,7 @@ class SharedMemory(OpenRTM__POA.PortSharedMemory):
       self._shmem = None
 
       try:
-        if not CORBA.is_nil(self._smInterface) and self._smInterface._non_existent():
+        if self._smInterface is not None and self._smInterface._non_existent():
           self._smInterface.close_memory(False)
       except:
         pass
@@ -314,7 +314,7 @@ class SharedMemory(OpenRTM__POA.PortSharedMemory):
       if data_size + SharedMemory.default_size > self._memory_size:
         self._memory_size = data_size + SharedMemory.default_size
 
-        if not CORBA.is_nil(self._smInterface):
+        if self._smInterface is not None:
           self._smInterface.close_memory(False)
 
 
@@ -384,7 +384,11 @@ class SharedMemory(OpenRTM__POA.PortSharedMemory):
   #
   # void setInterface(::OpenRTM::PortSharedMemory_var sm);
   def setInterface(self, sm):
-    self._smInterface = sm
+    if isinstance(sm, SharedMemory):
+      self._smInterface = sm
+    else:
+      if not CORBA.is_nil(sm):
+        self._smInterface = sm
 
 
   ##
@@ -407,7 +411,7 @@ class SharedMemory(OpenRTM__POA.PortSharedMemory):
   # void setEndian(bool endian);
   def setEndian(self, endian):
     self._endian = endian
-    if not CORBA.is_nil(self._smInterface):
+    if self._smInterface is not None:
       self._smInterface.setEndian(self._endian)
 
   ##


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

同一プロセス内でインターフェース型をshared_memoryに設定してデータポートを接続すると、接続時にエラーが発生する。


## Description of the Change
以下のsetObject関数内で、CorbaConsumerの`_ptr`関数でオブジェクトを取得するが、同一プロセス内の場合はオブジェクトリファレンスではなく実体を返す。

```Python
  def setObject(self, obj):
    if OpenRTM_aist.CorbaConsumer.setObject(self, obj):
      portshmem = self._ptr()
      if portshmem:
        self._shmem.setInterface(portshmem)

        return True
    return False
```

このあとCORBA.is_nilに`_ptr`関数で取得したオブジェクトを入力するとエラーになる。

このため、以下のようにまずオブジェクトリファレンスか実体かを判別するようにした。

```Python
  def setInterface(self, sm):
    if isinstance(sm, SharedMemory):
      self._smInterface = sm
    else:
      if not CORBA.is_nil(sm):
        self._smInterface = sm
```


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
