### PR TITLE
ConfigSample.pyがPython3で正常に動作しないバグの修正(1.2)

### DIFF
--- a/OpenRTM_aist/examples/ConfigSample/ConfigSample.py
+++ b/OpenRTM_aist/examples/ConfigSample/ConfigSample.py
@@ -116,8 +116,8 @@ class ConfigSample(OpenRTM_aist.DataFlowComponentBase):
     print(str_)
 
 
-    if self._int_param0 > 1000 and self._int_param0 < 1000000:
-      time.sleep(self._int_param0/1000000.0)
+    if self._int_param0[0] > 1000 and self._int_param0[0] < 1000000:
+      time.sleep(self._int_param0[0]/1000000.0)
     else:
       time.sleep(0.1)
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

ConfigSample.pyの以下の部分でリストと数値を比較しているが、Python2ではリスト内の数値と比較してくれるがPython3ではエラーになる。


```Python
    if self._int_param0 > 1000 and self._int_param0 < 1000000:
      time.sleep(self._int_param0/1000000.0)
```



## Description of the Change

数値同士を比較するように修正した。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
