### PR TITLE
unsubscribeInterfaceが呼び出されない問題の修正

### DIFF
--- a/OpenRTM_aist/InPortBase.py
+++ b/OpenRTM_aist/InPortBase.py
@@ -1088,6 +1088,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
       # guard = OpenRTM_aist.ScopedLock(self._connector_mutex)
       if id == self._connectors[idx].id():
         # Connector's dtor must call disconnect()
+        self._connectors[idx].unsubscribeInterface(connector_profile.properties)
         self._connectors[idx].deactivate()
         self._connectors[idx].disconnect()
         del self._connectors[idx]

--- a/OpenRTM_aist/InPortBase.py
+++ b/OpenRTM_aist/InPortBase.py
@@ -128,6 +128,12 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
       self._rtcout.RTC_ERROR("connector.size should be 0 in InPortBase's dtor.")
       # guard = OpenRTM_aist.ScopedLock(self._connector_mutex)
       for connector in self._connectors:
+        prop_list = []
+        prop = OpenRTM_aist.Properties()
+        node = prop.getNode("dataport")
+        node.mergeProperties(connector.profile().properties)
+        OpenRTM_aist.NVUtil.copyFromProperties(prop_list, prop)
+        connector.unsubscribeInterface(prop_list)
         connector.disconnect()
 
     if self._thebuffer is not None:

--- a/OpenRTM_aist/InPortConnector.py
+++ b/OpenRTM_aist/InPortConnector.py
@@ -259,9 +259,9 @@ class InPortConnector(OpenRTM_aist.ConnectorBase):
 
   #
   # @if jp
-  # @brief データを書き込める状態かを判定
+  # @brief データを読み込める状態かを判定
   # @param self
-  # @return True：書き込み可能
+  # @return True：読み込み可能
   # @else
   # @brief 
   # @param self
@@ -278,4 +278,15 @@ class InPortConnector(OpenRTM_aist.ConnectorBase):
   # @brief set Consumer
   # @endif
   def setConsumer(self, consumer):
+    pass
+
+  ##
+  # @if jp
+  # @brief コンシューマのインターフェースの登録を取り消す
+  # @param prop コネクタプロファイルのプロパティ
+  # @else
+  # @brief 
+  # @param prop
+  # @endif
+  def unsubscribeInterface(self, prop):
     pass

--- a/OpenRTM_aist/InPortDuplexConnector.py
+++ b/OpenRTM_aist/InPortDuplexConnector.py
@@ -227,6 +227,11 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
       self._provider.exit()
       
     self._provider = None
+
+
+    if self._consumer:
+      OpenRTM_aist.OutPortConsumerFactory.instance().deleteObject(self._consumer)
+    self._consumer = None
     
     return self.PORT_OK
 
@@ -449,6 +454,18 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
       self._rtcout.RTC_ERROR("unknown serializer from connector")
       return self.UNKNOWN_ERROR, None
     return self.PRECONDITION_NOT_MET, None
+
+  ##
+  # @if jp
+  # @brief コンシューマのインターフェースの登録を取り消す
+  # @param prop コネクタプロファイルのプロパティ
+  # @else
+  # @brief 
+  # @param prop
+  # @endif
+  def unsubscribeInterface(self, prop):
+    if self._consumer:
+      self._consumer.unsubscribeInterface(prop)
 
 
 ##

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -397,3 +397,14 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
     return True
 
 
+  ##
+  # @if jp
+  # @brief コンシューマのインターフェースの登録を取り消す
+  # @param prop コネクタプロファイルのプロパティ
+  # @else
+  # @brief 
+  # @param prop
+  # @endif
+  def unsubscribeInterface(self, prop):
+    if self._consumer:
+      self._consumer.unsubscribeInterface(prop)

--- a/OpenRTM_aist/OutPortBase.py
+++ b/OpenRTM_aist/OutPortBase.py
@@ -1131,6 +1131,7 @@ class OutPortBase(OpenRTM_aist.PortBase,OpenRTM_aist.DataPortStatus):
       idx = (len_ - 1) - i
       if id == self._connectors[idx].id():
         # Connector's dtor must call disconnect()
+        self._connectors[idx].unsubscribeInterface(connector_profile.properties)
         self._connectors[idx].deactivate()
         self._connectors[idx].disconnect()
         del self._connectors[idx]

--- a/OpenRTM_aist/OutPortConnector.py
+++ b/OpenRTM_aist/OutPortConnector.py
@@ -191,17 +191,76 @@ class OutPortConnector(OpenRTM_aist.ConnectorBase):
   def read(self, data):
     pass
 
+  #
+  # @if jp
+  # @brief データを書き込める状態かを判定
+  # @param self
+  # @return True：書き込み可能
+  # @else
+  # @brief 
+  # @param self
+  # @return 
+  # @endif
   def isWritable(self):
     return False
 
+  #
+  # @if jp
+  # @brief データを読み込める状態かを判定
+  # @param self
+  # @return True：読み込み可能
+  # @else
+  # @brief 
+  # @param self
+  # @return 
+  # @return 
+  # @endif
   def isReadable(self):
     return False
 
+  #
+  # @if jp
+  # @brief データを書き込める状態かを判定
+  # @param self
+  # @return True：書き込み可能
+  # @else
+  # @brief 
+  # @param self
+  # @return 
+  # @endif
   def setReadListener(self, listener):
     pass
 
+  #
+  # @if jp
+  # @brief データを読み込める状態かを判定
+  # @param self
+  # @return True：読み込み可能
+  # @else
+  # @brief 
+  # @param self
+  # @return 
+  # @return 
+  # @endif
   def setIsReadableListener(self, listener):
     pass
 
+  ##
+  # @if jp
+  # @brief コンシューマの設定
+  # @else
+  # @brief set Consumer
+  # @endif
   def setConsumer(self, consumer):
+    pass
+
+  ##
+  # @if jp
+  # @brief コンシューマのインターフェースの登録を取り消す
+  # @param prop コネクタプロファイルのプロパティ
+  # @else
+  # @brief 
+  # @param prop
+  # @endif
+  def unsubscribeInterface(self, prop):
     pass

--- a/OpenRTM_aist/OutPortDuplexConnector.py
+++ b/OpenRTM_aist/OutPortDuplexConnector.py
@@ -294,6 +294,14 @@ class OutPortDuplexConnector(OpenRTM_aist.OutPortConnector):
       OpenRTM_aist.SerializerFactory.instance().deleteObject(self._serializer)
     self._serializer = None
 
+
+    if self._consumer:
+      self._rtcout.RTC_DEBUG("delete consumer")
+      cfactory = OpenRTM_aist.InPortConsumerFactory.instance()
+      cfactory.deleteObject(self._consumer)
+
+    self._consumer = None
+
     return self.PORT_OK
 
 
@@ -432,6 +440,18 @@ class OutPortDuplexConnector(OpenRTM_aist.OutPortConnector):
       self._rtcout.RTC_ERROR("write(): serializer %s is not support.",self._marshaling_type)
       return self.UNKNOWN_ERROR, cdr_data
     return self.PORT_OK, cdr_data
+
+  ##
+  # @if jp
+  # @brief コンシューマのインターフェースの登録を取り消す
+  # @param prop コネクタプロファイルのプロパティ
+  # @else
+  # @brief 
+  # @param prop
+  # @endif
+  def unsubscribeInterface(self, prop):
+    if self._consumer:
+      self._consumer.unsubscribeInterface(prop)
 
 
 ##

--- a/OpenRTM_aist/OutPortPushConnector.py
+++ b/OpenRTM_aist/OutPortPushConnector.py
@@ -496,3 +496,15 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
     self._directInPort = directInPort
     self._inPortListeners = self._directInPort._listeners
     return True
+
+  ##
+  # @if jp
+  # @brief コンシューマのインターフェースの登録を取り消す
+  # @param prop コネクタプロファイルのプロパティ
+  # @else
+  # @brief 
+  # @param prop
+  # @endif
+  def unsubscribeInterface(self, prop):
+    if self._consumer:
+      self._consumer.unsubscribeInterface(prop)


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

データポートのコネクタをdisconnectした際にInPortConsumer、OutPortConsumerの`unsubscribeInterface`関数が呼び出されない問題があるが、ソースコードを読んだ限り呼び出すような記述自体がないため仕様かバグかも不明。



## Description of the Change

ROSTransportなどはunsubscribeInterface関数が呼び出されないと異常終了する可能性があるため`unsubscribeInterface`関数が呼び出されるように変更した。

`unsubscribeInterface`関数の引数にコネクタプロファイルが必要のため、OutPortConnector、InPortConnectorに`unsubscribeInterface`関数を追加してInPortBase、OutPortBaseのunsubscribeInterfaces関数内で呼び出すようにした。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
