### PR TITLE
ManagerActionListenerの基底クラス追加、引数ありListenerの修正

### DIFF
--- a/OpenRTM_aist/ListenerHolder.py
+++ b/OpenRTM_aist/ListenerHolder.py
@@ -198,7 +198,14 @@ class ListenerHolder:
     for listener in self.listeners:
       for (l,f) in listener.items():
         func_ = getattr(l,func,None)
-        ret = func_(*args)
-        if ret is not None:
-          args = ret
-    return args
+        if len(args) == 1:
+          ret = func_(args[0])
+          args = (ret,)
+        else:
+          ret = func_(*args)
+          if ret is not None:
+            args = ret
+    if len(args) == 1:
+      return args[0]
+    else:
+      return args

--- a/OpenRTM_aist/ListenerHolder.py
+++ b/OpenRTM_aist/ListenerHolder.py
@@ -198,5 +198,7 @@ class ListenerHolder:
     for listener in self.listeners:
       for (l,f) in listener.items():
         func_ = getattr(l,func,None)
-        func_(*args)
-    return
+        ret = func_(*args)
+        if ret is not None:
+          args = ret
+    return args

--- a/OpenRTM_aist/Manager.py
+++ b/OpenRTM_aist/Manager.py
@@ -564,7 +564,7 @@ class Manager:
                            (fname, initfunc))
     fname = fname.replace("/", os.sep)
     fname = fname.replace("\\", os.sep)
-    self._listeners.module_.preLoad(fname, initfunc)
+    fname, initfunc = self._listeners.module_.preLoad(fname, initfunc)
     try:
       fname_ = fname.split(os.sep)
       
@@ -578,7 +578,7 @@ class Manager:
         initfunc = mod[0]+"Init"
       path = self._module.load(fname, initfunc)
       self._rtcout.RTC_DEBUG("module path: %s", path)
-      self._listeners.module_.postLoad(path, initfunc)
+      path, initfunc = self._listeners.module_.postLoad(path, initfunc)
     except OpenRTM_aist.ModuleManager.NotAllowedOperation as e:
       self._rtcout.RTC_ERROR("Operation not allowed: %s",(e.reason))
       return RTC.PRECONDITION_NOT_MET
@@ -623,9 +623,9 @@ class Manager:
   # @endif
   def unload(self, fname):
     self._rtcout.RTC_TRACE("Manager.unload()")
-    self._listeners.module_.preUnload(fname)
+    fname = self._listeners.module_.preUnload(fname)
     self._module.unload(fname)
-    self._listeners.module_.postUnload(fname)
+    fname = self._listeners.module_.postUnload(fname)
     return
 
 
@@ -880,6 +880,8 @@ class Manager:
     comp_prop = OpenRTM_aist.Properties()
     comp_id   = OpenRTM_aist.Properties()
 
+    comp_args = self._listeners.rtclifecycle_.preCreate(comp_args)
+
     if not self.procComponentArgs(comp_args, comp_id, comp_prop):
       return None
     
@@ -887,8 +889,6 @@ class Manager:
       comp = self.getComponent(comp_prop.getProperty("instance_name"))
       if comp:
         return comp
-    
-    self._listeners.rtclifecycle_.preCreate(comp_args)
 
     if comp_prop.findNode("exported_ports"):
       exported_ports = OpenRTM_aist.split(comp_prop.getProperty("exported_ports"),

--- a/OpenRTM_aist/ManagerActionListener.py
+++ b/OpenRTM_aist/ManagerActionListener.py
@@ -42,6 +42,7 @@ class ManagerActionListener:
   # @endif
   # virtual void preShutdown();
   def preShutdown(self):
+    # type: () -> None
     pass
   ##
   # @if jp
@@ -53,6 +54,7 @@ class ManagerActionListener:
   # @endif
   # virtual void postShutdown();
   def postShutdown(self):
+    # type: () -> None
     pass
   ##
   # @if jp
@@ -64,6 +66,7 @@ class ManagerActionListener:
   # @endif
   # virtual void preReinit();
   def preReinit(self):
+    # type: () -> None
     pass
   ##
   # @if jp
@@ -75,6 +78,7 @@ class ManagerActionListener:
   # @endif
   # virtual void postReinit();
   def postReinit(self):
+    # type: () -> None
     pass
 
 
@@ -173,8 +177,9 @@ class ModuleActionListener:
   # @param funcname 
   # @return 
   # @endif
-  # virtual void preLoad();
+  # virtual void preLoad(std::string& modname, std::string& funcname);
   def preLoad(self, modname, funcname):
+    # type: (str, str) -> str, str
     return modname, funcname
   ##
   # @if jp
@@ -190,8 +195,9 @@ class ModuleActionListener:
   # @param funcname 
   # @return 
   # @endif
-  # virtual void postLoad();
+  # virtual void postLoad(std::string& modname, std::string& funcname);
   def postLoad(self, modname, funcname):
+    # type: (str, str) -> str, str
     return modname, funcname
   ##
   # @if jp
@@ -205,9 +211,10 @@ class ModuleActionListener:
   # @param modname 
   # @return 
   # @endif 
-  # virtual void preUnload();
+  # virtual void preUnload(std::string& modname));
   def preUnload(self, modname):
-    return modname,
+    # type: (str) -> str
+    return modname
   ##
   # @if jp
   # @brief postUnload コールバック関数
@@ -216,9 +223,10 @@ class ModuleActionListener:
   # @brief postUnload callback function
   # @param self 
   # @endif 
-  # virtual void postUnload();
+  # virtual void postUnload(std::string& modname));
   def postUnload(self, modname):
-    return modname,
+    # type: (str) -> str
+    return modname
   
 ##
 # @if jp
@@ -289,8 +297,7 @@ class ModuleActionListenerHolder(OpenRTM_aist.ListenerHolder):
   # @endif
   # virtual void preUnload(std::string& modname);
   def preUnload(self, modname):
-    modname, = self.LISTENERHOLDER_CALLBACK("preUnload", modname)
-    return modname
+    return self.LISTENERHOLDER_CALLBACK("preUnload", modname)
     
 
   ##
@@ -303,8 +310,7 @@ class ModuleActionListenerHolder(OpenRTM_aist.ListenerHolder):
   # @endif
   # virtual void postUnload(std::string& modname);
   def postUnload(self, modname):
-    modname, = self.LISTENERHOLDER_CALLBACK("postUnload", modname)
-    return modname
+    return self.LISTENERHOLDER_CALLBACK("postUnload", modname)
   
   
 ##
@@ -340,9 +346,10 @@ class RtcLifecycleActionListener:
   # @param args
   # @return 
   # @endif
-  # virtual void preCreate();
+  # virtual void preCreate(std::string& args);
   def preCreate(self, args):
-    return args,
+    # type: (str) -> str
+    return args
   ##
   # @if jp
   # @brief postCreate コールバック関数
@@ -353,8 +360,9 @@ class RtcLifecycleActionListener:
   # @param self 
   # @param rtobj 
   # @endif
-  # virtual void postCreate();
+  # virtual void postCreate(RTC::RTObject_impl*);
   def postCreate(self, rtobj):
+    # type: (OpenRTM_aist.RTObject_impl) -> None
     pass
   ##
   # @if jp
@@ -366,8 +374,9 @@ class RtcLifecycleActionListener:
   # @param self 
   # @param prop 
   # @endif 
-  # virtual void preConfigure();
+  # virtual void preConfigure(coil::Properties& prop);
   def preConfigure(self, prop):
+    # type: (OpenRTM_aist.Properties) -> None
     pass
   ##
   # @if jp
@@ -379,8 +388,9 @@ class RtcLifecycleActionListener:
   # @param self 
   # @param prop 
   # @endif 
-  # virtual void postConfigure();
+  # virtual void postConfigure(coil::Properties& prop);
   def postConfigure(self, prop):
+    # type: (OpenRTM_aist.Properties) -> None
     pass
 
   ##
@@ -393,6 +403,7 @@ class RtcLifecycleActionListener:
   # @endif 
   # virtual void preInitialize();
   def preInitialize(self):
+    # type: () -> None
     pass
 
   ##
@@ -405,6 +416,7 @@ class RtcLifecycleActionListener:
   # @endif 
   # virtual void postInitialize();
   def postInitialize(self):
+    # type: () -> None
     pass
 
 ##
@@ -449,8 +461,7 @@ class RtcLifecycleActionListenerHolder(OpenRTM_aist.ListenerHolder):
   # @endif
   # virtual void preCreate(std::string& args);
   def preCreate(self, args):
-    args, = self.LISTENERHOLDER_CALLBACK("preCreate", args)
-    return args
+    return self.LISTENERHOLDER_CALLBACK("preCreate", args)
     
     
 
@@ -555,8 +566,9 @@ class NamingActionListener:
   # @param rtobj
   # @param name
   # @endif
-  # virtual void preBind();
+  # virtual void preBind(RTC::RTObject_impl* rtobj, coil::vstring& name);
   def preBind(self, rtobj, name):
+    # type: (OpenRTM_aist.RTObject_impl, list) -> None
     pass
   ##
   # @if jp
@@ -570,8 +582,9 @@ class NamingActionListener:
   # @param rtobj 
   # @param name
   # @endif
-  # virtual void postBind();
+  # virtual void postBind(RTC::RTObject_impl* rtobj, coil::vstring& name);
   def postBind(self, rtobj, name):
+    # type: (OpenRTM_aist.RTObject_impl, list) -> None
     pass
   ##
   # @if jp
@@ -585,8 +598,9 @@ class NamingActionListener:
   # @param rtobj 
   # @param name
   # @endif 
-  # virtual void preUnbind();
+  # virtual void preUnbind(RTC::RTObject_impl* rtobj, coil::vstring& name);
   def preUnbind(self, rtobj, name):
+    # type: (OpenRTM_aist.RTObject_impl, list) -> None
     pass
   ##
   # @if jp
@@ -598,8 +612,9 @@ class NamingActionListener:
   # @param self 
   # @param prop 
   # @endif 
-  # virtual void postUnbind();
+  # virtual void postUnbind(RTC::RTObject_impl* rtobj, coil::vstring& name);
   def postUnbind(self, rtobj, name):
+    # type: (OpenRTM_aist.RTObject_impl, list) -> None
     pass
 
 
@@ -721,8 +736,9 @@ class LocalServiceActionListener:
   # @param service_name
   # @return
   # @endif
-  # virtual void preServiceRegister();
+  # virtual void preServiceRegister(std::string service_name);
   def preServiceRegister(self, service_name):
+    # type: (str) -> None
     pass
   ##
   # @if jp
@@ -738,8 +754,9 @@ class LocalServiceActionListener:
   # @param service
   # @return 
   # @endif
-  # virtual void postBind();
+  # virtual void postBind(std::string service_name, RTM::LocalServiceBase* service);
   def postServiceRegister(self, service_name, service):
+    # type: (str, OpenRTM_aist.LocalServiceBase) -> None
     pass
   ##
   # @if jp
@@ -753,8 +770,9 @@ class LocalServiceActionListener:
   # @param prop 
   # @param service
   # @endif 
-  # virtual void preServiceInit();
+  # virtual void preServiceInit(coil::Properties& prop, RTM::LocalServiceBase* service);
   def preServiceInit(self, prop, service):
+    # type: (OpenRTM_aist.Properties,  OpenRTM_aist.LocalServiceBase) -> None
     pass
   ##
   # @if jp
@@ -768,8 +786,9 @@ class LocalServiceActionListener:
   # @param prop 
   # @param service 
   # @endif 
-  # virtual void preServiceReinit();
+  # virtual void preServiceReinit(coil::Properties& prop, RTM::LocalServiceBase* service);
   def preServiceReinit(self, prop, service):
+    # type: (OpenRTM_aist.Properties,  OpenRTM_aist.LocalServiceBase) -> None
     pass
 
   ##
@@ -784,8 +803,9 @@ class LocalServiceActionListener:
   # @param prop 
   # @param service 
   # @endif 
-  # virtual void postServiceFinalize();
+  # virtual void postServiceFinalize(coil::Properties& prop, RTM::LocalServiceBase* service);
   def postServiceFinalize(self, prop, service):
+    # type: (OpenRTM_aist.Properties,  OpenRTM_aist.LocalServiceBase) -> None
     pass
 
   ##
@@ -800,8 +820,9 @@ class LocalServiceActionListener:
   # @param service_name 
   # @param service 
   # @endif 
-  # virtual void preServiceFinalize();
+  # virtual void preServiceFinalize(std::string service_name, RTM::LocalServiceBase* service);
   def preServiceFinalize(self, service_name, service):
+    # type: (str,  OpenRTM_aist.LocalServiceBase) -> None
     pass
 
   

--- a/OpenRTM_aist/ManagerActionListener.py
+++ b/OpenRTM_aist/ManagerActionListener.py
@@ -19,6 +19,65 @@
 
 import OpenRTM_aist
 
+
+##
+# @if jp
+# @class ManagerActionListener クラス
+#
+# - マネージャShutdownの直前: void onPreShutdown()
+# - マネージャShutdownの直後: void onPostShutdown()
+# - マネージャの再初期化直前: void onPreReinit()
+# - マネージャの再初期化直後: void onPostReinit()
+# @else
+# @class ManagerActionListener class
+# @endif
+class ManagerActionListener:
+  ##
+  # @if jp
+  # @brief preShutdown callback function
+  # @param self 
+  # @else
+  # @brief preShutdown callback function
+  # @param self 
+  # @endif
+  # virtual void preShutdown();
+  def preShutdown(self):
+    pass
+  ##
+  # @if jp
+  # @brief postShutdown callback function
+  # @param self 
+  # @else
+  # @brief postShutdown callback function
+  # @param self 
+  # @endif
+  # virtual void postShutdown();
+  def postShutdown(self):
+    pass
+  ##
+  # @if jp
+  # @brief preReinit コールバック関数
+  # @param self 
+  # @else
+  # @brief preReinit callback function
+  # @param self 
+  # @endif
+  # virtual void preReinit();
+  def preReinit(self):
+    pass
+  ##
+  # @if jp
+  # @brief postReinit コールバック関数
+  # @param self 
+  # @else
+  # @brief postReinit callback function
+  # @param self 
+  # @endif
+  # virtual void postReinit();
+  def postReinit(self):
+    pass
+
+
 ##
 # @if jp
 # @class ManagerActionListenerHolder クラス
@@ -92,6 +151,74 @@ class ManagerActionListenerHolder(OpenRTM_aist.ListenerHolder):
     self.LISTENERHOLDER_CALLBACK("postReinit")
     return
   
+
+##
+# @if jp
+# @class ModuleActionListener クラス
+# @else
+# @class ModuleActionListener class
+# @endif
+class ModuleActionListener:
+  ##
+  # @if jp
+  # @brief preLoad コールバック関数
+  # @param self 
+  # @param modname 
+  # @param funcname 
+  # @return 
+  # @else
+  # @brief preLoad callback function
+  # @param self 
+  # @param modname 
+  # @param funcname 
+  # @return 
+  # @endif
+  # virtual void preLoad();
+  def preLoad(self, modname, funcname):
+    return modname, funcname
+  ##
+  # @if jp
+  # @brief postLoad コールバック関数
+  # @param self 
+  # @param modname 
+  # @param funcname 
+  # @return 
+  # @else
+  # @brief postLoad callback function
+  # @param self 
+  # @param modname 
+  # @param funcname 
+  # @return 
+  # @endif
+  # virtual void postLoad();
+  def postLoad(self, modname, funcname):
+    return modname, funcname
+  ##
+  # @if jp
+  # @brief preUnload コールバック関数
+  # @param self 
+  # @param modname 
+  # @return 
+  # @else
+  # @brief preUnload callback function
+  # @param self 
+  # @param modname 
+  # @return 
+  # @endif 
+  # virtual void preUnload();
+  def preUnload(self, modname):
+    return modname,
+  ##
+  # @if jp
+  # @brief postUnload コールバック関数
+  # @param self 
+  # @else
+  # @brief postUnload callback function
+  # @param self 
+  # @endif 
+  # virtual void postUnload();
+  def postUnload(self, modname):
+    return modname,
   
 ##
 # @if jp
@@ -133,8 +260,8 @@ class ModuleActionListenerHolder(OpenRTM_aist.ListenerHolder):
   # virtual void preLoad(std::string& modname,
   #                      std::string& funcname);
   def preLoad(self, modname, funcname):
-    self.LISTENERHOLDER_CALLBACK("preLoad", modname, funcname)
-    return
+    return self.LISTENERHOLDER_CALLBACK("preLoad", modname, funcname)
+    
 
     
   ##
@@ -148,8 +275,8 @@ class ModuleActionListenerHolder(OpenRTM_aist.ListenerHolder):
   # virtual void postLoad(std::string& modname,
   #                       std::string& funcname);
   def postLoad(self, modname, funcname):
-    self.LISTENERHOLDER_CALLBACK("postLoad", modname, funcname)
-    return
+    return self.LISTENERHOLDER_CALLBACK("postLoad", modname, funcname)
+    
     
 
   ##
@@ -162,8 +289,8 @@ class ModuleActionListenerHolder(OpenRTM_aist.ListenerHolder):
   # @endif
   # virtual void preUnload(std::string& modname);
   def preUnload(self, modname):
-    self.LISTENERHOLDER_CALLBACK("preUnload", modname)
-    return
+    modname, = self.LISTENERHOLDER_CALLBACK("preUnload", modname)
+    return modname
     
 
   ##
@@ -176,10 +303,109 @@ class ModuleActionListenerHolder(OpenRTM_aist.ListenerHolder):
   # @endif
   # virtual void postUnload(std::string& modname);
   def postUnload(self, modname):
-    self.LISTENERHOLDER_CALLBACK("postUnload", modname)
-    return
+    modname, = self.LISTENERHOLDER_CALLBACK("postUnload", modname)
+    return modname
   
   
+##
+# @if jp
+# @class RtcLifecycleActionListener クラス
+#
+# RTC系
+# - RTC生成の直前 bool (std::string&)
+#   void preCreate(std::string& args) = 0;
+# - RTC生成の直後 bool (RTObject_impl*)
+#   void postCreate(RTObject_impl*) = 0;
+# - RTCのコンフィグ直前 bool (coil::Properties& prop)
+#   void preConfigure(coil::Properties& prop) = 0;
+# - RTCのコンフィグ直後 bool (coil::Properties& prop)
+#   void postConfigure(coil::Properties& prop) = 0;
+# - RTCの初期化の直前 bool (void)
+#   void preInitialize(void) = 0;
+# - RTCの初期化の直後 bool (void)
+#   void postInitialize(void) = 0;
+# @else
+# @class RtcLifecycleActionListener class
+# @endif
+class RtcLifecycleActionListener:
+  ##
+  # @if jp
+  # @brief preCreate コールバック関数
+  # @param self 
+  # @param args
+  # @return 
+  # @else
+  # @brief preCreate callback function
+  # @param self 
+  # @param args
+  # @return 
+  # @endif
+  # virtual void preCreate();
+  def preCreate(self, args):
+    return args,
+  ##
+  # @if jp
+  # @brief postCreate コールバック関数
+  # @param self 
+  # @param rtobj 
+  # @else
+  # @brief postCreate callback function
+  # @param self 
+  # @param rtobj 
+  # @endif
+  # virtual void postCreate();
+  def postCreate(self, rtobj):
+    pass
+  ##
+  # @if jp
+  # @brief preConfigure コールバック関数
+  # @param self 
+  # @param prop 
+  # @else
+  # @brief preConfigure callback function
+  # @param self 
+  # @param prop 
+  # @endif 
+  # virtual void preConfigure();
+  def preConfigure(self, prop):
+    pass
+  ##
+  # @if jp
+  # @brief postConfigure コールバック関数
+  # @param self 
+  # @param prop 
+  # @else
+  # @brief postConfigure callback function
+  # @param self 
+  # @param prop 
+  # @endif 
+  # virtual void postConfigure();
+  def postConfigure(self, prop):
+    pass
+
+  ##
+  # @if jp
+  # @brief preInitialize コールバック関数
+  # @param self 
+  # @else
+  # @brief preInitialize callback function
+  # @param self 
+  # @endif 
+  # virtual void preInitialize();
+  def preInitialize(self):
+    pass
+
+  ##
+  # @if jp
+  # @brief postInitialize コールバック関数
+  # @param self 
+  # @else
+  # @brief postInitialize callback function
+  # @param self 
+  # @endif 
+  # virtual void postInitialize();
+  def postInitialize(self):
+    pass
 
 ##
 # @if jp
@@ -223,8 +449,9 @@ class RtcLifecycleActionListenerHolder(OpenRTM_aist.ListenerHolder):
   # @endif
   # virtual void preCreate(std::string& args);
   def preCreate(self, args):
-    self.LISTENERHOLDER_CALLBACK("preCreate", args)
-    return
+    args, = self.LISTENERHOLDER_CALLBACK("preCreate", args)
+    return args
+    
     
 
   ##
@@ -296,6 +523,84 @@ class RtcLifecycleActionListenerHolder(OpenRTM_aist.ListenerHolder):
     self.LISTENERHOLDER_CALLBACK("postInitialize")
     return
 
+
+
+  
+##
+# @if jp
+# @class NamingActionListener クラス
+#
+# 各アクションに対応するユーザーコードが呼ばれる直前のタイミング
+# でコールされるリスなクラスの基底クラス。
+#
+# Registration系
+# - PRE_NS_REGISTER:    RTCの名前の登録の直前 bool (coil::vstring&)
+# - POST_NS_REGISTER:   RTCの名前の登録の直後 bool (coil::vstring&)
+# - PRE_NS_UNREGISTER:  RTCの名前の登録の直前 bool (coil::vstring&)
+# - POST_NS_UNREGISTER: RTCの名前の登録の直後 bool (coil::vstring&)
+#
+# @else
+# @class NamingActionListener class
+# @endif
+class NamingActionListener:
+  ##
+  # @if jp
+  # @brief preBind コールバック関数
+  # @param self 
+  # @param rtobj
+  # @param name
+  # @else
+  # @brief preBind callback function
+  # @param self 
+  # @param rtobj
+  # @param name
+  # @endif
+  # virtual void preBind();
+  def preBind(self, rtobj, name):
+    pass
+  ##
+  # @if jp
+  # @brief postBind コールバック関数
+  # @param self 
+  # @param rtobj 
+  # @param name
+  # @else
+  # @brief postBind callback function
+  # @param self 
+  # @param rtobj 
+  # @param name
+  # @endif
+  # virtual void postBind();
+  def postBind(self, rtobj, name):
+    pass
+  ##
+  # @if jp
+  # @brief preUnbind コールバック関数
+  # @param self 
+  # @param rtobj 
+  # @param name
+  # @else
+  # @brief preUnbind callback function
+  # @param self 
+  # @param rtobj 
+  # @param name
+  # @endif 
+  # virtual void preUnbind();
+  def preUnbind(self, rtobj, name):
+    pass
+  ##
+  # @if jp
+  # @brief postUnbind コールバック関数
+  # @param self 
+  # @param prop 
+  # @else
+  # @brief postUnbind callback function
+  # @param self 
+  # @param prop 
+  # @endif 
+  # virtual void postUnbind();
+  def postUnbind(self, rtobj, name):
+    pass
 
 
 ##
@@ -390,6 +695,115 @@ class NamingActionListenerHolder(OpenRTM_aist.ListenerHolder):
     return
   
   
+##
+# @if jp
+# @class LocalServiceActionListener クラス
+#
+# 各アクションに対応するユーザーコードが呼ばれる直前のタイミング
+# でコールされるリスナクラスの基底クラス。
+#
+# - ADD_PORT:
+# - REMOVE_PORT:
+#
+# @else
+# @class LocalServiceActionListener class
+# @endif
+class LocalServiceActionListener:
+  ##
+  # @if jp
+  # @brief preServiceRegister コールバック関数
+  # @param self 
+  # @param service_name
+  # @return
+  # @else
+  # @brief preServiceRegister callback function
+  # @param self 
+  # @param service_name
+  # @return
+  # @endif
+  # virtual void preServiceRegister();
+  def preServiceRegister(self, service_name):
+    pass
+  ##
+  # @if jp
+  # @brief postServiceRegister コールバック関数
+  # @param self 
+  # @param service_name 
+  # @param service
+  # @return 
+  # @else
+  # @brief postServiceRegister callback function
+  # @param self 
+  # @param service_name 
+  # @param service
+  # @return 
+  # @endif
+  # virtual void postBind();
+  def postServiceRegister(self, service_name, service):
+    pass
+  ##
+  # @if jp
+  # @brief preServiceInit コールバック関数
+  # @param self 
+  # @param prop 
+  # @param service
+  # @else
+  # @brief preServiceInit callback function
+  # @param self 
+  # @param prop 
+  # @param service
+  # @endif 
+  # virtual void preServiceInit();
+  def preServiceInit(self, prop, service):
+    pass
+  ##
+  # @if jp
+  # @brief preServiceReinit コールバック関数
+  # @param self 
+  # @param prop 
+  # @param service 
+  # @else
+  # @brief preServiceReinit callback function
+  # @param self 
+  # @param prop 
+  # @param service 
+  # @endif 
+  # virtual void preServiceReinit();
+  def preServiceReinit(self, prop, service):
+    pass
+
+  ##
+  # @if jp
+  # @brief postServiceFinalize コールバック関数
+  # @param self 
+  # @param prop 
+  # @param service 
+  # @else
+  # @brief postServiceFinalize callback function
+  # @param self 
+  # @param prop 
+  # @param service 
+  # @endif 
+  # virtual void postServiceFinalize();
+  def postServiceFinalize(self, prop, service):
+    pass
+
+  ##
+  # @if jp
+  # @brief preServiceFinalize コールバック関数
+  # @param self 
+  # @param service_name 
+  # @param service 
+  # @else
+  # @brief preServiceFinalize callback function
+  # @param self 
+  # @param service_name 
+  # @param service 
+  # @endif 
+  # virtual void preServiceFinalize();
+  def preServiceFinalize(self, service_name, service):
+    pass
+
   
 ##
 # @if jp


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#98
#95 

## Description of the Change

- ManagerActionListenerクラス、ModuleActionListenerクラス、RtcLifecycleActionListenerクラス、NamingActionListenerクラス、LocalServiceActionListenerクラスを定義
- 戻り値を引数の変数に格納することで、引数ありListenerで値を変更する場合に引数の値も変更するようにした


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
