### PR TITLE
rtc.confのパスの修正

### DIFF
--- a/OpenRTM_aist/ManagerConfig.py
+++ b/OpenRTM_aist/ManagerConfig.py
@@ -90,8 +90,7 @@ class ManagerConfig :
   if os.name == 'nt':
 
     config_file_path = ["./rtc.conf",
-                        "${RTM_ROOT}bin/${RTM_VC_VERSION}/rtc.conf",
-                        "C:/Python"+str(sys.version_info[0])+str(sys.version_info[1])+"/rtc.conf",
+                        "${APPDATA}/OpenRTM-aist/rtc.conf",
                         None]
   else:
     config_file_path = ["./rtc.conf",

--- a/OpenRTM_aist/ManagerConfig.py
+++ b/OpenRTM_aist/ManagerConfig.py
@@ -90,7 +90,7 @@ class ManagerConfig :
   if os.name == 'nt':
 
     config_file_path = ["./rtc.conf",
-                        "${APPDATA}/OpenRTM-aist/rtc.conf"]
+                        "${PROGRAMDATA}/OpenRTM-aist/rtc.conf"]
   else:
     config_file_path = ["./rtc.conf",
                         "/etc/rtc.conf",

--- a/OpenRTM_aist/ManagerConfig.py
+++ b/OpenRTM_aist/ManagerConfig.py
@@ -90,15 +90,13 @@ class ManagerConfig :
   if os.name == 'nt':
 
     config_file_path = ["./rtc.conf",
-                        "${APPDATA}/OpenRTM-aist/rtc.conf",
-                        None]
+                        "${APPDATA}/OpenRTM-aist/rtc.conf"]
   else:
     config_file_path = ["./rtc.conf",
                         "/etc/rtc.conf",
                         "/etc/rtc/rtc.conf",
                         "/usr/local/etc/rtc.conf",
-                        "/usr/local/etc/rtc/rtc.conf",
-                        None]
+                        "/usr/local/etc/rtc/rtc.conf"]
 
 
   ##
@@ -361,13 +359,11 @@ class ManagerConfig :
         self._configFile = env
         return True
 
-    i = 0
-    while (self.config_file_path[i]):
-      self.config_file_path[i] = OpenRTM_aist.replaceEnv(self.config_file_path[i])
-      if self.fileExist(self.config_file_path[i]):
-        self._configFile = self.config_file_path[i]
+    for file_path in self.config_file_path:
+      file_path = OpenRTM_aist.replaceEnv(file_path)
+      if self.fileExist(file_path):
+        self._configFile = file_path
         return True
-      i += 1
 
     return False
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Windowsでrtc.confのパスをインストールされるrtc.confに設定していたが、これが原因で`C:\Python37\rtc.conf`を読み込んで誤動作を起こすなど問題があった。


## Description of the Change

rtc.confのパスを`%APPDATA%\OpenRTM-aist\rtc.conf`に変更した。ここには意図してrtc.confを配置しない限りは読み込まないため上記のようなトラブルは発生しないはず。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
