### PR TITLE
CSPポートの不具合修正

### DIFF
--- a/OpenRTM_aist/CSPEventPort.py
+++ b/OpenRTM_aist/CSPEventPort.py
@@ -243,11 +243,48 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
       self._writable_listener = CSPEventPort.IsWritableZeroModeListener(self._ctrl, self._channeltimeout, self, self._manager)
       self._write_listener = CSPEventPort.WriteZeroModeListener(self._ctrl)
 
+  ##
+  # @if jp
+  #
+  # @brief CSPManagerの設定
+  #
+  # @param self
+  # @param manager CSPManager
+  #
+  # @else
+  #
+  # @brief 
+  #
+  # @param self
+  # @param manager
+  #
+  # @endif
+  #
   def setManager(self, manager):
     self._writable_listener.setManager(manager)
     self._manager = manager
     if manager:
       self._manager.addInPort(self)
+
+  ##
+  # @if jp
+  #
+  # @brief CSPManagerの設定解除
+  #
+  # @param self
+  #
+  # @else
+  #
+  # @brief 
+  #
+  # @param self
+  #
+  # @endif
+  #
+  def releaseManager(self):
+    self._writable_listener.releaseManager()
+    self._manager = None
+
 
   ##  
   # @if jp
@@ -683,6 +720,7 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
       self._channeltimeout = timeout
       self._manager = manager
       self._port = port
+      self._mutex = threading.RLock()
     ##
     # @if jp
     #
@@ -709,9 +747,11 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
     # @endif
     #
     def __call__(self, con):
+      guard_manager = OpenRTM_aist.Guard.ScopedLock(self._mutex)
       if self._manager:
         if self._manager.notify(inport=self._port):
           return True
+      del guard_manager
       guard = OpenRTM_aist.ScopedLock(self._ctrl._cond)
       if self._ctrl._writing:
         self._ctrl._cond.wait(self._channeltimeout)
@@ -722,8 +762,49 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
         self._ctrl._writing = False
         return False
 
+    ##
+    # @if jp
+    #
+    # @brief CSPManagerの設定
+    #
+    # @param self
+    # @param manager CSPManager
+    # 
+    #
+    #
+    # @else
+    #
+    # @brief 
+    #
+    # @param self
+    # @param manager
+    #
+    # @endif
+    #
     def setManager(self, manager):
+      guard_manager = OpenRTM_aist.Guard.ScopedLock(self._mutex)
       self._manager = manager
+
+    ##
+    # @if jp
+    #
+    # @brief CSPManagerの解除
+    #
+    # @param self
+    # 
+    #
+    #
+    # @else
+    #
+    # @brief 
+    #
+    # @param self
+    #
+    # @endif
+    #
+    def releaseManager(self):
+      guard_manager = OpenRTM_aist.Guard.ScopedLock(self._mutex)
+      self._manager = None
 
   ##
   # @if jp
@@ -854,6 +935,7 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
       self._channeltimeout = timeout
       self._manager = manager
       self._port = port
+      self._mutex = threading.RLock()
     ##
     # @if jp
     #
@@ -880,9 +962,11 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
     # @endif
     #
     def __call__(self, con):
+      guard_manager = OpenRTM_aist.Guard.ScopedLock(self._mutex)
       if self._manager:
         if self._manager.notify(inport=self._port):
           return True
+      del guard_manager
       guard = OpenRTM_aist.ScopedLock(self._ctrl._cond)
       if self._ctrl._waiting and self._ctrl._writing:
         self._ctrl._cond.wait(self._channeltimeout)
@@ -893,8 +977,49 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
         self._ctrl._writing = False
         return False
 
+    ##
+    # @if jp
+    #
+    # @brief CSPManagerの設定
+    #
+    # @param self
+    # @param manager CSPManager
+    # 
+    #
+    #
+    # @else
+    #
+    # @brief 
+    #
+    # @param self
+    # @param manager
+    #
+    # @endif
+    #
     def setManager(self, manager):
+      guard_manager = OpenRTM_aist.Guard.ScopedLock(self._mutex)
       self._manager = manager
+
+    ##
+    # @if jp
+    #
+    # @brief CSPManagerの解除
+    #
+    # @param self
+    # 
+    #
+    #
+    # @else
+    #
+    # @brief 
+    #
+    # @param self
+    #
+    # @endif
+    #
+    def releaseManager(self):
+      guard_manager = OpenRTM_aist.Guard.ScopedLock(self._mutex)
+      self._manager = None
         
   ##
   # @if jp

--- a/OpenRTM_aist/CSPEventPort.py
+++ b/OpenRTM_aist/CSPEventPort.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# -*- coding: euc-jp -*-
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 ##
 # @file CSPEventPort.py
@@ -25,7 +25,7 @@ import threading
 #
 # @class CSPEventPort
 #
-# @brief CSPEventPort �ƥ�ץ졼�ȥ��饹
+# @brief CSPEventPort テンプレートクラス
 # 
 #
 # @since 2.0.0
@@ -45,13 +45,13 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief ���󥹥ȥ饯��
+  # @brief コンストラクタ
   #
-  # ���󥹥ȥ饯����
-  # �ѥ�᡼���Ȥ���Ϳ������ T �����ѿ��˥Х���ɤ���롣
+  # コンストラクタ。
+  # パラメータとして与えられる T 型の変数にバインドされる。
   #
   # @param self
-  # @param name EventInPort ̾��EventInPortBase:name() �ˤ�껲�Ȥ���롣
+  # @param name EventInPort 名。EventInPortBase:name() により参照される。
   # @param fsm FSM
   #
   # @else
@@ -95,9 +95,9 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief �ǥ��ȥ饯��
+  # @brief デストラクタ
   #
-  # �ǥ��ȥ饯����
+  # デストラクタ。
   #
   # @param self
   #
@@ -120,12 +120,12 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief �ݡ���̾�Τ�������롣
+  # @brief ポート名称を取得する。
   #
-  # �ݡ���̾�Τ�������롣
+  # ポート名称を取得する。
   #
   # @param self
-  # @return �ݡ���̾��
+  # @return ポート名称
   #
   # @else
   #
@@ -146,14 +146,14 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief �����ʤ��Υ��٥�ȥϥ�ɥ����Ͽ����
+  # @brief 引数なしのイベントハンドラを登録する
   #
   # @param self
-  # @param name ���٥��̾
-  # @param handler ���٥�ȥϥ�ɥ�
-  # ���ͥ�����³����fsm_event_name�Ȥ������Ǥ����ꤹ�롣
-  # fsm_event_name�ȥ��٥��̾�����פ���ȥ��٥�Ȥ��¹Ԥ���롣
-  # ���٥�ȥϥ�ɥ�ˤ�Macho��������������٥�Ȥ����Ϥ���
+  # @param name イベント名
+  # @param handler イベントハンドラ
+  # コネクタ接続時にfsm_event_nameという要素を設定する。
+  # fsm_event_nameとイベント名が一致するとイベントが実行される。
+  # イベントハンドラにはMacho等で定義したイベントを入力する
   # 
   #
   # @else
@@ -171,12 +171,12 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief ��������Υ��٥�ȥϥ�ɥ����Ͽ����
+  # @brief 引数ありのイベントハンドラを登録する
   #
   # @param self
-  # @param name ���٥��̾
-  # @param handler ���٥�ȥϥ�ɥ�
-  # @param data_type ���ϥǡ���
+  # @param name イベント名
+  # @param handler イベントハンドラ
+  # @param data_type 入力データ
   #
   # @else
   #
@@ -196,15 +196,15 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief ������ؿ�
+  # @brief 初期化関数
   #
   # @param self
-  # @param prop ���ͥ����Υץ��ѥƥ�
-  # buffer(dataport.buffer)���ǤǥХåե�Ĺ����������
-  # channel_timeout(dataport.channel_timeout)���Ǥǡ�
-  # ������ǽ�ʥ����ȥݡ��Ȥ�¸�ߤ��ʤ����Υ֥��å��Υ����ॢ���Ȥ�����
+  # @param prop コネクタのプロパティ
+  # buffer(dataport.buffer)要素でバッファ長さ等を設定
+  # channel_timeout(dataport.channel_timeout)要素で、
+  # 送信可能なアウトポートが存在しない場合のブロックのタイムアウトを設定
   # 
-  # @return �ݡ���̾��
+  # @return ポート名称
   #
   # @else
   #
@@ -252,7 +252,7 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   ##  
   # @if jp
   #
-  # @brief �񤭹��߽����򳫻Ϥ������ͥ�������Ͽ
+  # @brief 書き込み処理を開始したコネクタを登録
   #
   # @param self
   # @param con InPortConnector
@@ -273,9 +273,9 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief ��³���OutPort�����ϲ�ǽ�Ǥ��뤳�Ȥ�����
-  # �Хåե����ե�ˤʤ롢�⤷�����Ե����OutPort���ʤ��ʤ�ޤǡ���³��Υ��ͥ����Υǡ������ɤ߹���
-  # �Хåե�����ǡ������ɤ߹�������ϡ����δؿ���ƤӽФ�ɬ�פ�����
+  # @brief 接続先のOutPortに入力可能であることを通知
+  # バッファがフルになる、もしくは待機中のOutPortがなくなるまで、接続先のコネクタのデータを読み込む
+  # バッファからデータを読み込んだ場合は、この関数を呼び出す必要がある
   #
   # @param self
   # 
@@ -304,16 +304,16 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief ���ͥ�����³�ؿ�
-  # InPortBase����³�����Τۤ��ˡ����ͥ����˽񤭹��߳�ǧ�����񤭹��߻��Υ�����Хå��ؿ������ꤹ��
+  # @brief コネクタ接続関数
+  # InPortBaseの接続処理のほかに、コネクタに書き込み確認時、書き込み時のコールバック関数を設定する
   #
   # @param self
-  # @param connector_profile ���ͥ����ץ��ե�����
+  # @param connector_profile コネクタプロファイル
   # @return ret, prof
-  # ret���꥿���󥳡���
-  # prof�����ͥ����ץ��ե�����
+  # ret：リターンコード
+  # prof：コネクタプロファイル
   # 
-  # @return �ݡ���̾��
+  # @return ポート名称
   #
   # @else
   #
@@ -336,16 +336,16 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief ��󥰥Хåե����ѥ⡼�ɻ��Υǡ����ɤ߹��߽���
-  # �Хåե���empty�ǤϤʤ����ϥХåե������ɤ߹���
-  # ���ͥ���������ɤ߹��߲�ǽ�ʤ�Τ�������ϡ����Υ��ͥ��������ɤ߹���
-  # ���������񤭹�����ξ��Ͻ񤭹��߽�λ�ޤǥ֥��å�����
+  # @brief リングバッファ使用モード時のデータ読み込み処理
+  # バッファがemptyではない場合はバッファから読み込む
+  # コネクタの中に読み込み可能なものがある場合は、そのコネクタから読み込む
+  # ただし、書き込み中の場合は書き込み終了までブロックする
   #
   # @param self
-  # @param connector_profile ���ͥ����ץ��ե�����
+  # @param connector_profile コネクタプロファイル
   # @return ret, prof
-  # ret��True���ɤ߹���������False���Хåե���empty�Ǥ����ɤ߹��߲�ǽ�ʥ��ͥ�����¸�ߤ��ʤ�
-  # data���ǡ���
+  # ret：True：読み込み成功、False：バッファがemptyでかつ読み込み可能なコネクタが存在しない
+  # data：データ
   # 
   #
   # @else
@@ -412,15 +412,15 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief ���󥰥Хåե����ѥ⡼�ɻ��Υǡ����ɤ߹��߽���
-  # �ǡ����ɤ߹��߲�ǽ�ʥ��ͥ�����¸�ߤ�����ϡ����Υ��ͥ�������ǡ������ɤ߹���
+  # @brief 非リングバッファ使用モード時のデータ読み込み処理
+  # データ読み込み可能なコネクタが存在する場合は、そのコネクタからデータを読み込む
   # 
   #
   # @param self
-  # @param connector_profile ���ͥ����ץ��ե�����
+  # @param connector_profile コネクタプロファイル
   # @return ret, data
-  # ret��True���ɤ߹���������False���ǡ����ɤ߹��߲�ǽ�ʥ��ͥ�����¸�ߤ��ʤ�
-  # data���ǡ���(�ɤ߹��߼��Ԥξ���None)
+  # ret：True：読み込み成功、False：データ読み込み可能なコネクタが存在しない
+  # data：データ(読み込み失敗の場合はNone)
   # 
   #
   # @else
@@ -450,12 +450,12 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief �ǡ����ɤ߹��߲�ǽ�ʥ��ͥ��������򤷡�
-  # self._value���ɤ߹�����ǡ������Ǽ����
+  # @brief データ読み込み可能なコネクタを選択し、
+  # self._valueに読み込んだデータを格納する
   # 
   #
   # @param self
-  # @return True���ɤ߹���������False���ɤ߹����Բ�
+  # @return True：読み込み成功、False：読み込み不可
   #
   #
   # @else
@@ -481,11 +481,11 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief select�ؿ��ǳ�Ǽ�����ǡ����μ���
+  # @brief select関数で格納したデータの取得
   # 
   #
   # @param self
-  # @return �ǡ���
+  # @return データ
   #
   #
   # @else
@@ -517,12 +517,12 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief �ǡ������ɤ߹��߲�ǽ�ʥ��ͥ��������򤷥ǡ������������
-  # �ɤ߹��߲�ǽ�ʥ��ͥ�����¸�ߤ��ʤ������Ե�����
+  # @brief データを読み込み可能なコネクタを選択しデータを取得する
+  # 読み込み可能なコネクタが存在しない場合は待機する
   # 
   #
   # @param self
-  # @return �ǡ���(�����ॢ���Ȥ�������None)
+  # @return データ(タイムアウトした場合はNone)
   #
   #
   # @else
@@ -553,12 +553,12 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief ��󥰥Хåե����ѥ⡼�ɻ��Υǡ����ɤ߹��߽���
-  # �ɤ߹��߲�ǽ�ʥ��ͥ�����¸�ߤ��ʤ������Ե�����
+  # @brief リングバッファ使用モード時のデータ読み込み処理
+  # 読み込み可能なコネクタが存在しない場合は待機する
   # 
   #
   # @param self
-  # @return �ǡ���(�����ॢ���Ȥ�������None)
+  # @return データ(タイムアウトした場合はNone)
   #
   #
   # @else
@@ -590,12 +590,12 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief ���󥰥Хåե����ѥ⡼�ɻ��Υǡ����ɤ߹��߽���
-  # �ɤ߹��߲�ǽ�ʥ��ͥ�����¸�ߤ��ʤ������Ե�����
+  # @brief 非リングバッファ使用モード時のデータ読み込み処理
+  # 読み込み可能なコネクタが存在しない場合は待機する
   # 
   #
   # @param self
-  # @return �ǡ���(�����ॢ���Ȥ�������None)
+  # @return データ(タイムアウトした場合はNone)
   #
   #
   # @else
@@ -633,7 +633,7 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   #
   # @class IsWritableListener
   #
-  # @brief �ǡ����񤭹��߻��γ�ǧ�ꥹ�ʴ��쥯�饹(��󥰥Хåե����ѥ⡼��)
+  # @brief データ書き込み時の確認リスナ基底クラス(リングバッファ使用モード)
   # 
   #
   # @since 2.0.0
@@ -653,15 +653,15 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
     ##
     # @if jp
     #
-    # @brief ���󥹥ȥ饯��
+    # @brief コンストラクタ
     # 
     #
     # @param self
-    # @param buff ��󥰥Хåե�
-    # @param control WorkerThreadCtrl���֥�������
-    # @param timeout �񤭹����Ե��Υ����ॢ����
-    # @param manager CSP����ͥ�����ޥ͡�����
-    # manager����ꤷ�����ϡ�manager���Ե���ξ��˥��å���������Τ�Ԥ�
+    # @param buff リングバッファ
+    # @param control WorkerThreadCtrlオブジェクト
+    # @param timeout 書き込み待機のタイムアウト
+    # @param manager CSPチャネル管理マネージャ
+    # managerを指定した場合は、managerが待機中の場合にロック解除の通知を行う
     # 
     #
     #
@@ -686,15 +686,15 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
     ##
     # @if jp
     #
-    # @brief �񤭹��߳�ǧ���Υ�����Хå��ؿ�
-    # ¾�Υ��ͥ������ǡ����񤭹�����ξ��ϴ�λ�ޤ��Ե�����
-    # �Хåե����ե�ǤϤʤ����Ͻ񤭹��߾��֤˰ܹԤ���
-    # ���Τ��ᡢ�񤭹��߲�ǽ�ʾ���ɬ���ǡ�����񤭹���ɬ�פ�����
+    # @brief 書き込み確認時のコールバック関数
+    # 他のコネクタがデータ書き込み中の場合は完了まで待機する
+    # バッファがフルではない場合は書き込み状態に移行する
+    # このため、書き込み可能な場合は必ずデータを書き込む必要がある
     # 
     #
     # @param self
     # @param con InPortConnector
-    # @return True���񤭹��߲�ǽ��False���񤭹����Բ�
+    # @return True：書き込み可能、False：書き込み不可
     # 
     #
     #
@@ -730,7 +730,7 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   #
   # @class WriteListener
   #
-  # @brief �ǡ����񤭹��߻��Υꥹ�ʴ��쥯�饹(��󥰥Хåե����ѥ⡼��)
+  # @brief データ書き込み時のリスナ基底クラス(リングバッファ使用モード)
   # 
   #
   # @since 2.0.0
@@ -750,11 +750,11 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
     ##
     # @if jp
     #
-    # @brief ���󥹥ȥ饯��
+    # @brief コンストラクタ
     # 
     #
     # @param self
-    # @param control WorkerThreadCtrl���֥�������
+    # @param control WorkerThreadCtrlオブジェクト
     # 
     #
     #
@@ -772,15 +772,15 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
     ##
     # @if jp
     #
-    # @brief �񤭹��߻��Υ�����Хå��ؿ�
-    # CSPEventPort�ǤϥХåե��ؤν񤭹��ߤ�ON_RECEIVED������Хå��Ǽ¹Ԥ��뤿�ᡢ
-    # �񤭹��߾��֤β���Τߤ�Ԥ���
+    # @brief 書き込み時のコールバック関数
+    # CSPEventPortではバッファへの書き込みはON_RECEIVEDコールバックで実行するため、
+    # 書き込み状態の解除のみを行う。
     # 
     #
     # @param self
-    # @param data �ǡ���
-    # @return �꥿���󥳡���
-    # BUFFER_OK�����ﴰλ
+    # @param data データ
+    # @return リターンコード
+    # BUFFER_OK：正常完了
     # 
     #
     #
@@ -805,7 +805,7 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   #
   # @class IsWritableZeroModeListener
   #
-  # @brief �ǡ����񤭹��߳�ǧ�ꥹ�ʴ��쥯�饹(���󥰥Хåե����ѥ⡼��)
+  # @brief データ書き込み確認リスナ基底クラス(非リングバッファ使用モード)
   # 
   #
   # @since 2.0.0
@@ -825,15 +825,15 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
     ##
     # @if jp
     #
-    # @brief ���󥹥ȥ饯��
+    # @brief コンストラクタ
     # 
     #
     # @param self
-    # @param buff ��󥰥Хåե�
-    # @param control WorkerThreadCtrl���֥�������
-    # @param timeout �񤭹����Ե��Υ����ॢ����
-    # @param manager CSP����ͥ�����ޥ͡�����
-    # manager����ꤷ�����ϡ�manager���Ե���ξ��˥��å���������Τ�Ԥ�
+    # @param buff リングバッファ
+    # @param control WorkerThreadCtrlオブジェクト
+    # @param timeout 書き込み待機のタイムアウト
+    # @param manager CSPチャネル管理マネージャ
+    # managerを指定した場合は、managerが待機中の場合にロック解除の通知を行う
     # 
     #
     #
@@ -857,15 +857,15 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
     ##
     # @if jp
     #
-    # @brief �񤭹��߳�ǧ���Υ�����Хå��ؿ�
-    # ¾�Υ��ͥ������ǡ����񤭹�����ξ��ϴ�λ�ޤ��Ե�����
-    # �Хåե����ե�ǤϤʤ����Ͻ񤭹��߾��֤˰ܹԤ���
-    # ���Τ��ᡢ�񤭹��߲�ǽ�ʾ���ɬ���ǡ�����񤭹���ɬ�פ�����
+    # @brief 書き込み確認時のコールバック関数
+    # 他のコネクタがデータ書き込み中の場合は完了まで待機する
+    # バッファがフルではない場合は書き込み状態に移行する
+    # このため、書き込み可能な場合は必ずデータを書き込む必要がある
     # 
     #
     # @param self
     # @param con InPortConnector
-    # @return True���񤭹��߲�ǽ��False���񤭹����Բ�
+    # @return True：書き込み可能、False：書き込み不可
     # 
     #
     #
@@ -901,7 +901,7 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   #
   # @class WriteZeroModeListener
   #
-  # @brief �ǡ����񤭹��߻��Υꥹ�ʴ��쥯�饹(���󥰥Хåե����ѥ⡼��)
+  # @brief データ書き込み時のリスナ基底クラス(非リングバッファ使用モード)
   # 
   #
   # @since 2.0.0
@@ -921,11 +921,11 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
     ##
     # @if jp
     #
-    # @brief ���󥹥ȥ饯��
+    # @brief コンストラクタ
     # 
     #
     # @param self
-    # @param control WorkerThreadCtrl���֥�������
+    # @param control WorkerThreadCtrlオブジェクト
     # 
     #
     #
@@ -943,15 +943,15 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
     ##
     # @if jp
     #
-    # @brief �񤭹��߻��Υ�����Хå��ؿ�
-    # CSPEventPort�ǤϥХåե��ؤν񤭹��ߤ�ON_RECEIVED������Хå��Ǽ¹Ԥ��뤿�ᡢ
-    # �񤭹��߾��֤β���Τߤ�Ԥ���
+    # @brief 書き込み時のコールバック関数
+    # CSPEventPortではバッファへの書き込みはON_RECEIVEDコールバックで実行するため、
+    # 書き込み状態の解除のみを行う。
     # 
     #
     # @param self
-    # @param data �ǡ���
-    # @return �꥿���󥳡���
-    # BUFFER_OK�����ﴰλ
+    # @param data データ
+    # @return リターンコード
+    # BUFFER_OK：正常完了
     # 
     #
     #

--- a/OpenRTM_aist/CSPInPort.py
+++ b/OpenRTM_aist/CSPInPort.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# -*- coding: euc-jp -*-
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 ##
 # @file CSPInPort.py
@@ -24,7 +24,7 @@ import threading
 #
 # @class CSPInPort
 #
-# @brief CSPInPort �ƥ�ץ졼�ȥ��饹
+# @brief CSPInPort テンプレートクラス
 # 
 #
 # @since 2.0.0
@@ -44,13 +44,13 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief ���󥹥ȥ饯��
+  # @brief コンストラクタ
   #
-  # ���󥹥ȥ饯����
-  # �ѥ�᡼���Ȥ���Ϳ������ T �����ѿ��˥Х���ɤ���롣
+  # コンストラクタ。
+  # パラメータとして与えられる T 型の変数にバインドされる。
   #
-  # @param name EventInPort ̾��EventInPortBase:name() �ˤ�껲�Ȥ���롣
-  # @param value ���� EventInPort �˥Х���ɤ���� T �����ѿ�
+  # @param name EventInPort 名。EventInPortBase:name() により参照される。
+  # @param value この EventInPort にバインドされる T 型の変数
   #
   # @else
   #
@@ -91,9 +91,9 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief �ǥ��ȥ饯��
+  # @brief デストラクタ
   #
-  # �ǥ��ȥ饯����
+  # デストラクタ。
   #
   # @else
   #
@@ -109,12 +109,12 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief �ݡ���̾�Τ�������롣
+  # @brief ポート名称を取得する。
   #
-  # �ݡ���̾�Τ�������롣
+  # ポート名称を取得する。
   #
   # @param self
-  # @return �ݡ���̾��
+  # @return ポート名称
   #
   # @else
   #
@@ -133,15 +133,15 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief ������ؿ�
+  # @brief 初期化関数
   #
   # @param self
-  # @param prop �������
-  # channel_timeout���ǡ����񤭹��ߡ��ɤ߹��߻��Υ����ॢ����
-  # buffer.length��0�ξ������󥰥Хåե��⡼�ɤ�����
-  # �ǡ����ɤ߹����Ե����֤˰ܹԤ��Ƥ��ʤ��ȥǡ�����񤭹��ळ�Ȥ��Ǥ��ʤ�
-  # buffer.length��1�ʾ�ξ��ϥ�󥰥Хåե��⡼�ɤ�����
-  # �Хåե��˶�����������ϥǡ����ν񤭹��ߤ��Ǥ���
+  # @param prop 設定情報
+  # channel_timeout：データ書き込み、読み込み時のタイムアウト
+  # buffer.lengthが0の場合は非リングバッファモードに設定
+  # データ読み込み待機状態に移行していないとデータを書き込むことができない
+  # buffer.lengthが1以上の場合はリングバッファモードに設定
+  # バッファに空きがある場合はデータの書き込みができる
   #
   # @else
   #
@@ -187,7 +187,7 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   ##  
   # @if jp
   #
-  # @brief �񤭹��߽����򳫻Ϥ������ͥ�������Ͽ
+  # @brief 書き込み処理を開始したコネクタを登録
   #
   # @param self
   # @param con InPortConnector
@@ -208,9 +208,9 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief ��³���OutPort�����ϲ�ǽ�Ǥ��뤳�Ȥ�����
-  # �Хåե����ե�ˤʤ롢�⤷�����Ե����OutPort���ʤ��ʤ�ޤǡ���³��Υ��ͥ����Υǡ������ɤ߹���
-  # �Хåե�����ǡ������ɤ߹�������ϡ����δؿ���ƤӽФ�ɬ�פ�����
+  # @brief 接続先のOutPortに入力可能であることを通知
+  # バッファがフルになる、もしくは待機中のOutPortがなくなるまで、接続先のコネクタのデータを読み込む
+  # バッファからデータを読み込んだ場合は、この関数を呼び出す必要がある
   #
   # @param self
   # 
@@ -239,16 +239,16 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief ���ͥ�����³�ؿ�
-  # InPortBase����³�����Τۤ��ˡ����ͥ����˽񤭹��߳�ǧ�����񤭹��߻��Υ�����Хå��ؿ������ꤹ��
+  # @brief コネクタ接続関数
+  # InPortBaseの接続処理のほかに、コネクタに書き込み確認時、書き込み時のコールバック関数を設定する
   #
   # @param self
-  # @param connector_profile ���ͥ����ץ��ե�����
+  # @param connector_profile コネクタプロファイル
   # @return ret, prof
-  # ret���꥿���󥳡���
-  # prof�����ͥ����ץ��ե�����
+  # ret：リターンコード
+  # prof：コネクタプロファイル
   # 
-  # @return �ݡ���̾��
+  # @return ポート名称
   #
   # @else
   #
@@ -272,16 +272,16 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief ��󥰥Хåե����ѥ⡼�ɻ��Υǡ����ɤ߹��߽���
-  # �Хåե���empty�ǤϤʤ����ϥХåե������ɤ߹���
-  # ���ͥ���������ɤ߹��߲�ǽ�ʤ�Τ�������ϡ����Υ��ͥ��������ɤ߹���
-  # ���������񤭹�����ξ��Ͻ񤭹��߽�λ�ޤǥ֥��å�����
+  # @brief リングバッファ使用モード時のデータ読み込み処理
+  # バッファがemptyではない場合はバッファから読み込む
+  # コネクタの中に読み込み可能なものがある場合は、そのコネクタから読み込む
+  # ただし、書き込み中の場合は書き込み終了までブロックする
   #
   # @param self
-  # @param connector_profile ���ͥ����ץ��ե�����
+  # @param connector_profile コネクタプロファイル
   # @return ret, prof
-  # ret��True���ɤ߹���������False���Хåե���empty�Ǥ����ɤ߹��߲�ǽ�ʥ��ͥ�����¸�ߤ��ʤ�
-  # data���ǡ���
+  # ret：True：読み込み成功、False：バッファがemptyでかつ読み込み可能なコネクタが存在しない
+  # data：データ
   # 
   #
   # @else
@@ -362,15 +362,15 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief ���󥰥Хåե����ѥ⡼�ɻ��Υǡ����ɤ߹��߽���
-  # �ǡ����ɤ߹��߲�ǽ�ʥ��ͥ�����¸�ߤ�����ϡ����Υ��ͥ�������ǡ������ɤ߹���
+  # @brief 非リングバッファ使用モード時のデータ読み込み処理
+  # データ読み込み可能なコネクタが存在する場合は、そのコネクタからデータを読み込む
   # 
   #
   # @param self
-  # @param connector_profile ���ͥ����ץ��ե�����
+  # @param connector_profile コネクタプロファイル
   # @return ret, prof
-  # ret��True���ɤ߹���������False���ǡ����ɤ߹��߲�ǽ�ʥ��ͥ�����¸�ߤ��ʤ�
-  # data���ǡ���(�ɤ߹��߼��Ԥξ���None)
+  # ret：True：読み込み成功、False：データ読み込み可能なコネクタが存在しない
+  # data：データ(読み込み失敗の場合はNone)
   # 
   #
   # @else
@@ -402,12 +402,12 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief �ǡ����ɤ߹��߲�ǽ�ʥ��ͥ��������򤷡�
-  # self._value���ɤ߹�����ǡ������Ǽ����
+  # @brief データ読み込み可能なコネクタを選択し、
+  # self._valueに読み込んだデータを格納する
   # 
   #
   # @param self
-  # @return True���ɤ߹���������False���ɤ߹����Բ�
+  # @return True：読み込み成功、False：読み込み不可
   #
   #
   # @else
@@ -433,11 +433,11 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief select�ؿ��ǳ�Ǽ�����ǡ����μ���
+  # @brief select関数で格納したデータの取得
   # 
   #
   # @param self
-  # @return �ǡ���
+  # @return データ
   #
   #
   # @else
@@ -473,12 +473,12 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief �ǡ������ɤ߹��߲�ǽ�ʥ��ͥ��������򤷥ǡ������������
-  # �ɤ߹��߲�ǽ�ʥ��ͥ�����¸�ߤ��ʤ������Ե�����
+  # @brief データを読み込み可能なコネクタを選択しデータを取得する
+  # 読み込み可能なコネクタが存在しない場合は待機する
   # 
   #
   # @param self
-  # @return �ǡ���(�����ॢ���Ȥ�������None)
+  # @return データ(タイムアウトした場合はNone)
   #
   #
   # @else
@@ -509,12 +509,12 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief ��󥰥Хåե����ѥ⡼�ɻ��Υǡ����ɤ߹��߽���
-  # �ɤ߹��߲�ǽ�ʥ��ͥ�����¸�ߤ��ʤ������Ե�����
+  # @brief リングバッファ使用モード時のデータ読み込み処理
+  # 読み込み可能なコネクタが存在しない場合は待機する
   # 
   #
   # @param self
-  # @return �ǡ���(�����ॢ���Ȥ�������None)
+  # @return データ(タイムアウトした場合はNone)
   #
   #
   # @else
@@ -551,12 +551,12 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   ##
   # @if jp
   #
-  # @brief ���󥰥Хåե����ѥ⡼�ɻ��Υǡ����ɤ߹��߽���
-  # �ɤ߹��߲�ǽ�ʥ��ͥ�����¸�ߤ��ʤ������Ե�����
+  # @brief 非リングバッファ使用モード時のデータ読み込み処理
+  # 読み込み可能なコネクタが存在しない場合は待機する
   # 
   #
   # @param self
-  # @return �ǡ���(�����ॢ���Ȥ�������None)
+  # @return データ(タイムアウトした場合はNone)
   #
   #
   # @else
@@ -602,7 +602,7 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   #
   # @class IsWritableListener
   #
-  # @brief �ǡ����񤭹��߳�ǧ�ꥹ�ʴ��쥯�饹(��󥰥Хåե����ѥ⡼��)
+  # @brief データ書き込み確認リスナ基底クラス(リングバッファ使用モード)
   # 
   #
   # @since 2.0.0
@@ -622,15 +622,15 @@ class CSPInPort(OpenRTM_aist.InPortBase):
     ##
     # @if jp
     #
-    # @brief ���󥹥ȥ饯��
+    # @brief コンストラクタ
     # 
     #
     # @param self
-    # @param buff ��󥰥Хåե�
-    # @param control WorkerThreadCtrl���֥�������
-    # @param timeout �񤭹����Ե��Υ����ॢ���Ȼ���
-    # @param manager CSP����ͥ�����ޥ͡�����
-    # manager����ꤷ�����ϡ�manager���Ե���ξ��˥��å���������Τ�Ԥ�
+    # @param buff リングバッファ
+    # @param control WorkerThreadCtrlオブジェクト
+    # @param timeout 書き込み待機のタイムアウト時間
+    # @param manager CSPチャネル管理マネージャ
+    # managerを指定した場合は、managerが待機中の場合にロック解除の通知を行う
     # 
     #
     #
@@ -655,15 +655,15 @@ class CSPInPort(OpenRTM_aist.InPortBase):
     ##
     # @if jp
     #
-    # @brief �񤭹��߳�ǧ���Υ�����Хå��ؿ�
-    # ¾�Υ��ͥ������ǡ����񤭹�����ξ��ϴ�λ�ޤ��Ե�����
-    # �Хåե����ե�ǤϤʤ����Ͻ񤭹��߾��֤˰ܹԤ���
-    # ���Τ��ᡢ�񤭹��߲�ǽ�ʾ���ɬ���ǡ�����񤭹���ɬ�פ�����
+    # @brief 書き込み確認時のコールバック関数
+    # 他のコネクタがデータ書き込み中の場合は完了まで待機する
+    # バッファがフルではない場合は書き込み状態に移行する
+    # このため、書き込み可能な場合は必ずデータを書き込む必要がある
     # 
     #
     # @param self
     # @param con InPortConnector
-    # @return True���񤭹��߲�ǽ��False���񤭹����Բ�
+    # @return True：書き込み可能、False：書き込み不可
     # 
     #
     #
@@ -702,7 +702,7 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   #
   # @class WriteListener
   #
-  # @brief �ǡ����񤭹��߻��Υꥹ�ʴ��쥯�饹(��󥰥Хåե����ѥ⡼��)
+  # @brief データ書き込み時のリスナ基底クラス(リングバッファ使用モード)
   # 
   #
   # @since 2.0.0
@@ -722,12 +722,12 @@ class CSPInPort(OpenRTM_aist.InPortBase):
     ##
     # @if jp
     #
-    # @brief ���󥹥ȥ饯��
+    # @brief コンストラクタ
     # 
     #
     # @param self
-    # @param buff ��󥰥Хåե�
-    # @param control WorkerThreadCtrl���֥�������
+    # @param buff リングバッファ
+    # @param control WorkerThreadCtrlオブジェクト
     # 
     #
     #
@@ -747,14 +747,14 @@ class CSPInPort(OpenRTM_aist.InPortBase):
     ##
     # @if jp
     #
-    # @brief �񤭹��߻��Υ�����Хå��ؿ�
-    # �ǡ�����Хåե����ɲä����񤭹��߾��֤�������
+    # @brief 書き込み時のコールバック関数
+    # データをバッファに追加し、書き込み状態を解除する
     # 
     #
     # @param self
-    # @param data �ǡ���
-    # @return �꥿���󥳡���
-    # BUFFER_OK�����ﴰλ
+    # @param data データ
+    # @return リターンコード
+    # BUFFER_OK：正常完了
     # 
     #
     #
@@ -780,7 +780,7 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   #
   # @class IsWritableZeroModeListener
   #
-  # @brief �ǡ����񤭹��߳�ǧ�ꥹ�ʴ��쥯�饹(���󥰥Хåե����ѥ⡼��)
+  # @brief データ書き込み確認リスナ基底クラス(非リングバッファ使用モード)
   # 
   #
   # @since 2.0.0
@@ -800,15 +800,15 @@ class CSPInPort(OpenRTM_aist.InPortBase):
     ##
     # @if jp
     #
-    # @brief ���󥹥ȥ饯��
+    # @brief コンストラクタ
     # 
     #
     # @param self
-    # @param buff ��󥰥Хåե�
-    # @param control WorkerThreadCtrl���֥�������
-    # @param timeout �񤭹����Ե��Υ����ॢ���Ȼ���
-    # @param manager CSP����ͥ�����ޥ͡�����
-    # manager����ꤷ�����ϡ�manager���Ե���ξ��˥��å���������Τ�Ԥ�
+    # @param buff リングバッファ
+    # @param control WorkerThreadCtrlオブジェクト
+    # @param timeout 書き込み待機のタイムアウト時間
+    # @param manager CSPチャネル管理マネージャ
+    # managerを指定した場合は、managerが待機中の場合にロック解除の通知を行う
     # 
     #
     #
@@ -833,15 +833,15 @@ class CSPInPort(OpenRTM_aist.InPortBase):
     ##
     # @if jp
     #
-    # @brief �񤭹��߳�ǧ���Υ�����Хå��ؿ�
-    # ¾�Υ��ͥ������ǡ����񤭹�����ξ��ϴ�λ�ޤ��Ե�����
-    # �Хåե����ե�ǤϤʤ����Ͻ񤭹��߾��֤˰ܹԤ���
-    # ���Τ��ᡢ�񤭹��߲�ǽ�ʾ���ɬ���ǡ�����񤭹���ɬ�פ�����
+    # @brief 書き込み確認時のコールバック関数
+    # 他のコネクタがデータ書き込み中の場合は完了まで待機する
+    # バッファがフルではない場合は書き込み状態に移行する
+    # このため、書き込み可能な場合は必ずデータを書き込む必要がある
     # 
     #
     # @param self
     # @param con InPortConnector
-    # @return True���񤭹��߲�ǽ��False���񤭹����Բ�
+    # @return True：書き込み可能、False：書き込み不可
     # 
     #
     #
@@ -880,7 +880,7 @@ class CSPInPort(OpenRTM_aist.InPortBase):
   #
   # @class WriteZeroModeListener
   #
-  # @brief �ǡ����񤭹��߻��Υꥹ�ʴ��쥯�饹(���󥰥Хåե����ѥ⡼��)
+  # @brief データ書き込み時のリスナ基底クラス(非リングバッファ使用モード)
   # 
   #
   # @since 2.0.0
@@ -900,12 +900,12 @@ class CSPInPort(OpenRTM_aist.InPortBase):
     ##
     # @if jp
     #
-    # @brief ���󥹥ȥ饯��
+    # @brief コンストラクタ
     # 
     #
     # @param self
-    # @param buff ��󥰥Хåե�
-    # @param control WorkerThreadCtrl���֥�������
+    # @param buff リングバッファ
+    # @param control WorkerThreadCtrlオブジェクト
     # 
     #
     #
@@ -925,14 +925,14 @@ class CSPInPort(OpenRTM_aist.InPortBase):
     ##
     # @if jp
     #
-    # @brief �񤭹��߻��Υ�����Хå��ؿ�
-    # �񤭹��߾��֤������Хåե��˥ǡ������ɲä��롣
+    # @brief 書き込み時のコールバック関数
+    # 書き込み状態を解除しバッファにデータを追加する。
     # 
     #
     # @param self
-    # @param data �ǡ���
-    # @return �꥿���󥳡���
-    # BUFFER_OK�����ﴰλ
+    # @param data データ
+    # @return リターンコード
+    # BUFFER_OK：正常完了
     # 
     #
     #

--- a/OpenRTM_aist/CSPInPort.py
+++ b/OpenRTM_aist/CSPInPort.py
@@ -178,6 +178,12 @@ class CSPInPort(OpenRTM_aist.InPortBase):
       self._writable_listener = OpenRTM_aist.CSPInPort.IsWritableZeroModeListener(self._thebuffer, self._ctrl, self._channeltimeout, self, self._manager)
       self._write_listener = OpenRTM_aist.CSPInPort.WriteZeroModeListener(self._thebuffer,self._ctrl)
 
+  def setManager(self, manager):
+    self._writable_listener.setManager(manager)
+    self._manager = manager
+    if manager:
+      self._manager.addInPort(self)
+
   ##  
   # @if jp
   #
@@ -688,6 +694,9 @@ class CSPInPort(OpenRTM_aist.InPortBase):
         self._ctrl._writing = False
         return False
 
+    def setManager(self, manager):
+      self._manager = manager
+
   ##
   # @if jp
   #
@@ -862,6 +871,9 @@ class CSPInPort(OpenRTM_aist.InPortBase):
       else:
         self._ctrl._writing = False
         return False
+  
+    def setManager(self, manager):
+      self._manager = manager
         
   ##
   # @if jp

--- a/OpenRTM_aist/CSPInPort.py
+++ b/OpenRTM_aist/CSPInPort.py
@@ -178,11 +178,47 @@ class CSPInPort(OpenRTM_aist.InPortBase):
       self._writable_listener = OpenRTM_aist.CSPInPort.IsWritableZeroModeListener(self._thebuffer, self._ctrl, self._channeltimeout, self, self._manager)
       self._write_listener = OpenRTM_aist.CSPInPort.WriteZeroModeListener(self._thebuffer,self._ctrl)
 
+  ##
+  # @if jp
+  #
+  # @brief CSPManagerの設定
+  #
+  # @param self
+  # @param manager CSPManager
+  #
+  # @else
+  #
+  # @brief 
+  #
+  # @param self
+  # @param manager
+  #
+  # @endif
+  #
   def setManager(self, manager):
     self._writable_listener.setManager(manager)
     self._manager = manager
     if manager:
       self._manager.addInPort(self)
+
+  ##
+  # @if jp
+  #
+  # @brief CSPManagerの設定解除
+  #
+  # @param self
+  #
+  # @else
+  #
+  # @brief 
+  #
+  # @param self
+  #
+  # @endif
+  #
+  def releaseManager(self):
+    self._writable_listener.releaseManager()
+    self._manager = None
 
   ##  
   # @if jp
@@ -652,6 +688,7 @@ class CSPInPort(OpenRTM_aist.InPortBase):
       self._channeltimeout = timeout
       self._manager = manager
       self._port = port
+      self._mutex = threading.RLock()
     ##
     # @if jp
     #
@@ -678,12 +715,14 @@ class CSPInPort(OpenRTM_aist.InPortBase):
     # @endif
     #
     def __call__(self, con):
+      guard_manager = OpenRTM_aist.Guard.ScopedLock(self._mutex)
       if self._manager:
         if self._manager.notify(inport=self._port):
           guard = OpenRTM_aist.ScopedLock(self._ctrl._cond)
           self._ctrl._writing = True
           self._port.setWritingConnector(con)
           return True
+      del guard_manager
       guard = OpenRTM_aist.ScopedLock(self._ctrl._cond)
       if self._ctrl._writing:
         self._ctrl._cond.wait(self._channeltimeout)
@@ -694,8 +733,49 @@ class CSPInPort(OpenRTM_aist.InPortBase):
         self._ctrl._writing = False
         return False
 
+    ##
+    # @if jp
+    #
+    # @brief CSPManagerの設定
+    #
+    # @param self
+    # @param manager CSPManager
+    # 
+    #
+    #
+    # @else
+    #
+    # @brief 
+    #
+    # @param self
+    # @param manager
+    #
+    # @endif
+    #
     def setManager(self, manager):
+      guard_manager = OpenRTM_aist.Guard.ScopedLock(self._mutex)
       self._manager = manager
+
+    ##
+    # @if jp
+    #
+    # @brief CSPManagerの解除
+    #
+    # @param self
+    # 
+    #
+    #
+    # @else
+    #
+    # @brief 
+    #
+    # @param self
+    #
+    # @endif
+    #
+    def releaseManager(self):
+      guard_manager = OpenRTM_aist.Guard.ScopedLock(self._mutex)
+      self._manager = None
 
   ##
   # @if jp
@@ -830,6 +910,7 @@ class CSPInPort(OpenRTM_aist.InPortBase):
       self._channeltimeout = timeout
       self._port = port
       self._manager = manager
+      self._mutex = threading.RLock()
     ##
     # @if jp
     #
@@ -856,12 +937,14 @@ class CSPInPort(OpenRTM_aist.InPortBase):
     # @endif
     #
     def __call__(self, con):
+      guard_manager = OpenRTM_aist.Guard.ScopedLock(self._mutex)
       if self._manager:
         if self._manager.notify(inport=self._port):
           guard = OpenRTM_aist.ScopedLock(self._ctrl._cond)
           self._ctrl._writing = True
           self._port.setWritingConnector(con)
           return True
+      del guard_manager
       guard = OpenRTM_aist.ScopedLock(self._ctrl._cond)
       if self._ctrl._waiting and self._ctrl._writing:
         self._ctrl._cond.wait(self._channeltimeout)
@@ -871,9 +954,50 @@ class CSPInPort(OpenRTM_aist.InPortBase):
       else:
         self._ctrl._writing = False
         return False
-  
+
+    ##
+    # @if jp
+    #
+    # @brief CSPManagerの設定
+    #
+    # @param self
+    # @param manager CSPManager
+    # 
+    #
+    #
+    # @else
+    #
+    # @brief 
+    #
+    # @param self
+    # @param manager
+    #
+    # @endif
+    #
     def setManager(self, manager):
+      guard_manager = OpenRTM_aist.Guard.ScopedLock(self._mutex)
       self._manager = manager
+
+    ##
+    # @if jp
+    #
+    # @brief CSPManagerの解除
+    #
+    # @param self
+    # 
+    #
+    #
+    # @else
+    #
+    # @brief 
+    #
+    # @param self
+    #
+    # @endif
+    #
+    def releaseManager(self):
+      guard_manager = OpenRTM_aist.Guard.ScopedLock(self._mutex)
+      self._manager = None
         
   ##
   # @if jp

--- a/OpenRTM_aist/CSPMachine.py
+++ b/OpenRTM_aist/CSPMachine.py
@@ -41,7 +41,7 @@ import RTC
 #
 # @endif
 #
-class CSPMachine(OpenRTM_aist.StaticFSM.Machine, OpenRTM_aist.CSPManager):
+class CSPMachine(OpenRTM_aist.StaticFSM.Machine):
   ##
   # @if jp
   #
@@ -59,10 +59,7 @@ class CSPMachine(OpenRTM_aist.StaticFSM.Machine, OpenRTM_aist.CSPManager):
   #
   def __init__(self, TOP, comp):
     OpenRTM_aist.StaticFSM.Machine.__init__(self, TOP, comp)
-    OpenRTM_aist.CSPManager.__init__(self)
-    self._outports = []
-    self._inports = []
-    self._ctrl = OpenRTM_aist.CSPManager.CSPThreadCtrl()
+    #self._ctrl = OpenRTM_aist.CSPManager.CSPThreadCtrl()
     
   ##
   # @if jp
@@ -129,7 +126,7 @@ class CSPMachine(OpenRTM_aist.StaticFSM.Machine, OpenRTM_aist.CSPManager):
   # @endif
   #
   def run_event(self, timeout=10):
-    ret, outport, inport = self.select(timeout)
+    ret, outport, inport = self._manager.select(timeout)
     if ret:
       if inport:
         event = inport.readData()

--- a/OpenRTM_aist/CSPManager.py
+++ b/OpenRTM_aist/CSPManager.py
@@ -82,6 +82,14 @@ class CSPManager(object):
   def __del__(self):
     pass
 
+  def reset(self):
+    for port in self._outports:
+      port.setManager(None)
+    for port in self._inports:
+      port.setManager(None)
+    self._outports = []
+    self._inports = []
+
   ##
   # @if jp
   #
@@ -164,22 +172,24 @@ class CSPManager(object):
     if ret:
       return ret, None, port
 
-    guard = OpenRTM_aist.ScopedLock(self._ctrl._cond)
-    self._ctrl._waiting = True
-    self._ctrl._timeout = True
-    self._ctrl._cond.wait(timeout)
-    self._ctrl._waiting = False
-    del guard
-    if self._ctrl._timeout:
-      return False, None, None
-    else:
-      if self._writableOutPort or self._readableInPort:
-        inport = self._readableInPort
-        outport = self._writableOutPort
-        self._writableOutPort = None
-        self._readableInPort = None
-        return True, outport, inport
-      return False, None, None
+    
+    if timeout >= 0:
+      guard = OpenRTM_aist.ScopedLock(self._ctrl._cond)
+      self._ctrl._waiting = True
+      self._ctrl._timeout = True
+      self._ctrl._cond.wait(timeout)
+      self._ctrl._waiting = False
+      del guard
+      if self._ctrl._timeout:
+        return False, None, None
+      else:
+        if self._writableOutPort or self._readableInPort:
+          inport = self._readableInPort
+          outport = self._writableOutPort
+          self._writableOutPort = None
+          self._readableInPort = None
+          return True, outport, inport
+    return False, None, None
 
 
   ##

--- a/OpenRTM_aist/CSPManager.py
+++ b/OpenRTM_aist/CSPManager.py
@@ -82,11 +82,26 @@ class CSPManager(object):
   def __del__(self):
     pass
 
+  ##
+  # @if jp
+  #
+  # @brief CSPポートに設定したCSPManagerとの関連付けを解除
+  #
+  # @param self
+  #
+  # @else
+  #
+  # @brief 
+  #
+  # @param self
+  #
+  # @endif
+  #
   def reset(self):
     for port in self._outports:
-      port.setManager(None)
+      port.releaseManager()
     for port in self._inports:
-      port.setManager(None)
+      port.releaseManager()
     self._outports = []
     self._inports = []
 

--- a/OpenRTM_aist/CSPManager.py
+++ b/OpenRTM_aist/CSPManager.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# -*- coding: euc-jp -*-
+ï»¿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 ##
 # @file CSPManager.py
@@ -24,7 +24,7 @@ import threading
 #
 # @class CSPManager
 #
-# @brief CSPOutPort¡¢CSPInPort¤ò´ÉÍı¤¹¤ë¥¯¥é¥¹
+# @brief CSPOutPortã€CSPInPortã‚’ç®¡ç†ã™ã‚‹ã‚¯ãƒ©ã‚¹
 # 
 #
 # @since 2.0.0
@@ -44,7 +44,7 @@ class CSPManager(object):
   ##
   # @if jp
   #
-  # @brief ¥³¥ó¥¹¥È¥é¥¯¥¿
+  # @brief ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
   #
   # @param self
   #
@@ -67,9 +67,9 @@ class CSPManager(object):
   ##
   # @if jp
   #
-  # @brief ¥Ç¥¹¥È¥é¥¯¥¿
+  # @brief ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
   #
-  # ¥Ç¥¹¥È¥é¥¯¥¿¡£
+  # ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ã€‚
   #
   # @else
   #
@@ -93,12 +93,12 @@ class CSPManager(object):
   ##
   # @if jp
   #
-  # @brief ½ñ¤­¹ş¤ß²ÄÇ½¤ÊOutPort¤òÁªÂò¤¹¤ë
+  # @brief æ›¸ãè¾¼ã¿å¯èƒ½ãªOutPortã‚’é¸æŠã™ã‚‹
   #
   # @param self
   # @return ret, port
-  # ret¡§True(½ñ¤­¹ş¤ß²ÄÇ½¤ÊOutPort¤¬Â¸ºß¤¹¤ë)¡¢False(Â¸ºß¤·¤Ê¤¤)
-  # port¡§½ñ¤­¹ş¤ß²ÄÇ½¤ÊOutPort¡£ÁªÂò¤Ç¤­¤Ê¤«¤Ã¤¿¾ì¹ç¤ÏNone
+  # retï¼šTrue(æ›¸ãè¾¼ã¿å¯èƒ½ãªOutPortãŒå­˜åœ¨ã™ã‚‹)ã€False(å­˜åœ¨ã—ãªã„)
+  # portï¼šæ›¸ãè¾¼ã¿å¯èƒ½ãªOutPortã€‚é¸æŠã§ããªã‹ã£ãŸå ´åˆã¯None
   #
   # @else
   #
@@ -118,12 +118,12 @@ class CSPManager(object):
   ##
   # @if jp
   #
-  # @brief ÆÉ¤ß¹ş¤ß²ÄÇ½¤ÊInPort¤òÁªÂò¤¹¤ë
+  # @brief èª­ã¿è¾¼ã¿å¯èƒ½ãªInPortã‚’é¸æŠã™ã‚‹
   #
   # @param self
   # @return ret, port
-  # ret¡§True(ÆÉ¤ß¹ş¤ß²ÄÇ½¤ÊInPort¤¬Â¸ºß¤¹¤ë)¡¢False(Â¸ºß¤·¤Ê¤¤)
-  # port¡§ÆÉ¤ß¹ş¤ß²ÄÇ½¤ÊInPort¡£ÁªÂò¤Ç¤­¤Ê¤«¤Ã¤¿¾ì¹ç¤ÏNone
+  # retï¼šTrue(èª­ã¿è¾¼ã¿å¯èƒ½ãªInPortãŒå­˜åœ¨ã™ã‚‹)ã€False(å­˜åœ¨ã—ãªã„)
+  # portï¼šèª­ã¿è¾¼ã¿å¯èƒ½ãªInPortã€‚é¸æŠã§ããªã‹ã£ãŸå ´åˆã¯None
   #
   # @else
   #
@@ -143,16 +143,16 @@ class CSPManager(object):
   ##
   # @if jp
   #
-  # @brief ÆÉ¤ß¹ş¤ß²ÄÇ½¤ÊInPort¡¢¤â¤·¤¯¤Ï½ñ¤­¹ş¤ß²ÄÇ½¤ÊOutPort¤òÁªÂò¤¹¤ë
-  # ÆÉ¤ß¹ş¤ß²ÄÇ½¤ÊInPort¡¢½ñ¤­¹ş¤ß²ÄÇ½¤ÊOutPort¤¬Â¸ºß¤·¤Ê¤¤¾ì¹ç¤Ï¥¿¥¤¥à¥¢¥¦¥È¤Ş¤ÇÂÔµ¡¤¹¤ë
-  # ÂÔµ¡²ò½ü¸å¡¢ÆÉ¤ß¹ş¤ß²ÄÇ½¤ÊInPort¡¢¤â¤·¤¯¤Ï½ñ¤­¹ş¤ß²ÄÇ½¤ÊOutPort¤òºÆÅÙÁªÂò¤¹¤ë
+  # @brief èª­ã¿è¾¼ã¿å¯èƒ½ãªInPortã€ã‚‚ã—ãã¯æ›¸ãè¾¼ã¿å¯èƒ½ãªOutPortã‚’é¸æŠã™ã‚‹
+  # èª­ã¿è¾¼ã¿å¯èƒ½ãªInPortã€æ›¸ãè¾¼ã¿å¯èƒ½ãªOutPortãŒå­˜åœ¨ã—ãªã„å ´åˆã¯ã‚¿ã‚¤ãƒ ã‚¢ã‚¦ãƒˆã¾ã§å¾…æ©Ÿã™ã‚‹
+  # å¾…æ©Ÿè§£é™¤å¾Œã€èª­ã¿è¾¼ã¿å¯èƒ½ãªInPortã€ã‚‚ã—ãã¯æ›¸ãè¾¼ã¿å¯èƒ½ãªOutPortã‚’å†åº¦é¸æŠã™ã‚‹
   #
   # @param self
-  # @param timeout ÂÔµ¡¤Î¥¿¥¤¥à¥¢¥¦¥È»ş´Ö
+  # @param timeout å¾…æ©Ÿã®ã‚¿ã‚¤ãƒ ã‚¢ã‚¦ãƒˆæ™‚é–“
   # @return ret, outport, inport
-  # ret¡§Ture(½ñ¤­¹ş¤ß¡¢ÆÉ¤ß¹ş¤ß²ÄÇ½¤Ê¥İ¡¼¥È¤¬Â¸ºß)¡¢False(¥¿¥¤¥à¥¢¥¦¥È)
-  # outport¡§OutPort¤òÁªÂò¤·¤¿¾ì¹ç¤Ë¡¢½ñ¤­¹ş¤ß²ÄÇ½¤ÊOutPort¤ò³ÊÇ¼
-  # inport¡§InPort¤òÁªÂò¤·¤¿¾ì¹ç¤Ë¡¢ÆÉ¤ß¹ş¤ß²ÄÇ½¤ÊInort¤ò³ÊÇ¼
+  # retï¼šTure(æ›¸ãè¾¼ã¿ã€èª­ã¿è¾¼ã¿å¯èƒ½ãªãƒãƒ¼ãƒˆãŒå­˜åœ¨)ã€False(ã‚¿ã‚¤ãƒ ã‚¢ã‚¦ãƒˆ)
+  # outportï¼šOutPortã‚’é¸æŠã—ãŸå ´åˆã«ã€æ›¸ãè¾¼ã¿å¯èƒ½ãªOutPortã‚’æ ¼ç´
+  # inportï¼šInPortã‚’é¸æŠã—ãŸå ´åˆã«ã€èª­ã¿è¾¼ã¿å¯èƒ½ãªInortã‚’æ ¼ç´
   #
   # @else
   #
@@ -195,11 +195,11 @@ class CSPManager(object):
   ##
   # @if jp
   #
-  # @brief ÂÔµ¡¾õÂÖ²ò½ü¤òÄÌÃÎ
-  # select´Ø¿ô¤ÇÂÔµ¡¤·¤Æ¤¤¤ë¾ì¹ç¤Ë¡¢ÂÔµ¡¤ò²ò½ü¤¹¤ë
+  # @brief å¾…æ©ŸçŠ¶æ…‹è§£é™¤ã‚’é€šçŸ¥
+  # selecté–¢æ•°ã§å¾…æ©Ÿã—ã¦ã„ã‚‹å ´åˆã«ã€å¾…æ©Ÿã‚’è§£é™¤ã™ã‚‹
   #
   # @param self
-  # @return True¡§ÂÔµ¡¾õÂÖ¤ò²ò½ü¡¢False¡§ÂÔµ¡¾õÂÖ¤Ç¤Ï¤Ê¤¤
+  # @return Trueï¼šå¾…æ©ŸçŠ¶æ…‹ã‚’è§£é™¤ã€Falseï¼šå¾…æ©ŸçŠ¶æ…‹ã§ã¯ãªã„
   #
   # @else
   #
@@ -226,7 +226,7 @@ class CSPManager(object):
   ##
   # @if jp
   #
-  # @brief InPort¤òÄÉ²Ã
+  # @brief InPortã‚’è¿½åŠ 
   #
   # @param self
   # @param port InPort
@@ -246,7 +246,7 @@ class CSPManager(object):
   ##
   # @if jp
   #
-  # @brief OutPort¤òÄÉ²Ã
+  # @brief OutPortã‚’è¿½åŠ 
   #
   # @param self
   # @param port OutPort
@@ -266,7 +266,7 @@ class CSPManager(object):
   ##
   # @if jp
   #
-  # @brief InPort¤òºï½ü
+  # @brief InPortã‚’å‰Šé™¤
   #
   # @param self
   # @param port InPort
@@ -286,7 +286,7 @@ class CSPManager(object):
   ##
   # @if jp
   #
-  # @brief Outort¤òºï½ü
+  # @brief Outortã‚’å‰Šé™¤
   #
   # @param self
   # @param port OutPort

--- a/OpenRTM_aist/CSPOutPort.py
+++ b/OpenRTM_aist/CSPOutPort.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# -*- coding: euc-jp -*-
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 ##
 # @file CSPOutPort.py
@@ -25,7 +25,7 @@ import threading
 #
 # @class EventInPort
 #
-# @brief EventInPort �ƥ�ץ졼�ȥ��饹
+# @brief EventInPort テンプレートクラス
 # 
 #
 # @since 2.0.0
@@ -45,13 +45,13 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
   ##
   # @if jp
   #
-  # @brief ���󥹥ȥ饯��
+  # @brief コンストラクタ
   #
-  # ���󥹥ȥ饯����
-  # �ѥ�᡼���Ȥ���Ϳ������ T �����ѿ��˥Х���ɤ���롣
+  # コンストラクタ。
+  # パラメータとして与えられる T 型の変数にバインドされる。
   #
-  # @param name EventInPort ̾��EventInPortBase:name() �ˤ�껲�Ȥ���롣
-  # @param value ���� EventInPort �˥Х���ɤ���� T �����ѿ�
+  # @param name EventInPort 名。EventInPortBase:name() により参照される。
+  # @param value この EventInPort にバインドされる T 型の変数
   #
   # @else
   #
@@ -85,9 +85,9 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
   ##
   # @if jp
   #
-  # @brief �ǥ��ȥ饯��
+  # @brief デストラクタ
   #
-  # �ǥ��ȥ饯����
+  # デストラクタ。
   #
   # @else
   #
@@ -103,12 +103,12 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
   ##
   # @if jp
   #
-  # @brief �ݡ���̾�Τ�������롣
+  # @brief ポート名称を取得する。
   #
-  # �ݡ���̾�Τ�������롣
+  # ポート名称を取得する。
   #
   # @param self
-  # @return �ݡ���̾��
+  # @return ポート名称
   #
   # @else
   #
@@ -127,11 +127,11 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
   ##
   # @if jp
   #
-  # @brief ������ؿ�
+  # @brief 初期化関数
   #
   # @param self
-  # @param prop �������
-  # channel_timeout���ǡ����񤭹��ߡ��ɤ߹��߻��Υ����ॢ����
+  # @param prop 設定情報
+  # channel_timeout：データ書き込み、読み込み時のタイムアウト
   #
   # @else
   #
@@ -160,16 +160,16 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
   ##
   # @if jp
   #
-  # @brief ���ͥ�����³�ؿ�
-  # OutPortBase����³�����Τۤ��ˡ����ͥ������ɤ߹��߳�ǧ�����ɤ߹��߻��Υ�����Хå��ؿ������ꤹ��
+  # @brief コネクタ接続関数
+  # OutPortBaseの接続処理のほかに、コネクタに読み込み確認時、読み込み時のコールバック関数を設定する
   #
   # @param self
-  # @param connector_profile ���ͥ����ץ��ե�����
+  # @param connector_profile コネクタプロファイル
   # @return ret, prof
-  # ret���꥿���󥳡���
-  # prof�����ͥ����ץ��ե�����
+  # ret：リターンコード
+  # prof：コネクタプロファイル
   # 
-  # @return �ݡ���̾��
+  # @return ポート名称
   #
   # @else
   #
@@ -192,12 +192,12 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
   ##
   # @if jp
   #
-  # @brief �ǡ������񤭹��߲�ǽ�����ǧ
+  # @brief データが書き込み可能かを確認
   #
   # @param self
   # @return ret, con
-  # ret��True(�񤭹��߲�ǽ)��False(�񤭹����Բ�)
-  # con���񤭹��߲�ǽ�ʥ��ͥ������񤭹����ԲĤξ���None
+  # ret：True(書き込み可能)、False(書き込み不可)
+  # con：書き込み可能なコネクタ。書き込み不可の場合はNone
   #
   # @else
   #
@@ -217,10 +217,10 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
   ##
   # @if jp
   #
-  # @brief �񤭹��߲�ǽ�ʥ��ͥ��������򤷤�self._writableConnector�˳�Ǽ����
+  # @brief 書き込み可能なコネクタを選択してself._writableConnectorに格納する
   #
   # @param self
-  # @return True���񤭹��߲�ǽ��False���񤭹����Բ�
+  # @return True：書き込み可能、False：書き込み不可
   #
   # @else
   #
@@ -245,11 +245,11 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
   ##
   # @if jp
   #
-  # @brief self._writableConnector�˳�Ǽ�������ͥ����˥ǡ�����񤭹���
-  # ���Τ��ᡢ������select�ؿ���¹Ԥ���ɬ�פ�����
+  # @brief self._writableConnectorに格納したコネクタにデータを書き込む
+  # このため、事前にselect関数を実行する必要がある
   #
   # @param self
-  # @param value �ǡ���
+  # @param value データ
   #
   # @else
   #
@@ -286,10 +286,10 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
   ##
   # @if jp
   #
-  # @brief �Ե����ֻ��˰ܹԤ������˥ǡ�������Ū���ѿ��˳�Ǽ����
+  # @brief 待機状態時に移行した場合にデータを一時的に変数に格納する
   #
   # @param self
-  # @param data �ǡ���
+  # @param data データ
   #
   # @else
   #
@@ -306,14 +306,14 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
   ##
   # @if jp
   #
-  # @brief �ǡ�����񤭹���
-  # �񤭹��߲�ǽ�ʥ��ͥ�����¸�ߤ�����ϡ��ǡ�����񤭹���ǽ�����λ����
-  # �񤭹��߲�ǽ�ʥ��ͥ�����¸�ߤ��ʤ����ϡ�InPort¦����ǡ������ɤ߹���ޤ��Ե�����
+  # @brief データを書き込む
+  # 書き込み可能なコネクタが存在する場合は、データを書き込んで処理を終了する
+  # 書き込み可能なコネクタが存在しない場合は、InPort側からデータを読み込むまで待機する
   #
   # @param self
-  # @param value �ǡ���
-  # @return True�����ﴰλ��False�����顼
-  # �ǡ����Υޡ������󥰡��񤭹��ߤΥ����ॢ���Ȥǥ��顼��ȯ������
+  # @param value データ
+  # @return True：正常完了、False：エラー
+  # データのマーシャリング、書き込みのタイムアウトでエラーが発生する
   #
   # @else
   #
@@ -382,7 +382,7 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
   #
   # @class IsReadableListener
   #
-  # @brief �ǡ����ɤ߹��߳�ǧ�ꥹ�ʴ��쥯�饹
+  # @brief データ読み込み確認リスナ基底クラス
   # 
   #
   # @since 2.0.0
@@ -402,14 +402,14 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
     ##
     # @if jp
     #
-    # @brief ���󥹥ȥ饯��
+    # @brief コンストラクタ
     # 
     #
     # @param self
-    # @param control WorkerThreadCtrl���֥�������
-    # @param timeout �ɤ߹����Ե��Υ����ॢ���Ȼ���
-    # @param manager CSP����ͥ�����ޥ͡�����
-    # manager����ꤷ�����ϡ�manager���Ե���ξ��˥��å���������Τ�Ԥ�
+    # @param control WorkerThreadCtrlオブジェクト
+    # @param timeout 読み込み待機のタイムアウト時間
+    # @param manager CSPチャネル管理マネージャ
+    # managerを指定した場合は、managerが待機中の場合にロック解除の通知を行う
     # 
     #
     #
@@ -433,15 +433,15 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
     ##
     # @if jp
     #
-    # @brief �ɤ߹��߳�ǧ���Υ�����Хå��ؿ�
-    # ¾�Υ��ͥ������ǡ����ɤ߹�����ξ��ϴ�λ�ޤ��Ե�����
-    # �ǡ����񤭹��ߤ��Ե����Ƥ���ξ����ɤ߹��߾��֤˰ܹԤ���
-    # ���Τ��ᡢ�ɤ߹��߲�ǽ�ʾ���ɬ���ǡ������ɤ߹���ɬ�פ�����
+    # @brief 読み込み確認時のコールバック関数
+    # 他のコネクタがデータ読み込み中の場合は完了まで待機する
+    # データ書き込みで待機しているの場合は読み込み状態に移行する
+    # このため、読み込み可能な場合は必ずデータを読み込み必要がある
     # 
     #
     # @param self
     # @param con OutPortConnector
-    # @return True���ɤ߹��߲�ǽ��False���ɤ߹����Բ�
+    # @return True：読み込み可能、False：読み込み不可
     # 
     #
     #
@@ -479,7 +479,7 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
   #
   # @class ReadListener
   #
-  # @brief �ǡ����ɤ߹��߻��Υꥹ�ʴ��쥯�饹
+  # @brief データ読み込み時のリスナ基底クラス
   # 
   #
   # @since 2.0.0
@@ -499,12 +499,12 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
     ##
     # @if jp
     #
-    # @brief ���󥹥ȥ饯��
+    # @brief コンストラクタ
     # 
     #
     # @param self
-    # @param data �ǡ������Ǽ�����ѿ�
-    # @param control WorkerThreadCtrl���֥�������
+    # @param data データを格納する変数
+    # @param control WorkerThreadCtrlオブジェクト
     # 
     #
     #
@@ -525,16 +525,16 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
     ##
     # @if jp
     #
-    # @brief �ɤ߹��߻��Υ�����Хå��ؿ�
-    # �ǡ������ѿ�������Ф����ɤ߹��߾��֤�������
+    # @brief 読み込み時のコールバック関数
+    # データを変数から取り出し、読み込み状態を解除する
     # 
     #
     # @param self
     # @return ret, data
-    # ret���꥿���󥳡���
-    # BUFFER_OK�����ﴰλ
-    # BUFFER_ERROR���ǡ�������Ǽ����Ƥ��ʤ�
-    # data���ǡ���
+    # ret：リターンコード
+    # BUFFER_OK：正常完了
+    # BUFFER_ERROR：データが格納されていない
+    # data：データ
     # 
     #
     #

--- a/OpenRTM_aist/CSPOutPort.py
+++ b/OpenRTM_aist/CSPOutPort.py
@@ -151,6 +151,11 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
     self._readable_listener = OpenRTM_aist.CSPOutPort.IsReadableListener(self._buffdata, self._ctrl, self._channeltimeout, self, self._manager)
     self._read_listener = OpenRTM_aist.CSPOutPort.ReadListener(self._buffdata, self._ctrl, self._channeltimeout)
 
+  def setManager(self, manager):
+    self._readable_listener.setManager(manager)
+    self._manager = manager
+    if manager:
+      self._manager.addOutPort(self)
 
   ##
   # @if jp
@@ -465,6 +470,9 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
       else:
         self._ctrl._reading = True
         return True
+
+    def setManager(self, manager):
+      self._manager = manager
 
   ##
   # @if jp

--- a/OpenRTM_aist/EventPort.py
+++ b/OpenRTM_aist/EventPort.py
@@ -359,7 +359,6 @@ class EventBinder1(OpenRTM_aist.ConnectorDataListenerT):
   #
   def __call__(self, info, data):
     data_ = OpenRTM_aist.ConnectorDataListenerT.__call__(self, info, data, self._data_type, OpenRTM_aist.PortType.InPortType)
-    
     if info.properties.getProperty("fsm_event_name") == self._eventName or info.name == self._eventName:
       self._buffer.write(Event1(self, data_))
       return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE

--- a/OpenRTM_aist/InPortCSPConsumer.py
+++ b/OpenRTM_aist/InPortCSPConsumer.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 ##
@@ -21,7 +21,7 @@ import CSP
 # @class InPortCSPConsumer
 # @brief InPortCSPConsumer クラス
 #
-# 通信手段に 共有メモリ を利用した入力ポートプロバイダーの実装クラス。
+# CSPモデルのチャネルを模擬した入力ポートプロバイダーの実装クラス。
 #
 #
 # @else

--- a/OpenRTM_aist/InPortCSPConsumer.py
+++ b/OpenRTM_aist/InPortCSPConsumer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 ##

--- a/OpenRTM_aist/InPortCSPProvider.py
+++ b/OpenRTM_aist/InPortCSPProvider.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 ##
@@ -21,7 +21,7 @@ import CSP__POA
 # @class InPortCSPProvider
 # @brief InPortCSPProvider クラス
 #
-# 通信手段に 共有メモリ を利用した入力ポートプロバイダーの実装クラス。
+# CSPモデルのチャネルを模擬した入力ポートプロバイダーの実装クラス。
 #
 #
 # @else

--- a/OpenRTM_aist/InPortCSPProvider.py
+++ b/OpenRTM_aist/InPortCSPProvider.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 ##

--- a/OpenRTM_aist/InPortDuplexConnector.py
+++ b/OpenRTM_aist/InPortDuplexConnector.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 ##
@@ -72,6 +72,7 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
       raise
 
     self._buffer = None
+    self._info = info
     self._provider.init(info.properties)
     self._provider.setListener(info, self._listeners)
     self.onConnect()
@@ -407,6 +408,7 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
   # @endif
   def setConsumer(self, consumer):
     self._consumer = consumer
+    self._consumer.setListener(self._info, self._listeners)
 
   def onBufferRead(self, data):
     if self._listeners and self._profile:

--- a/OpenRTM_aist/InPortDuplexConnector.py
+++ b/OpenRTM_aist/InPortDuplexConnector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 ##

--- a/OpenRTM_aist/OutPortCSPConsumer.py
+++ b/OpenRTM_aist/OutPortCSPConsumer.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 ##
@@ -21,7 +21,7 @@ import CSP
 # @class OutPortCSPConsumer
 # @brief OutPortCSPConsumer クラス
 #
-# 通信手段に 共有メモリ を利用した入力ポートプロバイダーの実装クラス。
+# CSPモデルのチャネルを模擬した出力ポートプロバイダーの実装クラス。
 #
 #
 # @else

--- a/OpenRTM_aist/OutPortCSPConsumer.py
+++ b/OpenRTM_aist/OutPortCSPConsumer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 ##

--- a/OpenRTM_aist/OutPortCSPProvider.py
+++ b/OpenRTM_aist/OutPortCSPProvider.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 ##
@@ -21,7 +21,7 @@ import CSP__POA
 # @class OutPortCSPProvider
 # @brief OutPortCSPProvider クラス
 #
-# 通信手段に 共有メモリ を利用した入力ポートプロバイダーの実装クラス。
+# CSPモデルのチャネルを模擬した出力ポートプロバイダーの実装クラス。
 #
 #
 # @else

--- a/OpenRTM_aist/OutPortCSPProvider.py
+++ b/OpenRTM_aist/OutPortCSPProvider.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 ##

--- a/OpenRTM_aist/OutPortDuplexConnector.py
+++ b/OpenRTM_aist/OutPortDuplexConnector.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 
@@ -75,7 +75,7 @@ class OutPortDuplexConnector(OpenRTM_aist.OutPortConnector):
       raise
 
     self._buffer = buffer
-
+    self._info = info
     self._provider.init(info.properties)
     self._provider.setConnector(self)
     self._provider.setListener(info, self._listeners)
@@ -408,6 +408,7 @@ class OutPortDuplexConnector(OpenRTM_aist.OutPortConnector):
   # @endif
   def setConsumer(self, consumer):
     self._consumer = consumer
+    self._consumer.setListener(self._info, self._listeners)
 
 
   ##

--- a/OpenRTM_aist/OutPortDuplexConnector.py
+++ b/OpenRTM_aist/OutPortDuplexConnector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 

--- a/OpenRTM_aist/examples/CSPStaticFsmSample/Inputbutton.py
+++ b/OpenRTM_aist/examples/CSPStaticFsmSample/Inputbutton.py
@@ -56,12 +56,12 @@ class Inputbutton(OpenRTM_aist.DataFlowComponentBase):
     self._stopOut = OpenRTM_aist.CSPOutPort("stop", self._stop)
     self._tickOut = OpenRTM_aist.CSPOutPort("tick", self._tick)
     # Set OutPort buffer
-    self.addOutPort("out", self._openOut)
-    self.addOutPort("out", self._closeOut)
-    self.addOutPort("out", self._minuteOut)
-    self.addOutPort("out", self._startOut)
-    self.addOutPort("out", self._stopOut)
-    self.addOutPort("out", self._tickOut)
+    self.addOutPort("open", self._openOut)
+    self.addOutPort("close", self._closeOut)
+    self.addOutPort("minute", self._minuteOut)
+    self.addOutPort("start", self._startOut)
+    self.addOutPort("stop", self._stopOut)
+    self.addOutPort("tick", self._tickOut)
 
 
     return RTC.RTC_OK

--- a/OpenRTM_aist/examples/CSPStaticFsmSample/Microwave.py
+++ b/OpenRTM_aist/examples/CSPStaticFsmSample/Microwave.py
@@ -50,7 +50,8 @@ class Microwave(OpenRTM_aist.DataFlowComponentBase):
   def onInitialize(self):
     self._fsm = CSPMachine.CSPMachine(MicrowaveFsm.TOP, self)
     #self._fsm.init()
-    self._eventIn = CSPEventPort.CSPEventPort("event", self._fsm)
+    self._cspmanager = OpenRTM_aist.CSPManager()
+    self._eventIn = CSPEventPort.CSPEventPort("event", self._fsm, self._cspmanager)
     
     self.addInPort("event", self._eventIn)
     self._eventIn.bindEvent0("open", MicrowaveFsm.TOP.open)
@@ -71,9 +72,19 @@ class Microwave(OpenRTM_aist.DataFlowComponentBase):
 
         
   def onExecute(self, ec_id):
-    self._fsm.run_event()
-    
+    #self._fsm.run_event()
+    ret, outport, inport = self._cspmanager.select(10)
+    if ret:
+      if inport:
+        event = inport.readData()
+        event()
+        return RTC.RTC_OK
+      elif outport:
+        outport.write()
+        return RTC.RTC_OK
     return RTC.RTC_OK
+    
+    
 
 
 def MicrowaveInit(manager):

--- a/OpenRTM_aist/examples/StaticFsm/Inputbutton.py
+++ b/OpenRTM_aist/examples/StaticFsm/Inputbutton.py
@@ -56,12 +56,12 @@ class Inputbutton(OpenRTM_aist.DataFlowComponentBase):
     self._stopOut = OpenRTM_aist.OutPort("stop", self._stop)
     self._tickOut = OpenRTM_aist.OutPort("tick", self._tick)
     # Set OutPort buffer
-    self.addOutPort("out", self._openOut)
-    self.addOutPort("out", self._closeOut)
-    self.addOutPort("out", self._minuteOut)
-    self.addOutPort("out", self._startOut)
-    self.addOutPort("out", self._stopOut)
-    self.addOutPort("out", self._tickOut)
+    self.addOutPort("open", self._openOut)
+    self.addOutPort("close", self._closeOut)
+    self.addOutPort("minute", self._minuteOut)
+    self.addOutPort("start", self._startOut)
+    self.addOutPort("stop", self._stopOut)
+    self.addOutPort("tick", self._tickOut)
 
 
     return RTC.RTC_OK


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
CSPポートに関連する以下の問題を修正した。

- CSPポート関連のファイルの文字コードをUTF-8に統一した
- 外部選択を行うためのCSPManagerの設定をCSPポート初期化後にも再設定できるようにした。(違うポートを対象にした外部選択の実装のため)
- StaticFSM.MachineクラスとCSPManagerクラスを多重継承してCSPMachineクラスを定義していたが、これはCSPポートが複数回外部選択を行う場合に都合が悪いためCSPManagerクラスの継承はやめた。
- CSPEventPortでOutPortが送信待ち状態の時に受信処理を開始した際にコネクタコールバック関数が呼ばれない問題の修正。





## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
