### PR TITLE
unsubscribeInterfaceが呼び出されない問題の修正

### DIFF
--- a/OpenRTM_aist/InPortDuplexConnector.py
+++ b/OpenRTM_aist/InPortDuplexConnector.py
@@ -227,6 +227,17 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
       self._provider.exit()
       
     self._provider = None
+
+
+    if self._consumer:
+      prop_list = []
+      prop = OpenRTM_aist.Properties()
+      node = prop.getNode("dataport")
+      node.mergeProperties(self._profile.properties)
+      OpenRTM_aist.NVUtil.copyFromProperties(prop_list, prop)
+      self._consumer.unsubscribeInterface(prop_list)
+      OpenRTM_aist.OutPortConsumerFactory.instance().deleteObject(self._consumer)
+    self._consumer = None
     
     return self.PORT_OK
 

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -277,6 +277,12 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
     self.onDisconnect()
     # delete consumer
     if self._consumer:
+      prop_list = []
+      prop = OpenRTM_aist.Properties()
+      node = prop.getNode("dataport")
+      node.mergeProperties(self._profile.properties)
+      OpenRTM_aist.NVUtil.copyFromProperties(prop_list, prop)
+      self._consumer.unsubscribeInterface(prop_list)
       OpenRTM_aist.OutPortConsumerFactory.instance().deleteObject(self._consumer)
     self._consumer = None
 

--- a/OpenRTM_aist/OutPortDuplexConnector.py
+++ b/OpenRTM_aist/OutPortDuplexConnector.py
@@ -294,6 +294,20 @@ class OutPortDuplexConnector(OpenRTM_aist.OutPortConnector):
       OpenRTM_aist.SerializerFactory.instance().deleteObject(self._serializer)
     self._serializer = None
 
+
+    if self._consumer:
+      self._rtcout.RTC_DEBUG("delete consumer")
+      prop_list = []
+      prop = OpenRTM_aist.Properties()
+      node = prop.getNode("dataport")
+      node.mergeProperties(self._profile.properties)
+      OpenRTM_aist.NVUtil.copyFromProperties(prop_list, prop)
+      self._consumer.unsubscribeInterface(prop_list)
+      cfactory = OpenRTM_aist.InPortConsumerFactory.instance()
+      cfactory.deleteObject(self._consumer)
+
+    self._consumer = None
+
     return self.PORT_OK
 
 

--- a/OpenRTM_aist/OutPortPushConnector.py
+++ b/OpenRTM_aist/OutPortPushConnector.py
@@ -306,6 +306,12 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
     # delete consumer
     if self._consumer:
       self._rtcout.RTC_DEBUG("delete consumer")
+      prop_list = []
+      prop = OpenRTM_aist.Properties()
+      node = prop.getNode("dataport")
+      node.mergeProperties(self._profile.properties)
+      OpenRTM_aist.NVUtil.copyFromProperties(prop_list, prop)
+      self._consumer.unsubscribeInterface(prop_list)
       cfactory = OpenRTM_aist.InPortConsumerFactory.instance()
       cfactory.deleteObject(self._consumer)
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

ROSTransport等の動作確認で気づいたのですが、OutPortConsumer、InPortConsumerの`unsubscribeInterface`関数が呼び出されていませんでした。C++も同様です。

ROSTransport等はunsubscribeInterface関数が呼び出される前提で作成しているため、呼び出されないと終了時に落ちる場合もあります。

## Description of the Change

OutPortPushConnector、InPortPullConnectorのdisconnect関数でunsubscribeInterface関数を呼び出すように変更しました。

## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
