### PR TITLE
remove_service_profileでコンポーネントオブザーバーを削除した場合にタイマースレッドが停止しない問題の修正

### DIFF
--- a/OpenRTM_aist/ext/fsm4rtc_observer/ComponentObserverConsumer.py
+++ b/OpenRTM_aist/ext/fsm4rtc_observer/ComponentObserverConsumer.py
@@ -227,6 +227,8 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
     self.unsetPortProfileListeners()
     self.unsetExecutionContextListeners()
     self.unsetConfigurationListeners()
+    self.unsetRTCHeartbeat()
+    self.stopTimer()
     return
 
 
@@ -441,8 +443,9 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
   #
   # void unsetRTCHeartbeat();
   def unsetRTCHeartbeat(self):
-    self._timer.unregisterListener(self._rtcHblistenerid)
-    self._rtcHblistenerid = None
+    if self._rtcHblistenerid:
+      self._timer.unregisterListener(self._rtcHblistenerid)
+      self._rtcHblistenerid = None
     self._rtcHeartbeat = False
     return
 

--- a/OpenRTM_aist/ext/sdo/observer/ComponentObserverConsumer.py
+++ b/OpenRTM_aist/ext/sdo/observer/ComponentObserverConsumer.py
@@ -152,6 +152,7 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
     self.unsetPortProfileListeners()
     self.unsetExecutionContextListeners()
     self.unsetConfigurationListeners()
+    self.unsetHeartbeat()
     del self._timer
     return
 

--- a/OpenRTM_aist/ext/sdo/observer/ComponentObserverConsumer.py
+++ b/OpenRTM_aist/ext/sdo/observer/ComponentObserverConsumer.py
@@ -356,8 +356,9 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
   #
   # void unsetHeartbeat();
   def unsetHeartbeat(self):
-    self._timer.unregisterListener(self._hblistenerid)
-    self._hblistenerid = None
+    if self._hblistenerid:
+      self._timer.unregisterListener(self._hblistenerid)
+      self._hblistenerid = None
     self._heartbeat = False
     self._timer.stop()
     return


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#76 の変更によりRTCをexitしたときにコンポーネントオブザーバーのタイマースレッドが停止するようになったが、`remove_service_profile`で削除した場合にタイマースレッドが停止しない。

## Description of the Change

コンポーネントオブザーバーの終了処理でもタイマースレッドを停止するようにした。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
