### PR TITLE
ExtTriggerのサンプルが正常に動作しない問題の修正

### DIFF
--- a/OpenRTM_aist/examples/ExtTrigger/Connector.py
+++ b/OpenRTM_aist/examples/ExtTrigger/Connector.py
@@ -18,6 +18,10 @@ def main():
   subs_type = "Flush"
 
   # initialization of ORB
+  manager = OpenRTM_aist.Manager.init(sys.argv + ["-o", "manager.shutdown_auto:NO", "-o", "manager.shutdown_on_nortcs:NO"])
+  manager.activateManager()
+  manager.runManager(True)
+
   orb = CORBA.ORB_init(sys.argv)
 
   # get NamingService
@@ -97,6 +101,8 @@ def main():
     except:
       print("Exception.")
       pass
+
+  manager.shutdown()
 
 if __name__ == "__main__":
   main()


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

ExtTriggerのConnector.py実行中に`Exception`と表示されてそれ以降はtickが実行できなくなる。


CorbaConsumerの_ptr関数内でManagerのインスタンスを取得していることが原因。

```
  def _ptr(self, get_ref=False):
    if get_ref:
      return self._var
    if self._sev is not None:
      return self._sev
    try:
      mgr = OpenRTM_aist.Manager.instance()
      self._sev = mgr._poa.reference_to_servant(self._var)
      return self._sev
    except:
      return self._var
```

Managerを初期化していない場合、_ptr関数内で初めてManagerを初期化することになる。
この時1つもRTCが起動していないため、10秒後にManagerが自動終了してしまいExceptionが発生していた。

## Description of the Change

Connector.pyでManagerを初期化してからtick等を実行するようにした。

Managerが時間で自動的に終了する機能はトラブルを起こすことが多いためデフォルトでオフにした方がいいと思います。

## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
