### PR TITLE
already_connected関数に同一のポートを2個指定した場合にfalseを返すようにする

### DIFF
--- a/OpenRTM_aist/CORBA_RTCUtil.py
+++ b/OpenRTM_aist/CORBA_RTCUtil.py
@@ -887,6 +887,8 @@ def create_connector(name, prop_arg, port0, port1):
 # @endif
 
 def already_connected(localport, otherport):
+  if localport._is_equivalent(otherport):
+    return False
   conprof = localport.get_connector_profiles()
   for c in conprof:
     for p in c.ports:


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
## Description of the Change
以下と同じ

https://github.com/OpenRTM/OpenRTM-aist/pull/428



## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
