### PR TITLE
C++版とコンポーネントオブザーバーの動作が違うため修正

### DIFF
--- a/OpenRTM_aist/ext/fsm4rtc_observer/ComponentObserverConsumer.py
+++ b/OpenRTM_aist/ext/fsm4rtc_observer/ComponentObserverConsumer.py
@@ -137,7 +137,7 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
     self._ecHblistenerid = None
 
     # このタイマーはいずれグローバルなタイマにおきかえる
-    self._timer = OpenRTM_aist.Timer(self._rtcInterval)
+    self._timer = OpenRTM_aist.Timer(OpenRTM_aist.TimeValue(0, 100000))
     return
 
 
@@ -456,7 +456,6 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
   # void stopTimer();
   def stopTimer(self):
     self._timer.stop()
-    self._timer.join()
 
 
 

--- a/OpenRTM_aist/ext/sdo/observer/ComponentObserverConsumer.py
+++ b/OpenRTM_aist/ext/sdo/observer/ComponentObserverConsumer.py
@@ -51,7 +51,7 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
     self._ecaction = self.ECAction(self)
     self._configMsg = self.ConfigAction(self)
 
-    self._interval = OpenRTM_aist.TimeValue(1, 0)
+    self._interval = OpenRTM_aist.TimeValue(0, 100000)
     self._heartbeat = False
     self._hblistenerid = None
 
@@ -326,13 +326,12 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
   def setHeartbeat(self, prop):
     if OpenRTM_aist.toBool(prop.getProperty("heartbeat.enable"), "YES", "NO", False):
       interval_ = prop.getProperty("heartbeat.interval")
-      if not interval_:
-        self._interval.set_time(1.0)
-      else:
-        tmp_ = float(interval_)
-        self._interval.set_time(tmp_)
+      tm_ = OpenRTM_aist.TimeValue(1, 0)
 
-      tm_ = self._interval
+      if interval_:
+        tmp_ = float(interval_)
+        tm_.set_time(tmp_)
+
       self._hblistenerid = self._timer.registerListenerObj(self,
                                                            ComponentObserverConsumer.heartbeat,
                                                            tm_)
@@ -358,9 +357,8 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
   def unsetHeartbeat(self):
     self._timer.unregisterListener(self._hblistenerid)
     self._hblistenerid = None
-    self._timer.stop()
-    self._timer.join()
     self._heartbeat = False
+    self._timer.stop()
     return
 
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

C++版と以下の点でコンポーネントオブザーバーの動作が違っている。

- タイマースレッドの周期はC++版ではコンストラクタで設定した値で固定。Python版は`heartbeat.enable`で設定した値に変更される。タイマースレッド動作中に周期を変更することは通常ないためC++版に合わせる必要がある。
- タイマースレッドの周期がC++版は0.1秒、Python版は1.0秒。


## Description of the Change

C++と同じ動作になるように修正した。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
