### PR TITLE
コンポーネントオブザーバーのタイマースレッドをonFinalizeで終了する処理に変更(1.2)

### DIFF
--- a/OpenRTM_aist/ext/sdo/observer/ComponentObserverConsumer.py
+++ b/OpenRTM_aist/ext/sdo/observer/ComponentObserverConsumer.py
@@ -152,7 +152,6 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
     self.unsetPortProfileListeners()
     self.unsetExecutionContextListeners()
     self.unsetConfigurationListeners()
-    self.unsetHeartbeat()
 
     del self._timer
     return
@@ -291,7 +290,8 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
   #
   # void heartbeat();
   def heartbeat(self):
-    self.updateStatus(OpenRTM.HEARTBEAT, "")
+    if self._heartbeat:
+      self.updateStatus(OpenRTM.HEARTBEAT, "")
     return
 
 
@@ -358,8 +358,9 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
   # void unsetHeartbeat();
   def unsetHeartbeat(self):
     self._timer.unregisterListener(self._hblistenerid)
-    self._hblistenerid = 0
+    self._hblistenerid = None
     self._timer.stop()
+    self._timer.join()
     self._heartbeat = False
     return
 
@@ -789,6 +790,7 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
 
     #void onFinalize(UniqueId ec_id, ReturnCode_t ret)
     def onFinalize(self, ec_id, ret):
+      self._coc.unsetHeartbeat()
       self.onGeneric("FINALIZE:", ec_id, ret)
       return
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

C++版の以下の変更と同じ。

- https://github.com/OpenRTM/OpenRTM-aist/pull/409

## Description of the Change


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
