### PR TITLE
引数の渡し方の見直し

### DIFF
--- a/OpenRTM_aist/BufferBase.py
+++ b/OpenRTM_aist/BufferBase.py
@@ -359,16 +359,17 @@ class BufferBase(OpenRTM_aist.BufferStatus):
   # ※サブクラスでの実装参照用
   # 
   # @param self 
-  # @param value 読み出しデータ
   # 
-  # @return データ読み出し結果(true:読み出し成功，false:読み出し失敗)
+  # @return ret, data
+  # ret :   データ読み出し結果(true:読み出し成功，false:読み出し失敗)
+  # value : 読み出しデータ
   # 
   # @else
   # 
   # @brief Read data from the buffer
   # 
   # @endif
-  def read(self, value, sec = -1, nsec = -1):
+  def read(self, sec = -1, nsec = -1):
     pass
 
 
@@ -515,20 +516,21 @@ class NullBuffer(BufferBase):
   # バッファに格納されたデータを読み出す。
   # 
   # @param self 
-  # @param value 読み出したデータ
   # 
-  # @return データ読み出し結果(true:読み出し成功，false:読み出し失敗)
+  # @return ret, data
+  # ret : データ読み出し結果(true:読み出し成功，false:読み出し失敗)
+  # data 読み出したデータ
   # 
   # @else
   # 
   # @brief Read data from the buffer
   # 
   # @endif
-  def read(self, value):
+  def read(self):
     if not self._inited:
-      return False
-    value[0] = self.get()
-    return True
+      return False, None
+    _, value = self.get()
+    return True, value
 
 
   ##
@@ -622,7 +624,10 @@ class NullBuffer(BufferBase):
   # 
   # @param self 
   # 
-  # @return 取得データ
+  # @return ret, value
+  #   ret : BUFFER_OK: 正常終了
+  #         BUFFER_ERROR: 異常終了
+  # value : 読み出しデータ
   # 
   # @else
   # 
@@ -631,7 +636,7 @@ class NullBuffer(BufferBase):
   # @endif
   def get(self):
     self._is_new = False
-    return self._data
+    return OpenRTM_aist.BufferStatus.BUFFER_OK, self._data
 
 
   ##

--- a/OpenRTM_aist/CORBA_CdrMemoryStream.py
+++ b/OpenRTM_aist/CORBA_CdrMemoryStream.py
@@ -17,6 +17,7 @@
 # $Id$
 #
 
+import sys
 import OpenRTM_aist
 from omniORB import cdrMarshal
 from omniORB import cdrUnmarshal
@@ -129,10 +130,19 @@ class CORBA_CdrMemoryStream(OpenRTM_aist.ByteDataStreamBase):
   ## virtual bool serialize(const DataType& data) = 0;
   def serialize(self, data):
     if self._endian is not None:
-      cdr = cdrMarshal(any.to_any(data).typecode(), data, self._endian)
-      return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK, cdr
+      try:
+        cdr = cdrMarshal(any.to_any(data).typecode(), data, self._endian)
+        return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK, cdr
+      except:
+        if sys.version_info[0] == 3:
+          return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR, b""
+        else:
+          return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR, ""
     else:
-      return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN, ""
+      if sys.version_info[0] == 3:
+        return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN, b""
+      else:
+        return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN, ""
 
 
   ##
@@ -157,8 +167,11 @@ class CORBA_CdrMemoryStream(OpenRTM_aist.ByteDataStreamBase):
   ## virtual bool deserialize(DataType& data) = 0;
   def deserialize(self, cdr, data_type):
     if self._endian is not None:
-      data = cdrUnmarshal(any.to_any(data_type).typecode(), cdr ,self._endian)
-      return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK, data
+      try:
+        data = cdrUnmarshal(any.to_any(data_type).typecode(), cdr ,self._endian)
+        return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK, data
+      except:
+        return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR, data_type
     else:
       return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN, data_type
 

--- a/OpenRTM_aist/CSPEventPort.py
+++ b/OpenRTM_aist/CSPEventPort.py
@@ -218,15 +218,16 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
   def init(self,prop):
     super(CSPEventPort, self).init(prop)
 
-    num = [10]
-    if OpenRTM_aist.stringTo(num, self._properties.getProperty("channel_timeout","10")):
-      self._channeltimeout = num[0]
+    num = 10
+    ret, num = OpenRTM_aist.stringTo(num, self._properties.getProperty("channel_timeout","10"))
+    if ret:
+      self._channeltimeout = num
 
     buff_prop = prop.getNode("buffer")
-    length = [8]
-    OpenRTM_aist.stringTo(length, buff_prop.getProperty("length","8"))
+    length = 8
+    _, length = OpenRTM_aist.stringTo(length, buff_prop.getProperty("length","8"))
 
-    if length[0] == 0:
+    if length == 0:
       buff_prop.setProperty("length","1")
       self._bufferzeromode = True
 
@@ -404,19 +405,17 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
       for con in self._connectors:
         guard_ctrl = OpenRTM_aist.ScopedLock(self._ctrl._cond)
         if not self._eventbuffer.empty():
-          value = [None]
-          self._eventbuffer.read(value)
+          _, value = self._eventbuffer.read()
           del guard_ctrl
           self.notify()
-          return True, value[0]
+          return True, value
         elif self._ctrl._writing:
           self._ctrl._cond.wait(self._channeltimeout)
-          value = [None]
           if not self._eventbuffer.empty():
-            self._eventbuffer.read(value)
+            _, value = self._eventbuffer.read()
             del guard_ctrl
             self.notify()
-            return True, value[0]
+            return True, value
           else:
             self._rtcout.RTC_ERROR("read timeout")
             return False, None
@@ -424,21 +423,19 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
           readable = con.isReadable()
           if readable:
             ret, _ = con.readBuff()
-            value = [None]
-            self._eventbuffer.read(value)
+            _, value = self._eventbuffer.read()
             if ret == OpenRTM_aist.DataPortStatus.PORT_OK:
-              return True, value[0]
+              return True, value
             else:
               self._rtcout.RTC_ERROR("read error:%s",(OpenRTM_aist.DataPortStatus.toString(ret)))
               return False, None
     else:
-      value = [None]
       guard_ctrl = OpenRTM_aist.ScopedLock(self._ctrl._cond)
       if not self._eventbuffer.empty():
-        self._eventbuffer.read(value)
+        _, value = self._eventbuffer.read()
         del guard_ctrl
         self.notify()
-        return True, value[0]
+        return True, value
       else:
         self._rtcout.RTC_ERROR("read error:%s",(OpenRTM_aist.BufferStatus.toString(ret)))
         del guard_ctrl
@@ -475,10 +472,9 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
       if con.isReadable():
         guard = OpenRTM_aist.ScopedLock(self._ctrl._cond)
         ret, _ = con.readBuff()
-        value = [None]
-        self._eventbuffer.read(value)
+        _, value = self._eventbuffer.read()
         if ret == OpenRTM_aist.DataPortStatus.PORT_OK:
-          return True, value[0]
+          return True, value
         else:
           self._rtcout.RTC_ERROR("read error:%s",(OpenRTM_aist.DataPortStatus.toString(ret)))
           return False, None
@@ -545,9 +541,8 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
       self._ctrl._cond.wait(self._channeltimeout)
       
     if not self._eventbuffer.empty():
-      value = [None]
-      self._eventbuffer.read(value)
-      return value[0]
+      _, value = self._eventbuffer.read()
+      return value
 
     return self._value
 
@@ -612,14 +607,13 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
     if ret:
       return data
     else:
-      value = [None]
       guard = OpenRTM_aist.ScopedLock(self._ctrl._cond)
       if self._ctrl._writing or self._eventbuffer.empty():
         self._ctrl._cond.wait(self._channeltimeout)
       if not self._eventbuffer.empty():
-        self._eventbuffer.read(value)
+        _, value = self._eventbuffer.read()
 
-        return value[0]
+        return value
       else:
         self._rtcout.RTC_ERROR("read timeout")
         return None
@@ -653,10 +647,9 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
       self._ctrl._waiting = True
       self._ctrl._cond.wait(self._channeltimeout)
       self._ctrl._waiting = False
-      value = [None]
       if not self._eventbuffer.empty():
-        self._eventbuffer.read(value)
-        return value[0]
+        _, value = self._eventbuffer.read()
+        return value
       else:
         self._rtcout.RTC_ERROR("read timeout")
         return None

--- a/OpenRTM_aist/CSPOutPort.py
+++ b/OpenRTM_aist/CSPOutPort.py
@@ -144,9 +144,10 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
   #
   def init(self, prop):
     super(CSPOutPort, self).init(prop)
-    num = [10]
-    if OpenRTM_aist.stringTo(num, self._properties.getProperty("channel_timeout","10")):
-      self._channeltimeout = num[0]
+    num = 10
+    ret, num = OpenRTM_aist.stringTo(num, self._properties.getProperty("channel_timeout","10"))
+    if ret:
+      self._channeltimeout = num
 
     self._readable_listener = OpenRTM_aist.CSPOutPort.IsReadableListener(self._buffdata, self._ctrl, self._channeltimeout, self, self._manager)
     self._read_listener = OpenRTM_aist.CSPOutPort.ReadListener(self._buffdata, self._ctrl, self._channeltimeout)

--- a/OpenRTM_aist/ConfigAdmin.py
+++ b/OpenRTM_aist/ConfigAdmin.py
@@ -215,10 +215,11 @@ class Config:
       return True
     self.string_value = val
     # value changed
-    if self._trans(self._var, val):
+    ret, self._var[0] = self._trans(self._var[0], val)
+    if ret:
       self.notifyUpdate(self.name, val)
       return True
-    self._trans(self._var, self.default_value)
+    ret, self._var[0] = self._trans(self._var[0], self.default_value)
     self.notifyUpdate(self.name, val)
     return False
 

--- a/OpenRTM_aist/ConnectorListener.py
+++ b/OpenRTM_aist/ConnectorListener.py
@@ -329,11 +329,11 @@ class ConnectorDataListenerT(ConnectorDataListener):
   #
   # virtual ReturnCode operator()(const ConnectorInfo& info,
   #                         const cdrMemoryStream& cdrdata)
-  def __call__(self, info, cdrdata, data, porttype):
+  def __call__(self, info, cdrdata, data, porttype=PortType.OutPortType):
     endian = info.properties.getProperty("serializer.cdr.endian","little")
     if endian is not "little" and endian is not None:
       endian = OpenRTM_aist.split(endian, ",") # Maybe endian is ["little","big"]
-      endian = OpenRTM_aist.normalize(endian) # Maybe self._endian is "little" or "big"
+      endian = OpenRTM_aist.normalize(endian[0]) # Maybe self._endian is "little" or "big"
 
     if endian == "little":
       endian = True

--- a/OpenRTM_aist/CorbaNaming.py
+++ b/OpenRTM_aist/CorbaNaming.py
@@ -835,10 +835,10 @@ class CorbaNaming:
       raise CosNaming.NamingContext.InvalidName
 
     slen = self.getNameLength(name_list)
-    string_name = [""]
-    self.nameToString(name_list, string_name, slen)
+    string_name = ""
+    string_name = self.nameToString(name_list, string_name, slen)
 
-    return string_name[0]
+    return string_name
 
 
   ##
@@ -1125,18 +1125,19 @@ class CorbaNaming:
     for i in range(len(name_list)):
       for id_ in name_list[i].id:
         if id_ == "/" or id_ == "." or id_ == "\\":
-          string_name[0] += "\\"
-        string_name[0] += id_
+          string_name += "\\"
+        string_name += id_
 
       if name_list[i].id == "" or name_list[i].kind != "":
-        string_name[0] += "."
+        string_name += "."
 
       for kind_ in name_list[i].kind:
         if kind_ == "/" or kind_ == "." or kind_ == "\\":
-          string_name[0] += "\\"
-        string_name[0] += kind_
+          string_name += "\\"
+        string_name += kind_
 
-      string_name[0] += "/"
+      string_name += "/"
+    return string_name
 
 
   ##

--- a/OpenRTM_aist/ExecutionContextWorker.py
+++ b/OpenRTM_aist/ExecutionContextWorker.py
@@ -289,27 +289,26 @@ class ExecutionContextWorker:
   # @endif
   # RTC::ReturnCode_t activateComponent(RTC::LightweightRTObject_ptr comp,
   #                                     RTObjectStateMachine*& rtobj);
-  def activateComponent(self, comp, rtobj):
+  def activateComponent(self, comp):
     self._rtcout.RTC_TRACE("activateComponent()")
     guard = OpenRTM_aist.ScopedLock(self._mutex)
     obj_ = self.findComponent(comp)
     if not obj_:
       del guard
       self._rtcout.RTC_ERROR("Given RTC is not participant of this EC.")
-      return RTC.BAD_PARAMETER
+      return RTC.BAD_PARAMETER, obj_
 
     self._rtcout.RTC_DEBUG("Component found in the EC.")
     if not obj_.isCurrentState(RTC.INACTIVE_STATE):
       del guard
       self._rtcout.RTC_ERROR("State of the RTC is not INACTIVE_STATE.")
-      return RTC.PRECONDITION_NOT_MET
+      return RTC.PRECONDITION_NOT_MET, obj_
 
     self._rtcout.RTC_DEBUG("Component is in INACTIVE state. Going to ACTIVE state.")
     obj_.goTo(RTC.ACTIVE_STATE)
-    rtobj[0] = obj_
     del guard
     self._rtcout.RTC_DEBUG("activateComponent() done.")
-    return RTC.RTC_OK
+    return RTC.RTC_OK, obj_
 
 
   # RTC::ReturnCode_t waitActivateComplete(RTObjectStateMachine*& rtobj,
@@ -351,24 +350,24 @@ class ExecutionContextWorker:
   # @endif
   # RTC::ReturnCode_t deactivateComponent(RTC::LightweightRTObject_ptr comp,
   #                                       RTObjectStateMachine*& rtobj);
-  def deactivateComponent(self, comp, rtobj):
+  def deactivateComponent(self, comp):
     self._rtcout.RTC_TRACE("deactivateComponent()")
     guard = OpenRTM_aist.ScopedLock(self._mutex)
 
-    rtobj[0] = self.findComponent(comp)
-    if not rtobj[0]: 
+    rtobj = self.findComponent(comp)
+    if not rtobj: 
       del guard
       self._rtcout.RTC_ERROR("Given RTC is not participant of this EC.")
-      return RTC.BAD_PARAMETER
+      return RTC.BAD_PARAMETER, rtobj
 
-    if not rtobj[0].isCurrentState(RTC.ACTIVE_STATE):
+    if not rtobj.isCurrentState(RTC.ACTIVE_STATE):
       del guard
       self._rtcout.RTC_ERROR("State of the RTC is not ACTIVE_STATE.")
-      return RTC.PRECONDITION_NOT_MET
+      return RTC.PRECONDITION_NOT_MET, rtobj
 
-    rtobj[0].goTo(RTC.INACTIVE_STATE)
+    rtobj.goTo(RTC.INACTIVE_STATE)
     del guard
-    return RTC.RTC_OK
+    return RTC.RTC_OK, rtobj
 
 
   # RTC::ReturnCode_t waitDeactivateComplete(RTObjectStateMachine*& rtobj,
@@ -410,24 +409,24 @@ class ExecutionContextWorker:
   # @endif
   # RTC::ReturnCode_t resetComponent(RTC::LightweightRTObject_ptr com,
   #                                  RTObjectStateMachine*& rtobj);
-  def resetComponent(self, comp, rtobj):
+  def resetComponent(self, comp):
     self._rtcout.RTC_TRACE("resetComponent()")
     guard = OpenRTM_aist.ScopedLock(self._mutex)
 
-    rtobj[0] = self.findComponent(comp)
-    if not rtobj[0]:
+    rtobj = self.findComponent(comp)
+    if not rtobj:
       del guard
       self._rtcout.RTC_ERROR("Given RTC is not participant of this EC.")
-      return RTC.BAD_PARAMETER
+      return RTC.BAD_PARAMETER, rtobj
 
-    if not rtobj[0].isCurrentState(RTC.ERROR_STATE):
+    if not rtobj.isCurrentState(RTC.ERROR_STATE):
       del guard
       self._rtcout.RTC_ERROR("State of the RTC is not ERROR_STATE.")
-      return RTC.PRECONDITION_NOT_MET
+      return RTC.PRECONDITION_NOT_MET, rtobj
 
-    rtobj[0].goTo(RTC.INACTIVE_STATE)
+    rtobj.goTo(RTC.INACTIVE_STATE)
     del guard
-    return RTC.RTC_OK
+    return RTC.RTC_OK, rtobj
 
 
   # RTC::ReturnCode_t waitResetComplete(RTObjectStateMachine*& rtobj,

--- a/OpenRTM_aist/GlobalFactory.py
+++ b/OpenRTM_aist/GlobalFactory.py
@@ -223,12 +223,12 @@ class Factory:
   #                        FACTORY_OK: normal return
   # @endif
   # ReturnCode objectToIdentifier(AbstractClass* obj, Identifier& id)
-  def objectToIdentifier(self, obj, id):
+  def objectToIdentifier(self, obj):
     if not obj in self._objects:
-      return self.NOT_FOUND
+      return self.NOT_FOUND, -1
 
-    id[0] = self._objects[obj].id_
-    return self.FACTORY_OK
+    id = self._objects[obj].id_
+    return self.FACTORY_OK, id
 
 
   ##

--- a/OpenRTM_aist/InPort.py
+++ b/OpenRTM_aist/InPort.py
@@ -351,16 +351,16 @@ class InPort(OpenRTM_aist.InPortBase):
       return self._value
 
     _val = copy.deepcopy(self._value)
-    cdr = [_val]
+    cdr = _val
 
 
     if name is None:
-      ret = self._connectors[0].read(cdr)
+      ret, cdr = self._connectors[0].read(cdr)
     else:
       ret = OpenRTM_aist.DataPortStatus.PRECONDITION_NOT_MET
       for con in self._connectors:
         if  con.name() == name:
-          ret = con.read(cdr)
+          ret, cdr = con.read(cdr)
       if ret == OpenRTM_aist.DataPortStatus.PRECONDITION_NOT_MET:
         self._rtcout.RTC_DEBUG("not found %s",name)
         return self._value
@@ -368,7 +368,7 @@ class InPort(OpenRTM_aist.InPortBase):
 
     if ret == OpenRTM_aist.DataPortStatus.PORT_OK:
       self._rtcout.RTC_DEBUG("data read succeeded")
-      self._value = cdr[0]
+      self._value = cdr
 
       if self._OnReadConvert is not None:
         self._value = self._OnReadConvert(self._value)

--- a/OpenRTM_aist/InPortBase.py
+++ b/OpenRTM_aist/InPortBase.py
@@ -202,12 +202,13 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
     if self._consumerTypes and self._providerTypes:
       self.appendProperty("dataport.dataflow_type", "duplex")
 
-    num = [-1]
-    if not OpenRTM_aist.stringTo(num, self._properties.getProperty("connection_limit","-1")):
+    num = -1
+    ret, num = OpenRTM_aist.stringTo(num, self._properties.getProperty("connection_limit","-1"))
+    if not ret:
       self._rtcout.RTC_ERROR("invalid connection_limit value: %s",
                              self._properties.getProperty("connection_limit"))
 
-    self.setConnectionLimit(num[0])
+    self.setConnectionLimit(num)
     return
 
 
@@ -442,21 +443,21 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
   #
   # @param id Connector ID
   # @param prof ConnectorProfile
-  # @return false　specified ID does not exist
+  # @return false specified ID does not exist
   #
   # @endif
   #
   # bool getConnectorProfileById(const char* id,
   #                              ConnectorInfo& prof);
-  def getConnectorProfileById(self, id, prof):
+  def getConnectorProfileById(self, id):
     self._rtcout.RTC_TRACE("getConnectorProfileById(id = %s)", id)
 
     # guard = OpenRTM_aist.ScopedLock(self._connector_mutex)
     conn = self.getConnectorById(id)
     if not conn:
-      return False
-    prof[0] = conn.profile()
-    return True
+      return False, None
+    prof = conn.profile()
+    return True, prof
 
 
   ##
@@ -483,15 +484,15 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
   #
   # bool getConnectorProfileByName(const char* name,
   #                                ConnectorInfo& prof);
-  def getConnectorProfileByName(self, name, prof):
+  def getConnectorProfileByName(self, name):
     self._rtcout.RTC_TRACE("getConnectorProfileByName(name = %s)", name)
 
     # guard = OpenRTM_aist.ScopedLock(self._connector_mutex)
     conn = self.getConnectorByName(name)
     if not conn:
-      return False
-    prof[0] = conn.profile()
-    return True
+      return False, None
+    prof = conn.profile()
+    return True, prof
 
 
   ##
@@ -567,16 +568,16 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
 
     #_str = self._properties.getProperty("fan_in")
     _str = node.getProperty("fan_in")
-    _type = [int(100)]
+    _type = int(100)
     
-    OpenRTM_aist.stringTo(_type, _str)
+    _, _type = OpenRTM_aist.stringTo(_type, _str)
     
     
 
     _str = prop.getProperty("dataport.fan_in")
-    OpenRTM_aist.stringTo(_type, _str)
+    _, _type = OpenRTM_aist.stringTo(_type, _str)
     
-    value =  _type[0]
+    value =  _type
 
     if value <= len(self._connectors):
       return (RTC.PRECONDITION_NOT_MET, connector_profile)
@@ -914,7 +915,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
     # などがアクセス可能になる。
     #
     dflow_type = prop.getProperty("dataflow_type")
-    dflow_type = OpenRTM_aist.normalize([dflow_type])
+    dflow_type = OpenRTM_aist.normalize(dflow_type)
 
     if dflow_type == "push":
       self._rtcout.RTC_DEBUG("dataflow_type = push .... create PushConnector")
@@ -1013,9 +1014,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
     # などがアクセス可能になる。
     #
     dflow_type = prop.getProperty("dataflow_type")
-    dtype = [dflow_type]
-    OpenRTM_aist.normalize(dtype)
-    dflow_type = dtype[0]
+    dflow_type = OpenRTM_aist.normalize(dflow_type)
     
     profile = OpenRTM_aist.ConnectorInfo(cprof.name,
                                          cprof.connector_id,
@@ -1144,7 +1143,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
                            OpenRTM_aist.flatten(provider_types))
 
     if self._properties.hasKey("provider_types") and \
-          OpenRTM_aist.normalize([self._properties.getProperty("provider_types")]) != "all":
+          OpenRTM_aist.normalize(self._properties.getProperty("provider_types")) != "all":
       self._rtcout.RTC_DEBUG("allowed providers: %s",
                              self._properties.getProperty("provider_types"))
 
@@ -1188,7 +1187,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
                            OpenRTM_aist.flatten(consumer_types))
 
     if self._properties.hasKey("consumer_types") and \
-          OpenRTM_aist.normalize([self._properties.getProperty("consumer_types")]) != "all":
+          OpenRTM_aist.normalize(self._properties.getProperty("consumer_types")) != "all":
       self._rtcout.RTC_DEBUG("allowed consumers: %s",
                              self._properties.getProperty("consumer_types"))
 
@@ -1349,7 +1348,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
       elif consumer_ is not None:
         self._rtcout.RTC_TRACE("InPortPullConnector created")
 
-      if OpenRTM_aist.StringUtil.normalize([prop.getProperty("interface_type")]) == "direct":
+      if OpenRTM_aist.StringUtil.normalize(prop.getProperty("interface_type")) == "direct":
         if consumer_ is not None:
           outport = self.getLocalOutPort(profile)
 

--- a/OpenRTM_aist/InPortConnector.py
+++ b/OpenRTM_aist/InPortConnector.py
@@ -170,14 +170,14 @@ class InPortConnector(OpenRTM_aist.ConnectorBase):
   # Buffer からデータを InPort へ read する関数
   #
   # @else
-  # @brief Destructor
+  # @brief 
   #
   # The read function to read data from buffer to InPort
   #
   # @endif
   #
   # virtual ReturnCode read(cdrMemoryStream& data) = 0;
-  def read(self, data):
+  def read(self, data=None):
     pass
 
   # void setConnectorInfo(ConnectorInfo profile);
@@ -191,7 +191,7 @@ class InPortConnector(OpenRTM_aist.ConnectorBase):
         return RTC.RTC_ERROR
         
       endian = OpenRTM_aist.split(endian, ",") # Maybe endian is ["little","big"]
-      endian = OpenRTM_aist.normalize(endian) # Maybe self._endian is "little" or "big"
+      endian = OpenRTM_aist.normalize(endian[0]) # Maybe self._endian is "little" or "big"
 
       if endian == "little":
         self._endian = True
@@ -215,8 +215,7 @@ class InPortConnector(OpenRTM_aist.ConnectorBase):
 
   def write(self, data):
     pass
-  def read(self, data):
-    pass
+
   #
   # @if jp
   # @brief データ書き込み時のリスナ設定

--- a/OpenRTM_aist/InPortCorbaCdrConsumer.py
+++ b/OpenRTM_aist/InPortCorbaCdrConsumer.py
@@ -375,9 +375,11 @@ class InPortCorbaCdrConsumer(OpenRTM_aist.InPortConsumer,OpenRTM_aist.CorbaConsu
     
     orb = OpenRTM_aist.Manager.instance().getORB()
     var = orb.string_to_object(ior)
-    if not self._ptr(True)._is_equivalent(var):
-      self._rtcout.RTC_ERROR("connector property inconsistency")
-      return False
+    ptr = self._ptr(True)
+    if ptr:
+      if not ptr._is_equivalent(var):
+        self._rtcout.RTC_ERROR("connector property inconsistency")
+        return False
     
     self.releaseObject()
     return True

--- a/OpenRTM_aist/InPortDuplexConnector.py
+++ b/OpenRTM_aist/InPortDuplexConnector.py
@@ -125,10 +125,9 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
   #
   def readBuff(self):
     self._rtcout.RTC_TRACE("readBuff()")
-    data = [None]
     if self._consumer:
-      read_ret = self._consumer.get(data)
-      return read_ret, data[0]
+      read_ret, data = self._consumer.get()
+      return read_ret, data
     self._rtcout.RTC_ERROR("cunsumer is not set")
     return self.PORT_ERROR, None
 
@@ -165,20 +164,20 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
   # @endif
   #
   # virtual ReturnCode read(cdrMemoryStream& data);
-  def read(self, data):
+  def read(self, data=None):
     self._rtcout.RTC_TRACE("read()")
     if not self._dataType:
       return self.PRECONDITION_NOT_MET
     ret, cdr = self.readBuff()
     if ret != self.PORT_OK:
-      return ret
+      return ret, data
     else:
       ret, _data = self.deserializeData(cdr)
       if ret == self.PORT_OK:
         if type(data) == list:
-          data[0] = _data
+          data = _data
         self.onBufferRead(cdr)
-      return ret
+      return ret, data
 
 
   #

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -202,7 +202,7 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
   # @endif
   #
   # virtual ReturnCode read(cdrMemoryStream& data);
-  def read(self, data):
+  def read(self, data=None):
     self._rtcout.RTC_TRACE("InPortPullConnector.read()")
 
     if self._directOutPort is not None:
@@ -213,50 +213,49 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
         self._rtcout.RTC_TRACE("ON_SENDER_EMPTY(InPort,OutPort) ")
         self._rtcout.RTC_TRACE("callback called in direct mode.")
 
-      self._directOutPort.read(data)
-      #self._outPortListeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(self._profile, data[0])
+      data = self._directOutPort.read()
+      #self._outPortListeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(self._profile, data)
       self._rtcout.RTC_TRACE("ON_BUFFER_READ(OutPort), ")
       self._rtcout.RTC_TRACE("callback called in direct mode.")
-      #self._outPortListeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(self._profile, data[0])
+      #self._outPortListeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(self._profile, data)
       self._rtcout.RTC_TRACE("ON_SEND(OutPort), ")
       self._rtcout.RTC_TRACE("callback called in direct mode.")
-      #self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(self._profile, data[0])
+      #self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(self._profile, data)
       self._rtcout.RTC_TRACE("ON_RECEIVED(InPort), ")
       self._rtcout.RTC_TRACE("callback called in direct mode.")
-      #self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(self._profile, data[0])
+      #self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(self._profile, data)
       self._rtcout.RTC_TRACE("ON_BUFFER_WRITE(InPort), ")
       self._rtcout.RTC_TRACE("callback called in direct mode.")
-      return self.PORT_OK
+      return self.PORT_OK, data
 
 
 
     if not self._consumer:
-      return self.PORT_ERROR
+      return self.PORT_ERROR, data
 
 
 
-    cdr_data = [None]
-    ret = self._consumer.get(cdr_data)
+    ret, cdr_data = self._consumer.get()
 
     if ret == self.PORT_OK:
-      if len(data) == 0:
+      if data is None:
         self._rtcout.RTC_ERROR("argument is invalid")
-        return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET
+        return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET, data
       
       self._serializer.isLittleEndian(self._endian)
-      ser_ret, data[0] = self._serializer.deserialize(cdr_data[0], data[0])
+      ser_ret, data = self._serializer.deserialize(cdr_data, data)
       
       if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:
         self._rtcout.RTC_ERROR("unknown endian from connector")
-        return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET
+        return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET, data
       elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR:
         self._rtcout.RTC_ERROR("unknown error")
-        return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET
+        return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET, data
       elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOTFOUND:
         self._rtcout.RTC_ERROR("unknown serializer from connector")
-        return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET
+        return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET, data
     
-    return ret
+    return ret, data
 
 
   ##

--- a/OpenRTM_aist/InPortSHMConsumer.py
+++ b/OpenRTM_aist/InPortSHMConsumer.py
@@ -138,8 +138,7 @@ class InPortSHMConsumer(OpenRTM_aist.InPortCorbaCdrConsumer):
 
 
       endian = OpenRTM_aist.split(endian, ",")
-      
-      endian = OpenRTM_aist.normalize(endian)
+      endian = OpenRTM_aist.normalize(endian[0])
       if endian == "little":
         self._endian = True
       elif endian == "big":

--- a/OpenRTM_aist/LocalServiceAdmin.py
+++ b/OpenRTM_aist/LocalServiceAdmin.py
@@ -183,16 +183,16 @@ class LocalServiceAdmin:
   # @endif
   # bool getServiceProfile(std::string name,
   #                        ::RTM::LocalServiceProfile& prof);
-  def getServiceProfile(self, name, prof):
+  def getServiceProfile(self, name):
     global services_mutex
     guard_ = OpenRTM_aist.ScopedLock(services_mutex)
     for svc_ in self._services:
       if name == svc_.getProfile().name:
-        prof[0] = svc_.getProfile()
+        prof = svc_.getProfile()
         del guard_
-        return True
+        return True, prof
     del guard_
-    return False
+    return False, None
     
 
   ##

--- a/OpenRTM_aist/LogstreamFile.py
+++ b/OpenRTM_aist/LogstreamFile.py
@@ -158,17 +158,14 @@ class LogstreamFile(OpenRTM_aist.LogstreamBase):
   #
   def addHandler(self, f):
     formatter = logging.Formatter('%(asctime)s %(name)s %(levelname)s %(message)s')
-    tmp = [f]
-    OpenRTM_aist.eraseHeadBlank(tmp)
-    OpenRTM_aist.eraseTailBlank(tmp)
-    f = tmp[0]
+    f = OpenRTM_aist.eraseHeadBlank(f)
+    f = OpenRTM_aist.eraseTailBlank(f)
     handlers = self.logger.handlers
     for h in handlers:
       if h.get_name() == f:
         return False
 
-    tmp = [f]
-    fname = OpenRTM_aist.StringUtil.normalize(tmp)
+    fname = OpenRTM_aist.StringUtil.normalize(f)
       
     if fname == "stdout":
       ch = logging.StreamHandler()

--- a/OpenRTM_aist/Manager.py
+++ b/OpenRTM_aist/Manager.py
@@ -1140,20 +1140,20 @@ class Manager:
     self._rtcout.RTC_TRACE("Manager.createContext()")
     self._rtcout.RTC_TRACE("ExecutionContext type: %s",
                            self._config.getProperty("exec_cxt.periodic.type"))
-    ec_id = [""]
     ec_prop = OpenRTM_aist.Properties()
+    ret, ec_id = self.procContextArgs(ec_args, ec_prop)
 
-    if not self.procContextArgs(ec_args, ec_id, ec_prop):
+    if not ret:
       return None
 
     avail_ec_ = OpenRTM_aist.ExecutionContextFactory.instance().getIdentifiers()
 
-    if not ec_id[0] in avail_ec_:
-      self._rtcout.RTC_ERROR("Factory not found: %s", ec_id[0])
+    if not ec_id in avail_ec_:
+      self._rtcout.RTC_ERROR("Factory not found: %s", ec_id)
       return None
 
     
-    ec = OpenRTM_aist.ExecutionContextFactory.instance().createObject(ec_id[0])
+    ec = OpenRTM_aist.ExecutionContextFactory.instance().createObject(ec_id)
     ec.init(ec_prop)
     self._ecs.append(ec)
     return ec
@@ -1770,14 +1770,12 @@ class Manager:
     opt      = self._config.getProperty("corba.args")
     self._rtcout.RTC_DEBUG("corba.args: %s",opt)
 
-    endpoints = []
-    self.createORBEndpoints(endpoints)
-    opt = [opt]
-    self.createORBEndpointOption(opt,endpoints)
+    endpoints = self.createORBEndpoints()
+    opt = self.createORBEndpointOption(opt,endpoints)
 
-    self._rtcout.RTC_PARANOID("ORB options: %s", opt[0])
+    self._rtcout.RTC_PARANOID("ORB options: %s", opt)
 
-    return opt[0]
+    return opt
 
 
   ##
@@ -1798,8 +1796,8 @@ class Manager:
   # @endif
   #
   # void createORBEndpoints(coil::vstring& endpoints);
-  def createORBEndpoints(self, endpoints):
-
+  def createORBEndpoints(self):
+    endpoints = []
     # corba.endpoint is obsolete
     # corba.endpoints with comma separated values are acceptable
     if self._config.findNode("corba.endpoints"):
@@ -1830,7 +1828,7 @@ class Manager:
 
     endpoints = OpenRTM_aist.unique_sv(endpoints)
     
-    return
+    return endpoints
 
     
   ##
@@ -1861,20 +1859,20 @@ class Manager:
         endpoint += ":"
 
       if corba == "omniORB":
-        endpoint = OpenRTM_aist.normalize([endpoint])
-        if OpenRTM_aist.normalize([endpoint]) == "all:":
-          opt[0] += " -ORBendPointPublish all(addr)"
+        endpoint = OpenRTM_aist.normalize(endpoint)
+        if endpoint == "all:":
+          opt += " -ORBendPointPublish all(addr)"
         else:
-          opt[0] += " -ORBendPoint giop:tcp:" + endpoint
+          opt += " -ORBendPoint giop:tcp:" + endpoint
 
       elif corba == "TAO":
-        opt[0] += "-ORBEndPoint iiop://" + endpoint
+        opt += "-ORBEndPoint iiop://" + endpoint
       elif corba == "MICO":
-        opt[0] += "-ORBIIOPAddr inet:" + endpoint
+        opt += "-ORBIIOPAddr inet:" + endpoint
 
       endpoints[i] = endpoint
 
-    return
+    return opt
 
 
   ##
@@ -2530,18 +2528,18 @@ class Manager:
   # bool procContextArgs(const char* ec_args,
   #                      std::string& ec_id,
   #                      coil::Properties& ec_conf);
-  def procContextArgs(self, ec_args, ec_id, ec_conf):
+  def procContextArgs(self, ec_args, ec_conf):
     id_and_conf = [s.strip() for s in ec_args.split("?")]
 
     if len(id_and_conf) != 1 and len(id_and_conf) != 2:
       self._rtcout.RTC_ERROR("Invalid arguments. Two or more '?'")
-      return False
+      return False, ""
 
     if (id_and_conf[0] == "") or id_and_conf[0] is None:
       self._rtcout.RTC_ERROR("Empty ExecutionContext's name")
-      return False
+      return False, ""
 
-    ec_id[0] = id_and_conf[0]
+    ec_id = id_and_conf[0]
 
     if len(id_and_conf) == 2:
       conf = [s.strip() for s in id_and_conf[1].split("&")]
@@ -2550,7 +2548,7 @@ class Manager:
         ec_conf.setProperty(k[0],k[1])
         self._rtcout.RTC_TRACE("EC property %s: %s",(k[0],k[1]))
         
-    return True
+    return True, ec_id
 
 
   ##
@@ -2594,6 +2592,7 @@ class Manager:
         self._rtcout.RTC_ERROR(OpenRTM_aist.Logger.print_exception())
       else:
         name_prop.load(conff)
+        conff.close()
 
     if self._config.findNode(category + "." + inst_name):
       temp_ = OpenRTM_aist.Properties(prop=self._config.getNode(category+"."+inst_name))
@@ -2618,6 +2617,7 @@ class Manager:
         self._rtcout.RTC_ERROR(OpenRTM_aist.Logger.print_exception())
       else:
         type_prop.load(conff)
+        conff.close()
 
     if self._config.findNode(category + "." + type_name):
       temp_ = OpenRTM_aist.Properties(prop=self._config.getNode(category+"."+type_name))
@@ -3106,8 +3106,10 @@ class Manager:
           ports.append(p)
           continue
         tmp = k.replace("port","")
-        v = [0]
-        if OpenRTM_aist.stringTo(v, tmp) and k.find("port") != -1:
+        v = 0
+        #パラメータ名の末尾が数字の場合(port0, port1...)
+        ret, v = OpenRTM_aist.stringTo(v, tmp)
+        if ret and k.find("port") != -1:
           ports.append(p)
           continue
         configs[k] = p

--- a/OpenRTM_aist/ManagerConfig.py
+++ b/OpenRTM_aist/ManagerConfig.py
@@ -294,8 +294,8 @@ class ManagerConfig :
           self._argprop.setProperty(key,value)
 
       if opt == "-p":
-        num = [-1]
-        ret = OpenRTM_aist.stringTo(num, arg)
+        num = -1
+        ret, num = OpenRTM_aist.stringTo(num, arg)
         if ret:
           arg_ = ":" + arg
           self._argprop.setProperty("corba.endpoints",arg_)

--- a/OpenRTM_aist/ManagerServant.py
+++ b/OpenRTM_aist/ManagerServant.py
@@ -496,10 +496,8 @@ class ManagerServant(RTM__POA.Manager):
 
 
     #module_name = module_name.split("&")[0]
-    module_name = [module_name]
-    self.getParameterByModulename("manager_address",module_name)
-    manager_name = self.getParameterByModulename("manager_name",module_name)
-    module_name = module_name[0]
+    _, module_name = self.getParameterByModulename("manager_address",module_name)
+    manager_name, module_name = self.getParameterByModulename("manager_name",module_name)
 
     comp_param = CompParam(module_name)
     
@@ -1041,9 +1039,7 @@ class ManagerServant(RTM__POA.Manager):
     wait_time = 1.0
     if self._mgr.getConfig().findNode("manager.termination_waittime"):
       s = self._mgr.getConfig().getProperty("manager.termination_waittime")
-      ret = [wait_time]
-      if OpenRTM_aist.stringTo(ret, s):
-        wait_time = ret[0]
+      ret, wait_time = OpenRTM_aist.stringTo(wait_time, s)
     
     
     self._mgr.createShutdownThread(wait_time)
@@ -1172,9 +1168,7 @@ class ManagerServant(RTM__POA.Manager):
     self._rtcout.RTC_TRACE("get_components_by_name()")
     rtcs = self._mgr.getComponents()
     crtcs = []
-    tmp = [name]
-    OpenRTM_aist.eraseHeadBlank(tmp)
-    name = tmp[0]
+    name = OpenRTM_aist.eraseHeadBlank(name)
     rtc_name = name.split("/")
     for rtc in rtcs:
       if len(rtc_name) == 1:
@@ -1285,14 +1279,14 @@ class ManagerServant(RTM__POA.Manager):
   # @endif
   # std::string getParameterByModulename(string param_name, string &module_name)
   def getParameterByModulename(self, param_name, module_name):
-    arg = module_name[0]
+    arg = module_name
     pos0 = arg.find("&"+param_name+"=")
     pos1 = arg.find("?"+param_name+"=")
     
     
 
     if pos0 == -1 and pos1 == -1:
-      return ""
+      return "", module_name
 
     pos = 0
     if pos0 == -1:
@@ -1327,9 +1321,9 @@ class ManagerServant(RTM__POA.Manager):
     else:
       arg = arg[:pos] + arg[endpos:]
 
-    module_name[0] = arg
+    module_name = arg
 
-    return paramstr
+    return paramstr, module_name
 
 
     
@@ -1354,10 +1348,7 @@ class ManagerServant(RTM__POA.Manager):
     
     arg = module_name
     
-
-    tmp = [arg]
-    mgrstr = self.getParameterByModulename("manager_name",tmp)
-    arg = tmp[0]
+    mgrstr, arg = self.getParameterByModulename("manager_name",arg)
 
     if not mgrstr:
       return RTC.RTObject._nil
@@ -1525,9 +1516,7 @@ class ManagerServant(RTM__POA.Manager):
   def createComponentByAddress(self, module_name):
 
     arg = module_name
-    tmp = [arg]
-    mgrstr = self.getParameterByModulename("manager_address",tmp)
-    arg = tmp[0]
+    mgrstr, arg = self.getParameterByModulename("manager_address",arg)
 
     if not mgrstr:
       return RTC.RTObject._nil

--- a/OpenRTM_aist/ModuleManager.py
+++ b/OpenRTM_aist/ModuleManager.py
@@ -80,14 +80,10 @@ class ModuleManager:
 
     self._configPath = prop.getProperty(CONFIG_PATH).split(",")
     for i in range(len(self._configPath)):
-      tmp = [self._configPath[i]]
-      OpenRTM_aist.eraseHeadBlank(tmp)
-      self._configPath[i] = tmp[0]
+      self._configPath[i] = OpenRTM_aist.eraseHeadBlank(self._configPath[i])
     self._loadPath = prop.getProperty(MOD_LOADPTH,"./").split(",")
     for i in range(len(self._loadPath)):
-      tmp = [self._loadPath[i]]
-      OpenRTM_aist.eraseHeadBlank(tmp)
-      self._loadPath[i] = tmp[0]
+      self._loadPath[i] = OpenRTM_aist.eraseHeadBlank(self._loadPath[i])
 
     self._absoluteAllowed = OpenRTM_aist.toBool(prop.getProperty(ALLOW_ABSPATH),
                                                 "yes", "no", False)
@@ -564,9 +560,7 @@ class ModuleManager:
       self._rtcout.RTC_DEBUG("Module load path: %s", path)
       flist = []
       for suffix in suffixes:
-        tmp = [suffix]
-        OpenRTM_aist.eraseHeadBlank(tmp)
-        suffix = tmp[0]
+        suffix = OpenRTM_aist.eraseHeadBlank(suffix)
         
         tmp = []
         OpenRTM_aist.getFileList(path,suffix,tmp)
@@ -662,14 +656,10 @@ class ModuleManager:
             if r.find(":") != -1:
               count += 1
               key = r[0:pos]
-              tmp = [key]
-              OpenRTM_aist.eraseHeadBlank(tmp)
-              key = tmp[0]
+              key = OpenRTM_aist.eraseHeadBlank(key)
               
               value = r[pos+1:]
-              tmp = [value]
-              OpenRTM_aist.eraseHeadBlank(tmp)
-              value = tmp[0]
+              value = OpenRTM_aist.eraseHeadBlank(value)
 
               prop.setProperty(key, value)
           if count > 0:
@@ -750,9 +740,7 @@ class ModuleManager:
     self._rtcout.RTC_DEBUG("langs: %s",self._properties.getProperty("manager.supported_languages"))
 
     for lang in langs:
-      tmp = [lang]
-      OpenRTM_aist.eraseHeadBlank(tmp)
-      lang = tmp[0]
+      lang = OpenRTM_aist.eraseHeadBlank(lang)
       
       modules_ = []
       self.getModuleList(lang, modules_)

--- a/OpenRTM_aist/MultilayerCompositeEC.py
+++ b/OpenRTM_aist/MultilayerCompositeEC.py
@@ -435,15 +435,17 @@ class MultilayerCompositeEC(OpenRTM_aist.PeriodicExecutionContext):
     task.setPeriod(0.0)
     task.executionMeasure(OpenRTM_aist.toBool(mprop.getProperty("exec_time"),
                                                     "enable", "disable", True))
-    ecount = [0]
-    if OpenRTM_aist.stringTo(ecount, mprop.getProperty("exec_count")):
-      task.executionMeasureCount(ecount[0])
+    ecount = 0
+    ret, ecount = OpenRTM_aist.stringTo(ecount, mprop.getProperty("exec_count"))
+    if ret:
+      task.executionMeasureCount(ecount)
 
     task.periodicMeasure(OpenRTM_aist.toBool(mprop.getProperty("period_time"),
                                                    "enable", "disable", True))
-    pcount = [0]
-    if OpenRTM_aist.stringTo(pcount, mprop.getProperty("period_count")):
-      task.periodicMeasureCount(pcount[0])
+    pcount = 0
+    ret, pcount = OpenRTM_aist.stringTo(pcount, mprop.getProperty("period_count"))
+    if ret:
+      task.periodicMeasureCount(pcount)
 
     for rtc in rtcs:
       self.addRTCToTask(ct, rtc)

--- a/OpenRTM_aist/OutPort.py
+++ b/OpenRTM_aist/OutPort.py
@@ -306,22 +306,24 @@ class OutPort(OpenRTM_aist.OutPortBase):
   # @brief データをダイレクトに読み込む
   #
   # @param self
-  # @param data 読み込むデータ
+  # @return 読み込んだデータ
   #
   # @else
   # @brief 
   #
   # @param self
-  # @param data 
+  # @return
   # @endif
   # void read(const DataType& data)
-  def read(self, data):
+  def read(self):
     guard = OpenRTM_aist.ScopedLock(self._valueMutex)
     self._directNewData = False
-    data[0] = self._directValue
+    data = self._directValue
     if self._OnWriteConvert:
-      data[0] = self._OnWriteConvert(data[0])
+      data = self._OnWriteConvert(data)
     del guard
+    return data
+
   def isEmpty(self):
     return (not self._directNewData)
     

--- a/OpenRTM_aist/OutPortBase.py
+++ b/OpenRTM_aist/OutPortBase.py
@@ -365,12 +365,13 @@ class OutPortBase(OpenRTM_aist.PortBase,OpenRTM_aist.DataPortStatus):
     if self._consumerTypes and self._providerTypes:
       self.appendProperty("dataport.dataflow_type", "duplex")
 
-    num = [-1]
-    if not OpenRTM_aist.stringTo(num, self._properties.getProperty("connection_limit","-1")):
+    num = -1
+    ret, num = OpenRTM_aist.stringTo(num, self._properties.getProperty("connection_limit","-1"))
+    if not ret:
       self._rtcout.RTC_ERROR("invalid connection_limit value: %s",
                              self._properties.getProperty("connection_limit"))
 
-    self.setConnectionLimit(num[0])
+    self.setConnectionLimit(num)
     return
 
   ##
@@ -472,16 +473,16 @@ class OutPortBase(OpenRTM_aist.PortBase,OpenRTM_aist.DataPortStatus):
     
 
     _str = node.getProperty("fan_out")
-    _type = [int(100)]
+    _type = int(100)
     
-    OpenRTM_aist.stringTo(_type, _str)
+    _, _type = OpenRTM_aist.stringTo(_type, _str)
     
     
 
     _str = prop.getProperty("dataport.fan_out")
-    OpenRTM_aist.stringTo(_type, _str)
+    _, _type = OpenRTM_aist.stringTo(_type, _str)
     
-    value =  _type[0]
+    value =  _type
 
     if value <= len(self._connectors):
       return (RTC.PRECONDITION_NOT_MET, connector_profile)
@@ -650,16 +651,16 @@ class OutPortBase(OpenRTM_aist.PortBase,OpenRTM_aist.DataPortStatus):
   #
   # bool OutPortBase::getConnectorProfileById(const char* id,
   #                                           ConnectorInfo& prof)
-  def getConnectorProfileById(self, id, prof):
+  def getConnectorProfileById(self, id):
     self._rtcout.RTC_TRACE("getConnectorProfileById(id = %s)", id)
 
     conn = self.getConnectorById(id)
 
     if not conn:
-      return False
+      return False, None
 
-    prof[0] = conn.profile()
-    return True
+    prof = conn.profile()
+    return True, prof
 
 
   ##
@@ -671,16 +672,16 @@ class OutPortBase(OpenRTM_aist.PortBase,OpenRTM_aist.DataPortStatus):
   #
   # bool OutPortBase::getConnectorProfileByName(const char* name,
   #                                             ConnectorInfo& prof)
-  def getConnectorProfileByName(self, name, prof):
+  def getConnectorProfileByName(self, name):
     self._rtcout.RTC_TRACE("getConnectorProfileByName(name = %s)", name)
 
     conn = self.getConnectorByName(name)
 
     if not conn:
-      return False
+      return False, None
 
-    prof[0] = conn.profile()
-    return True
+    prof = conn.profile()
+    return True, prof
 
 
   ##
@@ -985,7 +986,7 @@ class OutPortBase(OpenRTM_aist.PortBase,OpenRTM_aist.DataPortStatus):
     # prop["dataflow_type"]: データフロータイプ
     # prop["interface_type"]: インターフェースタイプ
     # などがアクセス可能になる。
-    dflow_type = OpenRTM_aist.normalize([prop.getProperty("dataflow_type")])
+    dflow_type = OpenRTM_aist.normalize(prop.getProperty("dataflow_type"))
 
     if dflow_type == "push":
       self._rtcout.RTC_PARANOID("dataflow_type = push .... do nothing")
@@ -1066,7 +1067,7 @@ class OutPortBase(OpenRTM_aist.PortBase,OpenRTM_aist.DataPortStatus):
     # prop["interface_type"]: インターフェースタイプ
     # などがアクセス可能になる。
     #
-    dflow_type = OpenRTM_aist.normalize([prop.getProperty("dataflow_type")])
+    dflow_type = OpenRTM_aist.normalize(prop.getProperty("dataflow_type"))
     
     profile = OpenRTM_aist.ConnectorInfo(cprof.name,
                                          cprof.connector_id,
@@ -1180,7 +1181,7 @@ class OutPortBase(OpenRTM_aist.PortBase,OpenRTM_aist.DataPortStatus):
                               OpenRTM_aist.flatten(provider_types))
 
     if self._properties.hasKey("provider_types") and \
-          OpenRTM_aist.normalize([self._properties.getProperty("provider_types")]) != "all":
+          OpenRTM_aist.normalize(self._properties.getProperty("provider_types")) != "all":
       self._rtcout.RTC_DEBUG("allowed providers: %s",
                              self._properties.getProperty("provider_types"))
 
@@ -1222,7 +1223,7 @@ class OutPortBase(OpenRTM_aist.PortBase,OpenRTM_aist.DataPortStatus):
                               OpenRTM_aist.flatten(consumer_types))
 
     if self._properties.hasKey("consumer_types") and \
-          OpenRTM_aist.normalize([self._properties.getProperty("consumer_types")]) != "all":
+          OpenRTM_aist.normalize(self._properties.getProperty("consumer_types")) != "all":
       self._rtcout.RTC_DEBUG("allowed consumers: %s",
                              self._properties.getProperty("consumer_types"))
 
@@ -1358,7 +1359,7 @@ class OutPortBase(OpenRTM_aist.PortBase,OpenRTM_aist.DataPortStatus):
         self._rtcout.RTC_TRACE("OutPortPullConnector created")
 
         
-      if OpenRTM_aist.StringUtil.normalize([prop.getProperty("interface_type")]) == "direct":
+      if OpenRTM_aist.StringUtil.normalize(prop.getProperty("interface_type")) == "direct":
         if consumer_ is not None:
           inport = self.getLocalInPort(profile)
         

--- a/OpenRTM_aist/OutPortCSPConsumer.py
+++ b/OpenRTM_aist/OutPortCSPConsumer.py
@@ -146,7 +146,7 @@ class OutPortCSPConsumer(OpenRTM_aist.OutPortCorbaCdrConsumer):
   #
   # ::OpenRTM::PortStatus put()
   #  throw (CORBA::SystemException);
-  def get(self, data):
+  def get(self):
     self._rtcout.RTC_PARANOID("get()")
 
     try:
@@ -155,17 +155,17 @@ class OutPortCSPConsumer(OpenRTM_aist.OutPortCorbaCdrConsumer):
       
       if ret == OpenRTM.PORT_OK:
         self._rtcout.RTC_DEBUG("get() successful")
-        data[0] = cdr_data
-        self.onReceived(data[0])
-        self.onBufferWrite(data[0])
+        data = cdr_data
+        self.onReceived(data)
+        self.onBufferWrite(data)
 
-        return self.PORT_OK
-      return self.convertReturn(ret,data[0])
+        return self.PORT_OK, data
+      return self.convertReturn(ret,data)
 
     except:
       self._rtcout.RTC_WARN("Exception caught from OutPort.get().")
       self._rtcout.RTC_ERROR(OpenRTM_aist.Logger.print_exception())
-      return self.CONNECTION_LOST
+      return self.CONNECTION_LOST, None
 
   ##
   # @if jp

--- a/OpenRTM_aist/OutPortCSPProvider.py
+++ b/OpenRTM_aist/OutPortCSPProvider.py
@@ -158,11 +158,10 @@ class OutPortCSPProvider(OpenRTM_aist.OutPortProvider, CSP__POA.OutPortCsp):
       return (OpenRTM.UNKNOWN_ERROR, "")
 
     try:
-      cdr = [None]
-      ret = self._connector.read(cdr)
+      ret, cdr = self._connector.read()
       
       if ret == OpenRTM_aist.BufferStatus.BUFFER_OK:
-        if cdr[0] is None:
+        if cdr is None:
           self._rtcout.RTC_ERROR("buffer is empty.")
           return (OpenRTM.BUFFER_EMPTY, "")
       
@@ -170,7 +169,7 @@ class OutPortCSPProvider(OpenRTM_aist.OutPortProvider, CSP__POA.OutPortCsp):
       self._rtcout.RTC_TRACE(OpenRTM_aist.Logger.print_exception())
       return (OpenRTM.UNKNOWN_ERROR, "")
     
-    return self.convertReturn(ret, cdr[0])
+    return self.convertReturn(ret, cdr)
 
 
   ##

--- a/OpenRTM_aist/OutPortConnector.py
+++ b/OpenRTM_aist/OutPortConnector.py
@@ -138,7 +138,7 @@ class OutPortConnector(OpenRTM_aist.ConnectorBase):
         return RTC.RTC_ERROR
         
       endian = OpenRTM_aist.split(endian, ",") # Maybe endian is ["little","big"]
-      endian = OpenRTM_aist.normalize(endian) # Maybe self._endian is "little" or "big"
+      endian = OpenRTM_aist.normalize(endian[0]) # Maybe self._endian is "little" or "big"
 
       if endian == "little":
         self._endian = True
@@ -188,7 +188,7 @@ class OutPortConnector(OpenRTM_aist.ConnectorBase):
 
   def write(self, data):
     pass
-  def read(self, data):
+  def read(self, data=None):
     pass
 
   #

--- a/OpenRTM_aist/OutPortCorbaCdrProvider.py
+++ b/OpenRTM_aist/OutPortCorbaCdrProvider.py
@@ -288,11 +288,10 @@ class OutPortCorbaCdrProvider(OpenRTM_aist.OutPortProvider,
       return (OpenRTM.UNKNOWN_ERROR, "")
 
     try:
-      cdr = [None]
-      ret = self._connector.read(cdr)
+      ret, cdr = self._connector.read()
 
       if ret == OpenRTM_aist.BufferStatus.BUFFER_OK:
-        if not cdr[0]:
+        if not cdr:
           self._rtcout.RTC_ERROR("buffer is empty.")
           return (OpenRTM.BUFFER_EMPTY, "")
       
@@ -300,7 +299,7 @@ class OutPortCorbaCdrProvider(OpenRTM_aist.OutPortProvider,
       self._rtcout.RTC_TRACE(OpenRTM_aist.Logger.print_exception())
       return (OpenRTM.UNKNOWN_ERROR, "")
 
-    return self.convertReturn(ret, cdr[0])
+    return self.convertReturn(ret, cdr)
     
   ##
   # @if jp

--- a/OpenRTM_aist/OutPortDSConsumer.py
+++ b/OpenRTM_aist/OutPortDSConsumer.py
@@ -200,26 +200,26 @@ class OutPortDSConsumer(OpenRTM_aist.OutPortConsumer,OpenRTM_aist.CorbaConsumer)
       
       if ret == RTC.PORT_OK:
         self._rtcout.RTC_DEBUG("get() successful")
-        data[0] = cdr_data
-        self.onReceived(data[0])
-        self.onBufferWrite(data[0])
+        data = cdr_data
+        self.onReceived(data)
+        self.onBufferWrite(data)
         
         if self._buffer.full():
           self._rtcout.RTC_INFO("InPort buffer is full.")
-          self.onBufferFull(data[0])
-          self.onReceiverFull(data[0])
+          self.onBufferFull(data)
+          self.onReceiverFull(data)
           
-        self._buffer.put(data[0])
+        self._buffer.put(data)
         self._buffer.advanceWptr()
         self._buffer.advanceRptr()
 
-        return self.PORT_OK
-      return self.convertReturn(ret,data[0])
+        return self.PORT_OK, data
+      return self.convertReturn(ret,data)
 
     except:
       self._rtcout.RTC_WARN("Exception caught from OutPort.get().")
       self._rtcout.RTC_ERROR(OpenRTM_aist.Logger.print_exception())
-      return self.CONNECTION_LOST
+      return self.CONNECTION_LOST, None
 
 
 
@@ -336,31 +336,31 @@ class OutPortDSConsumer(OpenRTM_aist.OutPortConsumer,OpenRTM_aist.CorbaConsumer)
   def convertReturn(self, status, data):
     if status == RTC.PORT_OK:
       # never comes here
-      return self.PORT_OK
+      return self.PORT_OK, data
 
     elif status == RTC.PORT_ERROR:
       self.onSenderError()
-      return self.PORT_ERROR
+      return self.PORT_ERROR, data
 
     elif status == RTC.BUFFER_FULL:
       # never comes here
-      return self.BUFFER_FULL
+      return self.BUFFER_FULL, data
 
     elif status == RTC.BUFFER_EMPTY:
       self.onSenderEmpty()
-      return self.BUFFER_EMPTY
+      return self.BUFFER_EMPTY, data
 
     elif status == RTC.BUFFER_TIMEOUT:
       self.onSenderTimeout()
-      return self.BUFFER_TIMEOUT
+      return self.BUFFER_TIMEOUT, data
 
     elif status == RTC.UNKNOWN_ERROR:
       self.onSenderError()
-      return self.UNKNOWN_ERROR
+      return self.UNKNOWN_ERROR, data
 
     else:
       self.onSenderError()
-      return self.UNKNOWN_ERROR
+      return self.UNKNOWN_ERROR, data
 
 
 

--- a/OpenRTM_aist/OutPortDSProvider.py
+++ b/OpenRTM_aist/OutPortDSProvider.py
@@ -291,12 +291,10 @@ class OutPortDSProvider(OpenRTM_aist.OutPortProvider,
       return (RTC.UNKNOWN_ERROR, "")
 
     try:
-
-      cdr = [None]
-      ret = self._connector.read(cdr)
+      ret, cdr = self._connector.read()
 
       if ret == OpenRTM_aist.BufferStatus.BUFFER_OK:
-        if not cdr[0]:
+        if not cdr:
           self._rtcout.RTC_ERROR("buffer is empty.")
           return (RTC.BUFFER_EMPTY, "")
       
@@ -304,7 +302,7 @@ class OutPortDSProvider(OpenRTM_aist.OutPortProvider,
       self._rtcout.RTC_TRACE(OpenRTM_aist.Logger.print_exception())
       return (RTC.UNKNOWN_ERROR, "")
 
-    return self.convertReturn(ret, cdr[0])
+    return self.convertReturn(ret, cdr)
     
   ##
   # @if jp

--- a/OpenRTM_aist/OutPortDuplexConnector.py
+++ b/OpenRTM_aist/OutPortDuplexConnector.py
@@ -194,11 +194,11 @@ class OutPortDuplexConnector(OpenRTM_aist.OutPortConnector):
   #
   # @endif
   #
-  def read(self, data):
+  def read(self, data=None):
     if self._readCallback:
-      ret, data[0] = self._readCallback()
-      return ret
-    return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET
+      ret, data = self._readCallback()
+      return ret, data
+    return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET, data
 
   ##
   # @if jp

--- a/OpenRTM_aist/OutPortPullConnector.py
+++ b/OpenRTM_aist/OutPortPullConnector.py
@@ -239,7 +239,7 @@ class OutPortPullConnector(OpenRTM_aist.OutPortConnector):
       return self.UNKNOWN_ERROR
     return self.PORT_OK
 
-  def read(self, data):
+  def read(self, data=None):
 
     if self._sync_readwrite:
       self._readcompleted_worker._completed = False
@@ -257,11 +257,10 @@ class OutPortPullConnector(OpenRTM_aist.OutPortConnector):
 
     if self._buffer.empty():
       self._rtcout.RTC_ERROR("buffer is empty.")
-      data[0] = ""
-      return OpenRTM_aist.BufferStatus.BUFFER_EMPTY
+      return OpenRTM_aist.BufferStatus.BUFFER_EMPTY, ""
       
       
-    ret = self._buffer.read(data)
+    ret, data = self._buffer.read()
 
     if self._sync_readwrite:
       self._readcompleted_worker._completed = True
@@ -272,7 +271,7 @@ class OutPortPullConnector(OpenRTM_aist.OutPortConnector):
       self._readready_worker._completed = False
 
 
-    return ret
+    return ret, data
     
 
   ##

--- a/OpenRTM_aist/OutPortPushConnector.py
+++ b/OpenRTM_aist/OutPortPushConnector.py
@@ -152,7 +152,7 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
         raise
         
       endian = OpenRTM_aist.split(endian, ",") # Maybe endian is ["little","big"]
-      endian = OpenRTM_aist.normalize(endian) # Maybe self._endian is "little" or "big"
+      endian = OpenRTM_aist.normalize(endian[0]) # Maybe self._endian is "little" or "big"
       if endian == "little":
         self._endian = True
       elif endian == "big":
@@ -413,7 +413,7 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
     pub_type = info.properties.getProperty("io_mode")
     if not pub_type:
       pub_type = info.properties.getProperty("subscription_type","flush")
-      pub_type = OpenRTM_aist.normalize([pub_type])
+      pub_type = OpenRTM_aist.normalize(pub_type)
       if pub_type == "flush":
         info.properties.setProperty("io_mode","block")
       elif pub_type == "new":

--- a/OpenRTM_aist/OutPortSHMConsumer.py
+++ b/OpenRTM_aist/OutPortSHMConsumer.py
@@ -151,7 +151,7 @@ class OutPortSHMConsumer(OpenRTM_aist.OutPortCorbaCdrConsumer):
   # @endif
   #
   # virtual ReturnCode get(cdrMemoryStream& data);
-  def get(self, data):
+  def get(self):
     self._rtcout.RTC_PARANOID("get()")
     
     try:
@@ -159,6 +159,8 @@ class OutPortSHMConsumer(OpenRTM_aist.OutPortCorbaCdrConsumer):
 
       guard = OpenRTM_aist.ScopedLock(self._mutex)
       ret = portshmem.get()
+
+      data = None
       
       if ret == OpenRTM.PORT_OK:
         self._rtcout.RTC_DEBUG("get() successful")
@@ -168,26 +170,26 @@ class OutPortSHMConsumer(OpenRTM_aist.OutPortCorbaCdrConsumer):
         shm_data = self._shmem.read()
         
 
-        data[0] = shm_data
-        self.onReceived(data[0])
-        self.onBufferWrite(data[0])
+        data = shm_data
+        self.onReceived(data)
+        self.onBufferWrite(data)
         
         if self._buffer.full():
           self._rtcout.RTC_INFO("InPort buffer is full.")
-          self.onBufferFull(data[0])
-          self.onReceiverFull(data[0])
+          self.onBufferFull(data)
+          self.onReceiverFull(data)
         
-        self._buffer.put(data[0])
+        self._buffer.put(data)
         self._buffer.advanceWptr()
         self._buffer.advanceRptr()
 
-        return self.PORT_OK
-      return self.convertReturn(ret,data[0])
+        return self.PORT_OK, data
+      return self.convertReturn(ret,data)
 
     except:
       self._rtcout.RTC_WARN("Exception caught from OutPort.get().")
       self._rtcout.RTC_ERROR(OpenRTM_aist.Logger.print_exception())
-      return self.CONNECTION_LOST
+      return self.CONNECTION_LOST, None
 
 
 

--- a/OpenRTM_aist/OutPortSHMProvider.py
+++ b/OpenRTM_aist/OutPortSHMProvider.py
@@ -121,7 +121,7 @@ class OutPortSHMProvider(OpenRTM_aist.OutPortProvider,OpenRTM_aist.SharedMemory)
 
         
       endian = OpenRTM_aist.split(endian, ",")
-      endian = OpenRTM_aist.normalize(endian)
+      endian = OpenRTM_aist.normalize(endian[0])
       if endian == "little":
         self._endian = True
       elif endian == "big":
@@ -171,12 +171,10 @@ class OutPortSHMProvider(OpenRTM_aist.OutPortProvider,OpenRTM_aist.SharedMemory)
       return OpenRTM.UNKNOWN_ERROR
 
     try:
-
-      cdr = [None]
-      ret = self._connector.read(cdr)
+      ret, cdr = self._connector.read()
       
       if ret == OpenRTM_aist.BufferStatus.BUFFER_OK:
-        if cdr[0] is None:
+        if cdr is None:
           self._rtcout.RTC_ERROR("buffer is empty.")
           return OpenRTM.BUFFER_EMPTY
       
@@ -187,10 +185,10 @@ class OutPortSHMProvider(OpenRTM_aist.OutPortProvider,OpenRTM_aist.SharedMemory)
 
     self.setEndian(self._endian)
     self.create_memory(self._memory_size, self._shm_address)
-    if cdr[0]:
-      self.write(cdr[0])
+    if cdr:
+      self.write(cdr)
     
-    return self.convertReturn(ret, cdr[0])
+    return self.convertReturn(ret, cdr)
 
     
   def onBufferRead(self, data):

--- a/OpenRTM_aist/PeriodicECSharedComposite.py
+++ b/OpenRTM_aist/PeriodicECSharedComposite.py
@@ -44,10 +44,9 @@ periodicecsharedcomposite_spec = ["implementation_id", "PeriodicECSharedComposit
                                   
 
 def stringToStrVec(v, _is):
-  str = [_is]
-  OpenRTM_aist.eraseBlank(str)
-  v[0] = str[0].split(",")
-  return True
+  _str = OpenRTM_aist.eraseBlank(_is)
+  v = _str.split(",")
+  return True, v
 
 
 class setCallback(OpenRTM_aist.ConfigurationSetListener):
@@ -141,11 +140,11 @@ class PeriodicECOrganization(OpenRTM_aist.Organization_impl):
     self._rtcout.RTC_DEBUG("add_members()")
     self.updateExportedPortsList()
     for sdo in sdo_list:
-      dfc = [None]
-      if not self.sdoToDFC(sdo, dfc):
+      ret, dfc = self.sdoToDFC(sdo)
+      if not ret:
         sdo_list.remove(sdo)
         continue
-      member = self.Member(dfc[0])
+      member = self.Member(dfc)
       self.stopOwnedEC(member)
       self.addOrganizationToTarget(member)
       self.addParticipantToEC(member)
@@ -188,12 +187,12 @@ class PeriodicECOrganization(OpenRTM_aist.Organization_impl):
     self.updateExportedPortsList()
 
     for sdo in sdo_list:
-      dfc = [None]
-      if not self.sdoToDFC(sdo, dfc):
+      ret, dfc = self.sdoToDFC(sdo)
+      if not ret:
         sdo_list.remove(sdo)
         continue
       
-      member = self.Member(dfc[0])
+      member = self.Member(dfc)
       self.stopOwnedEC(member)
       self.addOrganizationToTarget(member)
       self.addParticipantToEC(member)
@@ -279,15 +278,15 @@ class PeriodicECOrganization(OpenRTM_aist.Organization_impl):
   # @endif
   #
   # bool sdoToDFC(const SDO_ptr sdo, ::OpenRTM::DataFlowComponent_ptr& dfc);
-  def sdoToDFC(self, sdo, dfc):
+  def sdoToDFC(self, sdo):
     if CORBA.is_nil(sdo):
-      return False
+      return False, None
 
-    dfc[0] = sdo._narrow(OpenRTM.DataFlowComponent)
-    if CORBA.is_nil(dfc[0]):
-      return False
+    dfc = sdo._narrow(OpenRTM.DataFlowComponent)
+    if CORBA.is_nil(dfc):
+      return False, dfc
 
-    return True
+    return True, dfc
 
 
   ##
@@ -390,10 +389,10 @@ class PeriodicECOrganization(OpenRTM_aist.Organization_impl):
     for org in orglist:
       sdos = org.get_members()
       for sdo in sdos:
-        dfc = [None]
-        if not self.sdoToDFC(sdo, dfc):
+        ret, dfc = self.sdoToDFC(sdo)
+        if not ret:
           continue
-        self.addRTCToEC(dfc[0])
+        self.addRTCToEC(dfc)
     
 
 
@@ -421,10 +420,10 @@ class PeriodicECOrganization(OpenRTM_aist.Organization_impl):
     for org in orglist:
       sdos = org.get_members()
       for sdo in sdos:
-        dfc = [None]
-        if not self.sdoToDFC(sdo, dfc):
+        ret, dfc = self.sdoToDFC(sdo)
+        if not ret:
           continue
-        self._ec.remove_component(dfc[0])
+        self._ec.remove_component(dfc)
     return
 
 

--- a/OpenRTM_aist/Properties.py
+++ b/OpenRTM_aist/Properties.py
@@ -541,16 +541,16 @@ class Properties:
       if i > num or i > (len_ - 1) or defaults[i] == "":
         break
 
-      key = [defaults[i]]
-      value = [defaults[i+1]]
+      key = defaults[i]
+      value = defaults[i+1]
 
-      OpenRTM_aist.eraseHeadBlank(key)
-      OpenRTM_aist.eraseTailBlank(key)
+      key = OpenRTM_aist.eraseHeadBlank(key)
+      key = OpenRTM_aist.eraseTailBlank(key)
 
-      OpenRTM_aist.eraseHeadBlank(value)
-      OpenRTM_aist.eraseTailBlank(value)
+      value = OpenRTM_aist.eraseHeadBlank(value)
+      value = OpenRTM_aist.eraseTailBlank(value)
 
-      self.setDefault(key[0], value[0])
+      self.setDefault(key, value)
 
       i +=2
 
@@ -754,9 +754,7 @@ class Properties:
       if not readStr:
         continue
       
-      tmp = [readStr]
-      OpenRTM_aist.eraseHeadBlank(tmp)
-      _str = tmp[0]
+      _str = OpenRTM_aist.eraseHeadBlank(readStr)
       
       if _str[0] == "#" or _str[0] == "!" or _str[0] == "\n" or (_str[0] == "\r" and _str[1] == "\n"):
         continue
@@ -768,11 +766,7 @@ class Properties:
         continue
 
       if _str[len(_str)-1] == "\\" and not OpenRTM_aist.isEscaped(_str, len(_str)-1):
-        #_str = _str[0:len(_str)-1]
-        tmp = [_str[0:len(_str)-1]]
-        OpenRTM_aist.eraseTailBlank(tmp)
-        #pline += _str
-        pline += tmp[0]
+        pline += OpenRTM_aist.eraseTailBlank(_str[0:len(_str)-1])
         continue
       pline += _str
       #if pline == "":

--- a/OpenRTM_aist/PublisherNew.py
+++ b/OpenRTM_aist/PublisherNew.py
@@ -121,7 +121,7 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     push_policy = prop.getProperty("publisher.push_policy","new")
     self._rtcout.RTC_DEBUG("push_policy: %s", push_policy)
 
-    push_policy = OpenRTM_aist.normalize([push_policy])
+    push_policy = OpenRTM_aist.normalize(push_policy)
 
     if push_policy == "all":
       self._pushPolicy = self.PUBLISHER_POLICY_ALL
@@ -142,10 +142,10 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     skip_count = prop.getProperty("publisher.skip_count","0")
     self._rtcout.RTC_DEBUG("skip_count: %s", skip_count)
 
-    skipn = [self._skipn]
-    ret = OpenRTM_aist.stringTo(skipn, skip_count)
+    skipn = self._skipn
+    ret, skipn = OpenRTM_aist.stringTo(skipn, skip_count)
     if ret:
-      self._skipn = skipn[0]
+      self._skipn = skipn
     else:
       self._rtcout.RTC_ERROR("invalid skip_count value: %s", skip_count)
       self._skipn = 0
@@ -186,15 +186,17 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     self._task.setPeriod(0.0)
     self._task.executionMeasure(OpenRTM_aist.toBool(mprop.getProperty("exec_time"),
                                                     "enable", "disable", True))
-    ecount = [0]
-    if OpenRTM_aist.stringTo(ecount, mprop.getProperty("exec_count")):
-      self._task.executionMeasureCount(ecount[0])
+    ecount = 0
+    ret, ecount = OpenRTM_aist.stringTo(ecount, mprop.getProperty("exec_count"))
+    if ret:
+      self._task.executionMeasureCount(ecount)
 
     self._task.periodicMeasure(OpenRTM_aist.toBool(mprop.getProperty("period_time"),
                                                    "enable", "disable", True))
-    pcount = [0]
-    if OpenRTM_aist.stringTo(pcount, mprop.getProperty("period_count")):
-      self._task.periodicMeasureCount(pcount[0])
+    pcount = 0
+    ret, pcount = OpenRTM_aist.stringTo(pcount, mprop.getProperty("period_count"))
+    if ret:
+      self._task.periodicMeasureCount(pcount)
 
     self._task.suspend()
     self._task.activate()
@@ -617,7 +619,7 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     try:
 
       while self._buffer.readable() > 0:
-        cdr = self._buffer.get()
+        _, cdr = self._buffer.get()
         self.onBufferRead(cdr)
 
         self.onSend(cdr)
@@ -645,7 +647,7 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     self._rtcout.RTC_TRACE("pushFifo()")
 
     try:
-      cdr = self._buffer.get()
+      _, cdr = self._buffer.get()
       self.onBufferRead(cdr)
 
       self.onSend(cdr)
@@ -680,7 +682,7 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
 
       for i in range(int(loopcnt)):
         self._buffer.advanceRptr(postskip)
-        cdr = self._buffer.get()
+        _, cdr = self._buffer.get()
         self.onBufferRead(cdr)
 
         self.onSend(cdr)
@@ -723,7 +725,7 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     try:
       self._buffer.advanceRptr(self._buffer.readable() - 1)
         
-      cdr = self._buffer.get()
+      _, cdr = self._buffer.get()
       self.onBufferRead(cdr)
 
       self.onSend(cdr)

--- a/OpenRTM_aist/PublisherPeriodic.py
+++ b/OpenRTM_aist/PublisherPeriodic.py
@@ -126,7 +126,7 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     push_policy = prop.getProperty("publisher.push_policy","new")
     self._rtcout.RTC_DEBUG("push_policy: %s", push_policy)
 
-    push_policy = OpenRTM_aist.normalize([push_policy])
+    push_policy = OpenRTM_aist.normalize(push_policy)
 
     if push_policy == "all":
       self._pushPolicy = self.PUBLISHER_POLICY_ALL
@@ -147,10 +147,10 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     skip_count = prop.getProperty("publisher.skip_count","0")
     self._rtcout.RTC_DEBUG("skip_count: %s", skip_count)
 
-    skipn = [self._skipn]
-    ret = OpenRTM_aist.stringTo(skipn, skip_count)
+    skipn = self._skipn
+    ret, skipn = OpenRTM_aist.stringTo(skipn, skip_count)
     if ret:
-      self._skipn = skipn[0]
+      self._skipn = skipn
     else:
       self._rtcout.RTC_ERROR("invalid skip_count value: %s", skip_count)
       self._skipn = 0
@@ -205,16 +205,18 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     self._task.executionMeasure(OpenRTM_aist.toBool(mprop.getProperty("exec_time"),
                                                     "enable", "disable", True))
     
-    ecount = [0]
-    if OpenRTM_aist.stringTo(ecount, mprop.getProperty("exec_count")):
-      self._task.executionMeasureCount(ecount[0])
+    ecount = 0
+    ret, ecount = OpenRTM_aist.stringTo(ecount, mprop.getProperty("exec_count"))
+    if ret:
+      self._task.executionMeasureCount(ecount)
 
     self._task.periodicMeasure(OpenRTM_aist.toBool(mprop.getProperty("period_time"),
                                                    "enable", "disable", True))
 
-    pcount = [0]
-    if OpenRTM_aist.stringTo(pcount, mprop.getProperty("period_count")):
-      self._task.periodicMeasureCount(pcount[0])
+    pcount = 0
+    ret, ecount = OpenRTM_aist.stringTo(pcount, mprop.getProperty("period_count"))
+    if ret:
+      self._task.periodicMeasureCount(pcount)
 
     # Start task in suspended mode
     self._task.suspend()
@@ -654,7 +656,7 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
       return self.BUFFER_EMPTY
 
     while self._buffer.readable() > 0:
-      cdr = self._buffer.get()
+      _, cdr = self._buffer.get()
       self.onBufferRead(cdr)
 
       self.onSend(cdr)
@@ -682,7 +684,7 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     if self.bufferIsEmpty():
       return self.BUFFER_EMPTY
 
-    cdr = self._buffer.get()
+    _, cdr = self._buffer.get()
     self.onBufferRead(cdr)
 
     self.onSend(cdr)
@@ -716,7 +718,7 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     postskip = self._skipn - self._leftskip
     for i in range(int(loopcnt)):
       self._buffer.advanceRptr(postskip)
-      cdr = self._buffer.get()
+      _, cdr = self._buffer.get()
       self.onBufferRead(cdr)
 
       self.onSend(cdr)
@@ -753,7 +755,7 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
 
     self._buffer.advanceRptr(self._buffer.readable() - 1)
     
-    cdr = self._buffer.get()
+    _, cdr = self._buffer.get()
     self.onBufferRead(cdr)
 
     self.onSend(cdr)

--- a/OpenRTM_aist/RTObject.py
+++ b/OpenRTM_aist/RTObject.py
@@ -5107,7 +5107,7 @@ class RTObject_impl:
     default_opts_ = OpenRTM_aist.Properties()
     self.getInheritedECOptions(default_opts_)
     for ec_tmp in ecs_tmp_:
-      if OpenRTM_aist.normalize([ec_tmp]) == "none":
+      if OpenRTM_aist.normalize(ec_tmp) == "none":
         self._rtcout.RTC_INFO("EC none. EC will not be bound to the RTC.")
         ec_args = []
         return RTC.RTC_OK

--- a/OpenRTM_aist/RTObjectBase.py
+++ b/OpenRTM_aist/RTObjectBase.py
@@ -5042,7 +5042,7 @@ class RTObjectBase:
     default_opts_ = OpenRTM_aist.Properties()
     self.getInheritedECOptions(default_opts_)
     for ec_tmp in ecs_tmp_:
-      if OpenRTM_aist.normalize([ec_tmp]) == "none":
+      if OpenRTM_aist.normalize(ec_tmp) == "none":
         self._rtcout.RTC_INFO("EC none. EC will not be bound to the RTC.")
         ec_args = []
         return RTC.RTC_OK

--- a/OpenRTM_aist/StaticFSM.py
+++ b/OpenRTM_aist/StaticFSM.py
@@ -256,7 +256,7 @@ class Machine(OpenRTM_aist.Macho.Machine):
   #
   def run_event(self):
     while self._buffer.readable() > 0:
-      event = self._buffer.get()
+      _, event = self._buffer.get()
       event()
       self._buffer.advanceRptr()
 

--- a/OpenRTM_aist/StaticFSM_pyfsm.py
+++ b/OpenRTM_aist/StaticFSM_pyfsm.py
@@ -79,7 +79,7 @@ class Machine(pyfsm.Machine):
     return self._rtComponent
   def run_event(self):
     while self._buffer.readable() > 0:
-      event = self._buffer.get()
+      _, event = self._buffer.get()
       event()
       self._buffer.advanceRptr()
 

--- a/OpenRTM_aist/StringUtil.py
+++ b/OpenRTM_aist/StringUtil.py
@@ -224,11 +224,9 @@ def unescape(_str):
 #
 # @endif
 #
-def eraseBlank(str):
-    if len(str) == 0:
-        return
-    str[0] = str[0].strip(" ")
-    l_str = str[0].split(" ")
+def eraseBlank(_str):
+    _str = _str.strip(" ")
+    l_str = _str.split(" ")
     tmp_str = ""
     for s in l_str:
         if s:
@@ -241,7 +239,8 @@ def eraseBlank(str):
         if s:
             tmp_str+=s.strip('\t')
 
-    str[0] = tmp_str
+    _str = tmp_str
+    return _str
 
 
 ##
@@ -257,8 +256,8 @@ def eraseBlank(str):
 # @brief Erase the head blank characters of string
 # @endif
 def eraseHeadBlank(_str):
-  _str[0] = _str[0].lstrip('\t ')
-
+  _str = _str.lstrip('\t ')
+  return _str
 
 ##
 # @if jp
@@ -273,13 +272,13 @@ def eraseHeadBlank(_str):
 # @brief Erase the tail blank characters of string
 # @endif
 def eraseTailBlank(_str):
-  #_str[0] = _str[0].rstrip('\t ')
-  if _str[0] == "":
-    return
+  #_str = _str.rstrip('\t ')
+  if _str == "":
+    return _str
 
-  while (_str[0][-1] == " " or _str[0][-1] == '\t') and not isEscaped(_str[0], len(_str[0]) - 1):
-    _str[0] = _str[0][:-1]
-
+  while (_str[-1] == " " or _str[-1] == '\t') and not isEscaped(_str, len(_str) - 1):
+    _str = _str[:-1]
+  return _str
 
 #
 # @if jp
@@ -289,8 +288,8 @@ def eraseTailBlank(_str):
 # @endif
 #
 def normalize(_str):
-  _str[0] = _str[0].strip().lower()
-  return _str[0]
+  _str = _str.strip().lower()
+  return _str
 
 
 ##
@@ -302,12 +301,13 @@ def normalize(_str):
 # @param str 置き換え処理対象文字列
 # @param _from 置換元文字
 # @param _to 置換先文字
+# @return 置き換え結果文字列
 #
 # @else
 # @brief Replace string
 # @endif
-def replaceString(str, _from, _to):
-  str[0] = str[0].replace(_from, _to)
+def replaceString(_str, _from, _to):
+  return _str.replace(_from, _to)
 
 
 ##
@@ -337,10 +337,10 @@ def split(input, delimiter):
     if del_result[i] == "" or del_result[i] == " ":
       continue
       
-    str_ = [del_result[i]]
-    eraseHeadBlank(str_)
-    eraseTailBlank(str_)
-    result.append(str_[0])
+    str_ = del_result[i]
+    str_ = eraseHeadBlank(str_)
+    str_ = eraseTailBlank(str_)
+    result.append(str_)
     
   return result
 
@@ -500,7 +500,6 @@ def otos(n):
 #
 # 引数で指定された文字列を｢,｣で分割し、リストに変換する。
 #
-# @param _type 変換結果リスト
 # @param _str 変換元文字列
 #
 # @return リスト変換処理結果
@@ -512,36 +511,34 @@ def _stringToList(_type, _str):
   list_ = split(_str,",")
   len_ = len(list_)
 
-  if len(_type[0]) < len(list_):
-    sub = len(list_) - len(_type[0])
+  if len(_type) < len(list_):
+    sub = len(list_) - len(_type)
     for i in range(sub):
-      _type[0].append(_type[0][0])
-  elif len(_type[0]) > len(list_):
-    sub = len(_type[0]) - len(list_)
+      _type.append(_type[0])
+  elif len(_type) > len(list_):
+    sub = len(_type) - len(list_)
     for i in range(sub):
-      del _type[0][-1]
+      del _type[-1]
 
   for i in range(len_):
-    str_ = [list_[i]]
-    eraseHeadBlank(str_)
-    eraseTailBlank(str_)
-    list_[i] = str_[0]
+    list_[i] = eraseHeadBlank(list_[i])
+    list_[i] = eraseTailBlank(list_[i])
 
   for i in range(len(list_)):
-    if type(_type[0][i]) == int:
-      _type[0][i] = int(list_[i])
-    elif type(_type[0][i]) == long:
-      _type[0][i] = long(list_[i])
-    elif type(_type[0][i]) == float:
-      _type[0][i] = float(list_[i])
-    elif type(_type[0][i]) == str:
-      _type[0][i] = str(list_[i])
+    if type(_type[i]) == int:
+      _type[i] = int(list_[i])
+    elif type(_type[i]) == long:
+      _type[i] = long(list_[i])
+    elif type(_type[i]) == float:
+      _type[i] = float(list_[i])
+    elif type(_type[i]) == str:
+      _type[i] = str(list_[i])
     
       
     else:
-      return False
+      return False, _type
 
-  return True
+  return True, _type
 
 
 ##
@@ -550,7 +547,6 @@ def _stringToList(_type, _str):
 #
 # 引数で与えられた文字列を指定されたオブジェクトに変換する。
 #
-# @param _type 変換先オブジェクト
 # @param _str 変換元文字列
 #
 # @return 変換処理実行結果
@@ -560,30 +556,30 @@ def _stringToList(_type, _str):
 # @endif
 def stringTo(_type, _str):
   if not _str:
-    return False
+    return False, _type
 
   try:
-    if type(_type[0]) == int:
-      _type[0] = int(_str)
-      return True
-    elif type(_type[0]) == long:
-      _type[0] = long(_str)
-      return True
-    elif type(_type[0]) == float:
-      _type[0] = float(_str)
-      return True
-    elif type(_type[0]) == list:
+    if type(_type) == int:
+      _type = int(_str)
+      return True, _type
+    elif type(_type) == long:
+      _type = long(_str)
+      return True, _type
+    elif type(_type) == float:
+      _type = float(_str)
+      return True, _type
+    elif type(_type) == list:
       return _stringToList(_type, _str)
-    elif type(_type[0]) == str:
-      _type[0] = str(_str)
-      return True
+    elif type(_type) == str:
+      _type = str(_str)
+      return True, _type
 
   #except ValueError:
-  #  return False
+  #  return False, _type
   except:
-    return False
+    return False, _type
   
-  return False
+  return False, _type
 
 
 ##
@@ -764,14 +760,14 @@ def replaceEnv(_str):
 #
 # @endif
 def findFile(dir, filename, filelist):
-	dirs = glob.glob(os.path.join(dir,"*"))
-	for d in dirs:
-		if os.path.isdir(d):
-			findFile(d, filename, filelist)
-	files = glob.glob(os.path.join(dir,filename))
-	for f in files:
-		if os.path.isfile(d):
-			filelist.append(f)
+    dirs = glob.glob(os.path.join(dir,"*"))
+    for d in dirs:
+        if os.path.isdir(d):
+            findFile(d, filename, filelist)
+        files = glob.glob(os.path.join(dir,filename))
+        for f in files:
+            if os.path.isfile(d):
+                filelist.append(f)
 
 
 ##
@@ -793,12 +789,15 @@ def findFile(dir, filename, filelist):
 #
 #
 # @endif
-def getFileList(dir, ext, filelist):
+def getFileList(dir, ext, filelist=None):
+    if filelist is None:
+        filelist = []
     dirs = glob.glob(os.path.join(dir,"*"))
     for d in dirs:
         if os.path.isdir(d):
-          getFileList(d, ext, filelist)
+            filelist = getFileList(d, ext, filelist)
     files = glob.glob(os.path.join(dir,"*."+ext))
     for f in files:
         if os.path.isfile(f):
-          filelist.append(f)
+            filelist.append(f)
+    return filelist

--- a/OpenRTM_aist/ext/local_service/nameservice_file/FileNameservice.py
+++ b/OpenRTM_aist/ext/local_service/nameservice_file/FileNameservice.py
@@ -317,9 +317,8 @@ class FileNameservice(OpenRTM_aist.LocalServiceBase):
     if fs_ == "flat":
       self._rtcout.RTC_DEBUG("file_structure = flat")
       d_ = self._profile.properties.getProperty("context_delimiter")
-      ns_path_ = [path]
-      OpenRTM_aist.replaceString(ns_path_, "/", d_)
-      pathstring_ += ns_path_[0]
+      ns_path_ = OpenRTM_aist.replaceString(path, "/", d_)
+      pathstring_ += ns_path_
 
     elif fs_ == "tree":
       self._rtcout.RTC_DEBUG("file_structure = tree")


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#46 
C++版のOpenRTM-aistが元になっているせいか、Pythonらしくないコードが多々あるため見直す。

## Description of the Change

一旦リストに格納後に引数に入力して参照渡しのように使っている場合は以下のように記述していた。

```Python
skipn = [self._skipn]
ret = OpenRTM_aist.stringTo(skipn, skip_count)
```

これは以下のように複数戻り値を返せば1行で書けるため該当箇所は修正した。

```Python
ret, skipn = OpenRTM_aist.stringTo(self._skipn, skip_count)
```

ただし、以下の場合については修正せずにそのままにしてある。

1. コンフィギュレーションパラメータの変数のように共有する必要がある場合。
2. 変更すると複雑化する場合
TimeMeasureクラスのgetStatistics関数は変更すると難しくなるためそのままにしてあります。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
