### PR TITLE
Linux、Python3でビルドを実行するとエラーになる問題の修正

### DIFF
--- a/OpenRTM_aist/CSPMachine.py
+++ b/OpenRTM_aist/CSPMachine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 ##

--- a/OpenRTM_aist/InPortCSPConsumer.py
+++ b/OpenRTM_aist/InPortCSPConsumer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 ##

--- a/OpenRTM_aist/InPortCSPProvider.py
+++ b/OpenRTM_aist/InPortCSPProvider.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 ##

--- a/OpenRTM_aist/InPortDuplexConnector.py
+++ b/OpenRTM_aist/InPortDuplexConnector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 ##

--- a/OpenRTM_aist/OutPortCSPConsumer.py
+++ b/OpenRTM_aist/OutPortCSPConsumer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 ##

--- a/OpenRTM_aist/OutPortCSPProvider.py
+++ b/OpenRTM_aist/OutPortCSPProvider.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 ##

--- a/OpenRTM_aist/OutPortDuplexConnector.py
+++ b/OpenRTM_aist/OutPortDuplexConnector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # @file setup.py

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #
 # @file setup.py
 # @author Noriaki Ando <n-ando@aist.go.jp>
@@ -131,7 +132,7 @@ import string
 if sys.version_info[0] == 2:
   import commands
 else:
-  import subprocess as commands
+  import subprocess
 import glob
 import shutil
 from distutils import core
@@ -433,8 +434,16 @@ def compile_idl(idl_compiler, include_dirs, current_dir, files):
       os.system(cmdline)
       return
     log.info(cmdline)
-    status, output = commands.getstatusoutput(cmdline)
-    log.info(output)
+    if sys.version_info[0] == 2:
+      status, output = commands.getstatusoutput(cmdline)
+      log.info(output)
+    else:
+      try:
+        proc = subprocess.run(cmdline, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        status = 0
+        log.info(proc.stdout.decode("UTF-8"))
+      except:
+        status = 1
     if status != 0:
       raise errors.DistutilsExecError("Return status of %s is %d" %
                                       (cmd, status))
@@ -465,8 +474,17 @@ def create_doc(doxygen_conf, target_dir):
       os.system(cmdline)
       return
     log.info(cmdline)
-    status, output = commands.getstatusoutput(cmdline)
-    log.info(output)
+    if sys.version_info[0] == 2:
+      status, output = commands.getstatusoutput(cmdline)
+      log.info(output)
+    else:
+      try:
+        proc = subprocess.run(cmdline, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        status = 0
+        log.info(proc.stdout.decode("UTF-8"))
+      except:
+        status = 1
+      
     if status != 0:
       raise errors.DistutilsExecError("Return status of %s is %d" %
                                       (cmd, status))

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# -*- coding: euc-jp -*-
 #
 # @file setup.py
 # @author Noriaki Ando <n-ando@aist.go.jp>


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#14


## Description of the Change

subprocess.getstatusoutputはPython3ではうまく動作しないようです。
getstatusoutput関数は[Python3のドキュメント](https://docs.python.org/ja/3/library/subprocess.html#legacy-shell-invocation-functions)で「レガシーなシェル呼び出し関数」と書かれているので、今後改善する可能性もなさそうです。
このためsubprocess.runを使う方法に変更しました。
また一部のファイルで文字コード、改行コードに誤りがありsetup.py実行時にエラーとなったため修正した。

## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
