### PR TITLE
コネクタリスナの仕様を変更

### DIFF
--- a/OpenRTM_aist/ComponentActionListener.py
+++ b/OpenRTM_aist/ComponentActionListener.py
@@ -34,7 +34,7 @@
 # - PRE_ON_RATE_CHANGED:  onRateChanged 直前
 #
 # @else
-# @brief The types of ConnectorDataListener
+# @brief The types of PreComponentActionListenerType
 #
 # @endif
 class PreComponentActionListenerType:
@@ -202,7 +202,7 @@ class PreComponentActionListener:
 # - POST_ON_RATE_CHANGED:
 #
 # @else
-# @brief The types of ConnectorDataListener
+# @brief The types of PostComponentActionListenerType
 #
 # @endif
 class PostComponentActionListenerType:

--- a/OpenRTM_aist/ConfigurationListener.py
+++ b/OpenRTM_aist/ConfigurationListener.py
@@ -21,7 +21,7 @@
 # - ON_UPDATE_CONFIG_PARAM,
 #
 # @else
-# @brief The types of ConnectorDataListener
+# @brief The types of ConfigurationParamListenerType
 #
 # - ON_UPDATE_CONFIG_PARAM,
 #

--- a/OpenRTM_aist/EventPort.py
+++ b/OpenRTM_aist/EventPort.py
@@ -240,13 +240,13 @@ class EventBinder0(OpenRTM_aist.ConnectorDataListener):
     # @endif
     #
 
-    def __call__(self, info, data):
+    def __call__(self, info, cdrdata):
         if info.properties.getProperty(
                 "fsm_event_name") == self._eventName or info.name == self._eventName:
             self._buffer.write(Event0(self))
 
-            return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE
-        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE
+            return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE, cdrdata
+        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE, cdrdata
 
     ##
     # @if jp
@@ -291,7 +291,7 @@ class EventBinder0(OpenRTM_aist.ConnectorDataListener):
 #
 # @endif
 #
-class EventBinder1(OpenRTM_aist.ConnectorDataListenerT):
+class EventBinder1(OpenRTM_aist.ConnectorDataListener):
     ##
     # @if jp
     #
@@ -364,14 +364,14 @@ class EventBinder1(OpenRTM_aist.ConnectorDataListenerT):
     #
     # @endif
     #
-    def __call__(self, info, data):
+    def __call__(self, info, cdrdata):
         data_ = OpenRTM_aist.ConnectorDataListenerT.__call__(
-            self, info, data, self._data_type, OpenRTM_aist.PortType.InPortType)
+            self, info, cdrdata, self._data_type, OpenRTM_aist.PortType.InPortType)
         if info.properties.getProperty(
                 "fsm_event_name") == self._eventName or info.name == self._eventName:
             self._buffer.write(Event1(self, data_))
-            return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE
-        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE
+            return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE, cdrdata
+        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE, cdrdata
 
     ##
     # @if jp

--- a/OpenRTM_aist/EventPort_pyfsm.py
+++ b/OpenRTM_aist/EventPort_pyfsm.py
@@ -45,18 +45,19 @@ class EventBinder0(OpenRTM_aist.ConnectorDataListener):
     def __del__(self):
         pass
 
-    def __call__(self, info, data):
+    def __call__(self, info, cdrdata):
         if info.properties.getProperty(
                 "fsm_event_name") == self._eventName or info.name == self._eventName:
             self._buffer.write(Event0(self))
-            return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE
-        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE
+
+            return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE, cdrdata
+        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE, cdrdata
 
     def run(self):
         self._fsm.dispatch(pyfsm.Event(self._handler))
 
 
-class EventBinder1(OpenRTM_aist.ConnectorDataListenerT):
+class EventBinder1(OpenRTM_aist.ConnectorDataListener):
     def __init__(self, fsm, event_name, handler, data_type, buffer):
         self._fsm = fsm
         self._eventName = event_name
@@ -67,15 +68,14 @@ class EventBinder1(OpenRTM_aist.ConnectorDataListenerT):
     def __del__(self):
         pass
 
-    def __call__(self, info, data):
+    def __call__(self, info, cdrdata):
         data_ = OpenRTM_aist.ConnectorDataListenerT.__call__(
-            self, info, data, self._data_type, OpenRTM_aist.PortType.InPortType)
-
+            self, info, cdrdata, self._data_type, OpenRTM_aist.PortType.InPortType)
         if info.properties.getProperty(
                 "fsm_event_name") == self._eventName or info.name == self._eventName:
             self._buffer.write(Event1(self, data_))
-            return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE
-        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE
+            return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE, cdrdata
+        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE, cdrdata
 
     def run(self, data):
         self._fsm.dispatch(pyfsm.Event(self._handler, data_))

--- a/OpenRTM_aist/FsmActionListener.py
+++ b/OpenRTM_aist/FsmActionListener.py
@@ -64,7 +64,7 @@ import OpenRTM_aist.Guard
 # - PRE_ON_STATE_CHANGE:  状態遷移直前
 #
 # @else
-# @brief The types of ConnectorDataListener
+# @brief The types of PreFsmActionListenerType
 #
 # PreFsmActionListener has the following hook points. If these
 # listeners are actually called or not called are depends on FSM
@@ -318,7 +318,7 @@ class PreFsmActionListener:
 # - POST_ON_STATE_CHANGE:  状態遷移直後
 #
 # @else
-# @brief The types of ConnectorDataListener
+# @brief The types of PostFsmActionListenerType
 #
 # PreFsmActionListener has the following hook points. If these
 # listeners are actually called or not called are depends on FSM

--- a/OpenRTM_aist/InPort.py
+++ b/OpenRTM_aist/InPort.py
@@ -94,6 +94,9 @@ class InPort(OpenRTM_aist.InPortBase):
         self._directNewData = False
         self._valueMutex = threading.RLock()
 
+        self._listeners.setDataType(copy.deepcopy(value))
+        self._listeners.setPortType(OpenRTM_aist.PortType.InPortType)
+
         self.addConnectorDataListener(
             OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED,
             OpenRTM_aist.Timestamp("on_received"))

--- a/OpenRTM_aist/InPortCSPProvider.py
+++ b/OpenRTM_aist/InPortCSPProvider.py
@@ -156,7 +156,7 @@ class InPortCSPProvider(OpenRTM_aist.InPortProvider, CSP__POA.InPortCsp):
 
             self._rtcout.RTC_PARANOID("received data size: %d", len(data))
 
-            self.onReceived(data)
+            data = self.onReceived(data)
 
             ret = self._connector.write(data)
 
@@ -193,38 +193,38 @@ class InPortCSPProvider(OpenRTM_aist.InPortProvider, CSP__POA.InPortCsp):
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
                 self._profile, data)
-        return
+        return data
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
@@ -235,17 +235,17 @@ class InPortCSPProvider(OpenRTM_aist.InPortProvider, CSP__POA.InPortCsp):
 
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
                 self._profile, data)
-        return
+        return data
 
     def convertReturn(self, status, data):
         if status == OpenRTM_aist.BufferStatus.BUFFER_OK:
@@ -257,7 +257,7 @@ class InPortCSPProvider(OpenRTM_aist.InPortProvider, CSP__POA.InPortCsp):
             return OpenRTM.PORT_ERROR
 
         elif status == OpenRTM_aist.BufferStatus.BUFFER_FULL:
-            self.onBufferFull(data)
+            data = self.onBufferFull(data)
             self.onReceiverFull(data)
             return OpenRTM.BUFFER_FULL
 
@@ -269,7 +269,7 @@ class InPortCSPProvider(OpenRTM_aist.InPortProvider, CSP__POA.InPortCsp):
             return OpenRTM.PORT_ERROR
 
         elif status == OpenRTM_aist.BufferStatus.TIMEOUT:
-            self.onBufferWriteTimeout(data)
+            data = self.onBufferWriteTimeout(data)
             self.onReceiverTimeout(data)
             return OpenRTM.BUFFER_TIMEOUT
 

--- a/OpenRTM_aist/InPortCorbaCdrProvider.py
+++ b/OpenRTM_aist/InPortCorbaCdrProvider.py
@@ -178,7 +178,7 @@ class InPortCorbaCdrProvider(OpenRTM_aist.InPortProvider,
 
             self._rtcout.RTC_PARANOID("received data size: %d", len(data))
 
-            self.onReceived(data)
+            data = self.onReceived(data)
 
             ret = self._connector.write(data)
 
@@ -198,7 +198,7 @@ class InPortCorbaCdrProvider(OpenRTM_aist.InPortProvider,
             return OpenRTM.PORT_ERROR
 
         elif status == OpenRTM_aist.BufferStatus.BUFFER_FULL:
-            self.onBufferFull(data)
+            data = self.onBufferFull(data)
             self.onReceiverFull(data)
             return OpenRTM.BUFFER_FULL
 
@@ -210,7 +210,7 @@ class InPortCorbaCdrProvider(OpenRTM_aist.InPortProvider,
             return OpenRTM.PORT_ERROR
 
         elif status == OpenRTM_aist.BufferStatus.TIMEOUT:
-            self.onBufferWriteTimeout(data)
+            data = self.onBufferWriteTimeout(data)
             self.onReceiverTimeout(data)
             return OpenRTM.BUFFER_TIMEOUT
 
@@ -225,63 +225,63 @@ class InPortCorbaCdrProvider(OpenRTM_aist.InPortProvider,
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferFull(const cdrMemoryStream& data)
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferWriteTimeout(const cdrMemoryStream& data)
 
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferWriteOverwrite(const cdrMemoryStream& data)
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceived(const cdrMemoryStream& data)
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverFull(const cdrMemoryStream& data)
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
 
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverError(const cdrMemoryStream& data)
 
@@ -290,7 +290,7 @@ class InPortCorbaCdrProvider(OpenRTM_aist.InPortProvider,
             self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
                 self._profile, data)
-        return
+        return data
 
 
 def InPortCorbaCdrProviderInit():

--- a/OpenRTM_aist/InPortDSProvider.py
+++ b/OpenRTM_aist/InPortDSProvider.py
@@ -181,7 +181,7 @@ class InPortDSProvider(OpenRTM_aist.InPortProvider,
 
             self._rtcout.RTC_PARANOID("received data size: %d", len(data))
 
-            self.onReceived(data)
+            data = self.onReceived(data)
 
             ret = self._connector.write(data)
 
@@ -201,7 +201,7 @@ class InPortDSProvider(OpenRTM_aist.InPortProvider,
             return RTC.PORT_ERROR
 
         elif status == OpenRTM_aist.BufferStatus.BUFFER_FULL:
-            self.onBufferFull(data)
+            data = self.onBufferFull(data)
             self.onReceiverFull(data)
             return RTC.BUFFER_FULL
 
@@ -213,7 +213,7 @@ class InPortDSProvider(OpenRTM_aist.InPortProvider,
             return RTC.PORT_ERROR
 
         elif status == OpenRTM_aist.BufferStatus.TIMEOUT:
-            self.onBufferWriteTimeout(data)
+            data = self.onBufferWriteTimeout(data)
             self.onReceiverTimeout(data)
             return RTC.BUFFER_TIMEOUT
 
@@ -228,72 +228,72 @@ class InPortDSProvider(OpenRTM_aist.InPortProvider,
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferFull(const cdrMemoryStream& data)
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferWriteTimeout(const cdrMemoryStream& data)
 
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferWriteOverwrite(const cdrMemoryStream& data)
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceived(const cdrMemoryStream& data)
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverFull(const cdrMemoryStream& data)
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
 
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverError(const cdrMemoryStream& data)
 
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
                 self._profile, data)
-        return
+        return data
 
 
 def InPortDSProviderInit():

--- a/OpenRTM_aist/InPortDirectProvider.py
+++ b/OpenRTM_aist/InPortDirectProvider.py
@@ -119,72 +119,72 @@ class InPortDirectProvider(OpenRTM_aist.InPortProvider):
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferFull(const cdrMemoryStream& data)
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferWriteTimeout(const cdrMemoryStream& data)
 
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferWriteOverwrite(const cdrMemoryStream& data)
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceived(const cdrMemoryStream& data)
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverFull(const cdrMemoryStream& data)
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
 
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverError(const cdrMemoryStream& data)
 
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
                 self._profile, data)
-        return
+        return data
 
 
 def InPortDirectProviderInit():

--- a/OpenRTM_aist/InPortDuplexConnector.py
+++ b/OpenRTM_aist/InPortDuplexConnector.py
@@ -173,9 +173,9 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
         if ret != self.PORT_OK:
             return ret, data
         else:
+            cdr = self.onBufferRead(cdr)
             ret, _data = self.deserializeData(cdr)
-            if ret == self.PORT_OK:
-                self.onBufferRead(cdr)
+                
             return ret, _data
 
     #
@@ -414,9 +414,9 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
 
     def onBufferRead(self, data):
         if self._listeners and self._profile:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(self._profile, data)
-        return
+        return data
 
     def onBufferEmpty(self, data):
         if self._listeners and self._profile:

--- a/OpenRTM_aist/InPortPushConnector.py
+++ b/OpenRTM_aist/InPortPushConnector.py
@@ -232,11 +232,11 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
             return self.PORT_OK, cdr
 
         if ret == OpenRTM_aist.BufferStatus.BUFFER_EMPTY:
-            self.onBufferEmpty(cdr)
+            cdr = self.onBufferEmpty(cdr)
             return self.BUFFER_EMPTY, cdr
 
         elif ret == OpenRTM_aist.BufferStatus.TIMEOUT:
-            self.onBufferReadTimeout(cdr)
+            cdr = self.onBufferReadTimeout(cdr)
             return self.BUFFER_TIMEOUT, cdr
 
         elif ret == OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET:
@@ -288,12 +288,12 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
         if ret != self.PORT_OK:
             return ret, data
         else:
+            cdr = self.onBufferRead(cdr)
             self._serializer.isLittleEndian(self._endian)
             ser_ret, _data = self._serializer.deserialize(cdr, self._dataType)
 
             if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK:
                 data = _data
-                self.onBufferRead(cdr)
                 return self.PORT_OK, data
             elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:
                 self._rtcout.RTC_ERROR("unknown endian from connector")
@@ -502,10 +502,10 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
 
     def onBufferRead(self, data):
         if self._listeners and self._profile:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(
                 self._profile, data)
-        return
+        return data
 
     def onBufferEmpty(self, data):
         if self._listeners and self._profile:

--- a/OpenRTM_aist/InPortSHMProvider.py
+++ b/OpenRTM_aist/InPortSHMProvider.py
@@ -155,7 +155,7 @@ class InPortSHMProvider(OpenRTM_aist.InPortProvider,
 
             self._rtcout.RTC_PARANOID("received data size: %d", len(shm_data))
 
-            self.onReceived(shm_data)
+            shm_data = self.onReceived(shm_data)
 
             ret = self._connector.write(shm_data)
 
@@ -167,59 +167,59 @@ class InPortSHMProvider(OpenRTM_aist.InPortProvider,
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
                 self._profile, data)
-        return
+        return data
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
                 self._profile, data)
-        return
+        return data
 
     def convertReturn(self, status, data):
         if status == OpenRTM_aist.BufferStatus.BUFFER_OK:
@@ -231,7 +231,7 @@ class InPortSHMProvider(OpenRTM_aist.InPortProvider,
             return OpenRTM.PORT_ERROR
 
         elif status == OpenRTM_aist.BufferStatus.BUFFER_FULL:
-            self.onBufferFull(data)
+            data = self.onBufferFull(data)
             self.onReceiverFull(data)
             return OpenRTM.BUFFER_FULL
 
@@ -243,7 +243,7 @@ class InPortSHMProvider(OpenRTM_aist.InPortProvider,
             return OpenRTM.PORT_ERROR
 
         elif status == OpenRTM_aist.BufferStatus.TIMEOUT:
-            self.onBufferWriteTimeout(data)
+            data = self.onBufferWriteTimeout(data)
             self.onReceiverTimeout(data)
             return OpenRTM.BUFFER_TIMEOUT
 

--- a/OpenRTM_aist/OutPort.py
+++ b/OpenRTM_aist/OutPort.py
@@ -21,6 +21,7 @@ from omniORB import any
 
 import OpenRTM_aist
 import threading
+import copy
 
 
 ##
@@ -100,6 +101,8 @@ class OutPort(OpenRTM_aist.OutPortBase):
         #self._OnUnderflow    = None
         #self._OnConnect      = None
         #self._OnDisconnect   = None
+        self._listeners.setDataType(copy.deepcopy(value))
+        self._listeners.setPortType(OpenRTM_aist.PortType.OutPortType)
         self.addConnectorDataListener(
             OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE,
             OpenRTM_aist.Timestamp("on_write"))

--- a/OpenRTM_aist/OutPortCSPProvider.py
+++ b/OpenRTM_aist/OutPortCSPProvider.py
@@ -193,17 +193,17 @@ class OutPortCSPProvider(OpenRTM_aist.OutPortProvider, CSP__POA.OutPortCsp):
 
     def onBufferRead(self, data):
         if self._listeners and self._profile:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(
                 self._profile, data)
-        return
+        return data
 
     def onSend(self, data):
         if self._listeners and self._profile:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(
                 self._profile, data)
-        return
+        return data
 
     def onBufferEmpty(self):
         if self._listeners and self._profile:
@@ -242,8 +242,8 @@ class OutPortCSPProvider(OpenRTM_aist.OutPortProvider, CSP__POA.OutPortCsp):
 
     def convertReturn(self, status, data):
         if status == OpenRTM_aist.BufferStatus.BUFFER_OK:
-            self.onBufferRead(data)
-            self.onSend(data)
+            data = self.onBufferRead(data)
+            data = self.onSend(data)
             return (OpenRTM.PORT_OK, data)
 
         elif status == OpenRTM_aist.BufferStatus.BUFFER_ERROR:

--- a/OpenRTM_aist/OutPortCorbaCdrConsumer.py
+++ b/OpenRTM_aist/OutPortCorbaCdrConsumer.py
@@ -206,13 +206,13 @@ class OutPortCorbaCdrConsumer(
             if ret == OpenRTM.PORT_OK:
                 self._rtcout.RTC_DEBUG("get() successful")
                 data = cdr_data
-                self.onReceived(data)
-                self.onBufferWrite(data)
+                data = self.onReceived(data)
+                data = self.onBufferWrite(data)
 
                 if self._buffer.full():
                     self._rtcout.RTC_INFO("InPort buffer is full.")
-                    self.onBufferFull(data)
-                    self.onReceiverFull(data)
+                    data = self.onBufferFull(data)
+                    data = self.onReceiverFull(data)
 
                 self._buffer.put(data)
                 self._buffer.advanceWptr()
@@ -375,31 +375,31 @@ class OutPortCorbaCdrConsumer(
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
                 self._profile, data)
 
-        return
+        return data
 
     # inline void onBufferFull(const cdrMemoryStream& data)
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
                 self._profile, data)
 
-        return
+        return data
 
     # inline void onReceived(const cdrMemoryStream& data)
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
                 self._profile, data)
 
-        return
+        return data
 
     # inline void onReceiverFull(const cdrMemoryStream& data)
 
@@ -409,7 +409,7 @@ class OutPortCorbaCdrConsumer(
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
                 self._profile, data)
 
-        return
+        return data
 
     ##
     # @brief Connector listener functions

--- a/OpenRTM_aist/OutPortCorbaCdrProvider.py
+++ b/OpenRTM_aist/OutPortCorbaCdrProvider.py
@@ -315,10 +315,10 @@ class OutPortCorbaCdrProvider(OpenRTM_aist.OutPortProvider,
     # inline void onBufferRead(const cdrMemoryStream& data)
     def onBufferRead(self, data):
         if self._listeners and self._profile:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -332,10 +332,10 @@ class OutPortCorbaCdrProvider(OpenRTM_aist.OutPortProvider,
     # inline void onSend(const cdrMemoryStream& data)
     def onSend(self, data):
         if self._listeners and self._profile:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -424,8 +424,8 @@ class OutPortCorbaCdrProvider(OpenRTM_aist.OutPortProvider,
 
     def convertReturn(self, status, data):
         if status == OpenRTM_aist.BufferStatus.BUFFER_OK:
-            self.onBufferRead(data)
-            self.onSend(data)
+            data = self.onBufferRead(data)
+            data = self.onSend(data)
             return (OpenRTM.PORT_OK, data)
 
         elif status == OpenRTM_aist.BufferStatus.BUFFER_ERROR:

--- a/OpenRTM_aist/OutPortDSConsumer.py
+++ b/OpenRTM_aist/OutPortDSConsumer.py
@@ -203,13 +203,13 @@ class OutPortDSConsumer(OpenRTM_aist.OutPortConsumer,
             if ret == RTC.PORT_OK:
                 self._rtcout.RTC_DEBUG("get() successful")
                 data = cdr_data
-                self.onReceived(data)
-                self.onBufferWrite(data)
+                data = self.onReceived(data)
+                data = self.onBufferWrite(data)
 
                 if self._buffer.full():
                     self._rtcout.RTC_INFO("InPort buffer is full.")
-                    self.onBufferFull(data)
-                    self.onReceiverFull(data)
+                    data = self.onBufferFull(data)
+                    data = self.onReceiverFull(data)
 
                 self._buffer.put(data)
                 self._buffer.advanceWptr()
@@ -375,41 +375,41 @@ class OutPortDSConsumer(OpenRTM_aist.OutPortConsumer,
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
                 self._profile, data)
 
-        return
+        return data
 
     # inline void onBufferFull(const cdrMemoryStream& data)
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
                 self._profile, data)
 
-        return
+        return data
 
     # inline void onReceived(const cdrMemoryStream& data)
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
                 self._profile, data)
 
-        return
+        return data
 
     # inline void onReceiverFull(const cdrMemoryStream& data)
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
                 self._profile, data)
 
-        return
+        return data
 
     ##
     # @brief Connector listener functions

--- a/OpenRTM_aist/OutPortDSProvider.py
+++ b/OpenRTM_aist/OutPortDSProvider.py
@@ -316,10 +316,10 @@ class OutPortDSProvider(OpenRTM_aist.OutPortProvider,
     # inline void onBufferRead(const cdrMemoryStream& data)
     def onBufferRead(self, data):
         if self._listeners and self._profile:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -333,10 +333,10 @@ class OutPortDSProvider(OpenRTM_aist.OutPortProvider,
     # inline void onSend(const cdrMemoryStream& data)
     def onSend(self, data):
         if self._listeners and self._profile:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -425,8 +425,8 @@ class OutPortDSProvider(OpenRTM_aist.OutPortProvider,
 
     def convertReturn(self, status, data):
         if status == OpenRTM_aist.BufferStatus.BUFFER_OK:
-            self.onBufferRead(data)
-            self.onSend(data)
+            data = self.onBufferRead(data)
+            data = self.onSend(data)
             return (RTC.PORT_OK, data)
 
         elif status == OpenRTM_aist.BufferStatus.BUFFER_ERROR:

--- a/OpenRTM_aist/OutPortDirectConsumer.py
+++ b/OpenRTM_aist/OutPortDirectConsumer.py
@@ -193,41 +193,41 @@ class OutPortDirectConsumer(OpenRTM_aist.OutPortConsumer):
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
                 self._profile, data)
 
-        return
+        return data
 
     # inline void onBufferFull(const cdrMemoryStream& data)
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
                 self._profile, data)
 
-        return
+        return data
 
     # inline void onReceived(const cdrMemoryStream& data)
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
                 self._profile, data)
 
-        return
+        return data
 
     # inline void onReceiverFull(const cdrMemoryStream& data)
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
                 self._profile, data)
 
-        return
+        return data
 
     ##
     # @brief Connector listener functions

--- a/OpenRTM_aist/OutPortDirectProvider.py
+++ b/OpenRTM_aist/OutPortDirectProvider.py
@@ -119,19 +119,19 @@ class OutPortDirectProvider(OpenRTM_aist.OutPortProvider):
 
     def onBufferRead(self, data):
         if self._listeners and self._profile:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onSend(const cdrMemoryStream& data)
 
     def onSend(self, data):
         if self._listeners and self._profile:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferEmpty()
 

--- a/OpenRTM_aist/OutPortSHMProvider.py
+++ b/OpenRTM_aist/OutPortSHMProvider.py
@@ -180,17 +180,17 @@ class OutPortSHMProvider(OpenRTM_aist.OutPortProvider,
 
     def onBufferRead(self, data):
         if self._listeners and self._profile:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(
                 self._profile, data)
-        return
+        return data
 
     def onSend(self, data):
         if self._listeners and self._profile:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(
                 self._profile, data)
-        return
+        return data
 
     def onBufferEmpty(self):
         if self._listeners and self._profile:
@@ -229,7 +229,7 @@ class OutPortSHMProvider(OpenRTM_aist.OutPortProvider,
 
     def convertReturn(self, status, data):
         if status == OpenRTM_aist.BufferStatus.BUFFER_OK:
-            self.onBufferRead(data)
+            data = self.onBufferRead(data)
             self.onSend(data)
             return OpenRTM.PORT_OK
 

--- a/OpenRTM_aist/PublisherFlush.py
+++ b/OpenRTM_aist/PublisherFlush.py
@@ -283,30 +283,30 @@ class PublisherFlush(OpenRTM_aist.PublisherBase):
             self._rtcout.RTC_DEBUG("write(): connection lost.")
             return self._retcode
 
-        self.onSend(data)
+        data = self.onSend(data)
 
         self._retcode = self._consumer.put(data)
 
         if self._retcode == self.PORT_OK:
-            self.onReceived(data)
+            data = self.onReceived(data)
             return self._retcode
         elif self._retcode == self.PORT_ERROR:
-            self.onReceiverError(data)
+            data = self.onReceiverError(data)
             return self._retcode
         elif self._retcode == self.SEND_FULL:
-            self.onReceiverFull(data)
+            data = self.onReceiverFull(data)
             return self._retcode
         elif self._retcode == self.SEND_TIMEOUT:
-            self.onReceiverTimeout(data)
+            data = self.onReceiverTimeout(data)
             return self._retcode
         elif self._retcode == self.CONNECTION_LOST:
-            self.onReceiverTimeout(data)
+            data = self.onReceiverTimeout(data)
             return self._retcode
         elif self._retcode == self.UNKNOWN_ERROR:
-            self.onReceiverError(data)
+            data = self.onReceiverError(data)
             return self._retcode
         else:
-            self.onReceiverError(data)
+            data = self.onReceiverError(data)
             return self._retcode
 
     ##
@@ -422,10 +422,10 @@ class PublisherFlush(OpenRTM_aist.PublisherBase):
     # inline void onSend(const cdrMemoryStream& data)
     def onSend(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -439,10 +439,10 @@ class PublisherFlush(OpenRTM_aist.PublisherBase):
     # inline void onReceived(const cdrMemoryStream& data)
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -456,10 +456,10 @@ class PublisherFlush(OpenRTM_aist.PublisherBase):
     # inline void onReceiverFull(const cdrMemoryStream& data)
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -473,10 +473,10 @@ class PublisherFlush(OpenRTM_aist.PublisherBase):
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -490,10 +490,10 @@ class PublisherFlush(OpenRTM_aist.PublisherBase):
     # inline void onReceiverError(const cdrMemoryStream& data)
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
                 self._profile, data)
-        return
+        return data
 
 
 def PublisherFlushInit():

--- a/OpenRTM_aist/PublisherNew.py
+++ b/OpenRTM_aist/PublisherNew.py
@@ -632,7 +632,7 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
                 _, cdr = self._buffer.get()
                 self.onBufferRead(cdr)
 
-                self.onSend(cdr)
+                cdr = self.onSend(cdr)
                 ret = self._consumer.put(cdr)
 
                 if ret != self.PORT_OK:
@@ -640,7 +640,7 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
                         "%s = consumer.put()",
                         OpenRTM_aist.DataPortStatus.toString(ret))
                     return self.invokeListener(ret, cdr)
-                self.onReceived(cdr)
+                cdr = self.onReceived(cdr)
 
                 self._buffer.advanceRptr()
 
@@ -661,7 +661,7 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
             _, cdr = self._buffer.get()
             self.onBufferRead(cdr)
 
-            self.onSend(cdr)
+            cdr = self.onSend(cdr)
             ret = self._consumer.put(cdr)
 
             if ret != self.PORT_OK:
@@ -669,7 +669,7 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
                     "%s = consumer.put()",
                     OpenRTM_aist.DataPortStatus.toString(ret))
                 return self.invokeListener(ret, cdr)
-            self.onReceived(cdr)
+            cdr = self.onReceived(cdr)
 
             self._buffer.advanceRptr()
 
@@ -697,7 +697,7 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
                 _, cdr = self._buffer.get()
                 self.onBufferRead(cdr)
 
-                self.onSend(cdr)
+                cdr = self.onSend(cdr)
                 ret = self._consumer.put(cdr)
                 if ret != self.PORT_OK:
                     self._buffer.advanceRptr(-postskip)
@@ -706,7 +706,7 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
                         OpenRTM_aist.DataPortStatus.toString(ret))
                     return self.invokeListener(ret, cdr)
 
-                self.onReceived(cdr)
+                cdr = self.onReceived(cdr)
                 postskip = self._skipn + 1
 
             self._buffer.advanceRptr(self._buffer.readable())
@@ -741,7 +741,7 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
             _, cdr = self._buffer.get()
             self.onBufferRead(cdr)
 
-            self.onSend(cdr)
+            cdr = self.onSend(cdr)
             ret = self._consumer.put(cdr)
 
             if ret != self.PORT_OK:
@@ -750,7 +750,7 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
                     OpenRTM_aist.DataPortStatus.toString(ret))
                 return self.invokeListener(ret, cdr)
 
-            self.onReceived(cdr)
+            cdr = self.onReceived(cdr)
             self._buffer.advanceRptr()
 
             return self.PORT_OK
@@ -912,10 +912,10 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onBufferWrite(const cdrMemoryStream& data)
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -929,10 +929,10 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onBufferFull(const cdrMemoryStream& data)
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -946,10 +946,10 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onBufferWriteTimeout(const cdrMemoryStream& data)
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -963,10 +963,10 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onBufferWriteOverwrite(const cdrMemoryStream& data)
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -980,10 +980,10 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onBufferRead(const cdrMemoryStream& data)
     def onBufferRead(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -997,10 +997,10 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onSend(const cdrMemoryStream& data)
     def onSend(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -1014,10 +1014,10 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onReceived(const cdrMemoryStream& data)
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -1031,10 +1031,10 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onReceiverFull(const cdrMemoryStream& data)
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -1048,10 +1048,10 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -1065,10 +1065,10 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onReceiverError(const cdrMemoryStream& data)
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp

--- a/OpenRTM_aist/PublisherPeriodic.py
+++ b/OpenRTM_aist/PublisherPeriodic.py
@@ -669,7 +669,7 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
             _, cdr = self._buffer.get()
             self.onBufferRead(cdr)
 
-            self.onSend(cdr)
+            cdr = self.onSend(cdr)
             ret = self._consumer.put(cdr)
 
             if ret != self.PORT_OK:
@@ -678,7 +678,7 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
                     OpenRTM_aist.DataPortStatus.toString(ret))
                 return self.invokeListener(ret, cdr)
 
-            self.onReceived(cdr)
+            cdr = self.onReceived(cdr)
             self._buffer.advanceRptr()
 
         return self.PORT_OK
@@ -699,7 +699,7 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
         _, cdr = self._buffer.get()
         self.onBufferRead(cdr)
 
-        self.onSend(cdr)
+        cdr = self.onSend(cdr)
         ret = self._consumer.put(cdr)
 
         if ret != self.PORT_OK:
@@ -708,7 +708,7 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
                 OpenRTM_aist.DataPortStatus.toString(ret))
             return self.invokeListener(ret, cdr)
 
-        self.onReceived(cdr)
+        cdr = self.onReceived(cdr)
         self._buffer.advanceRptr()
 
         return self.PORT_OK
@@ -735,7 +735,7 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
             _, cdr = self._buffer.get()
             self.onBufferRead(cdr)
 
-            self.onSend(cdr)
+            cdr = self.onSend(cdr)
             ret = self._consumer.put(cdr)
             if ret != self.PORT_OK:
                 self._buffer.advanceRptr(-postskip)
@@ -743,7 +743,7 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
                     "%s = consumer.put()",
                     OpenRTM_aist.DataPortStatus.toString(ret))
                 return self.invokeListener(ret, cdr)
-            self.onReceived(cdr)
+            cdr = self.onReceived(cdr)
             postskip = self._skipn + 1
 
         self._buffer.advanceRptr(self._buffer.readable())
@@ -774,7 +774,7 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
         _, cdr = self._buffer.get()
         self.onBufferRead(cdr)
 
-        self.onSend(cdr)
+        cdr = self.onSend(cdr)
         ret = self._consumer.put(cdr)
 
         if ret != self.PORT_OK:
@@ -783,7 +783,7 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
                 OpenRTM_aist.DataPortStatus.toString(ret))
             return self.invokeListener(ret, cdr)
 
-        self.onReceived(cdr)
+        cdr = self.onReceived(cdr)
 
         self._buffer.advanceRptr()
         return self.PORT_OK
@@ -931,10 +931,10 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onBufferWrite(const cdrMemoryStream& data)
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -948,10 +948,10 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onBufferFull(const cdrMemoryStream& data)
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -965,10 +965,10 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onBufferWriteTimeout(const cdrMemoryStream& data)
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -982,10 +982,10 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     #  inline void onBufferRead(const cdrMemoryStream& data)
     def onBufferRead(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -999,10 +999,10 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onSend(const cdrMemoryStream& data)
     def onSend(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -1016,10 +1016,10 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onReceived(const cdrMemoryStream& data)
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -1033,10 +1033,10 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onReceiverFull(const cdrMemoryStream& data)
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -1050,10 +1050,10 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp
@@ -1067,10 +1067,10 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onReceiverError(const cdrMemoryStream& data)
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp

--- a/OpenRTM_aist/Timestamp.py
+++ b/OpenRTM_aist/Timestamp.py
@@ -25,8 +25,8 @@ class Timestamp(OpenRTM_aist.ConnectorDataListenerT):
 
     def __call__(self, info, data):
         if info.properties.getProperty("timestamp_policy") != self._ts_type:
-            return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE
+            return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE, data
         tm = OpenRTM_aist.Time().gettimeofday()
         data.tm.sec = tm.sec()
         data.tm.nsec = tm.usec() * 1000
-        return OpenRTM_aist.ConnectorListenerStatus.DATA_CHANGED
+        return OpenRTM_aist.ConnectorListenerStatus.DATA_CHANGED, data

--- a/OpenRTM_aist/examples/SimpleIO/ConsoleIn.py
+++ b/OpenRTM_aist/examples/SimpleIO/ConsoleIn.py
@@ -28,18 +28,14 @@ class DataListener(OpenRTM_aist.ConnectorDataListenerT):
     def __del__(self):
         print("dtor of ", self._name)
 
-    def __call__(self, info, cdrdata):
-        data = OpenRTM_aist.ConnectorDataListenerT.__call__(
-            self, info, cdrdata, RTC.TimedLong(
-                RTC.Time(
-                    0, 0), 0), OpenRTM_aist.PortType.OutPortType)
+    def __call__(self, info, data):
         print("------------------------------")
         print("Listener:       ", self._name)
         print("Profile::name:  ", info.name)
         print("Profile::id:    ", info.id)
         print("Data:           ", data.data)
         print("------------------------------")
-        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE
+        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE, data
 
 
 class ConnListener(OpenRTM_aist.ConnectorListener):

--- a/OpenRTM_aist/examples/SimpleIO/ConsoleOut.py
+++ b/OpenRTM_aist/examples/SimpleIO/ConsoleOut.py
@@ -37,6 +37,7 @@ class DataListener(OpenRTM_aist.ConnectorDataListenerT):
         print("Profile::id:    ", info.id)
         print("Data:           ", data.data)
         print("------------------------------")
+        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE, data
 
 
 class ConnListener(OpenRTM_aist.ConnectorListener):

--- a/OpenRTM_aist/examples/SimpleIO/ConsoleOut.py
+++ b/OpenRTM_aist/examples/SimpleIO/ConsoleOut.py
@@ -30,18 +30,13 @@ class DataListener(OpenRTM_aist.ConnectorDataListenerT):
     def __del__(self):
         print("dtor of ", self._name)
 
-    def __call__(self, info, cdrdata):
-        data = OpenRTM_aist.ConnectorDataListenerT.__call__(
-            self, info, cdrdata, RTC.TimedLong(
-                RTC.Time(
-                    0, 0), 0), OpenRTM_aist.PortType.InPortType)
+    def __call__(self, info, data):
         print("------------------------------")
         print("Listener:       ", self._name)
         print("Profile::name:  ", info.name)
         print("Profile::id:    ", info.id)
         print("Data:           ", data.data)
         print("------------------------------")
-        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE
 
 
 class ConnListener(OpenRTM_aist.ConnectorListener):

--- a/OpenRTM_aist/ext/fsm4rtc_observer/COCTestRTC.py
+++ b/OpenRTM_aist/ext/fsm4rtc_observer/COCTestRTC.py
@@ -27,15 +27,14 @@ class DataListener(OpenRTM_aist.ConnectorDataListenerT):
     def __del__(self):
         print("dtor of ", self._name)
 
-    def __call__(self, info, cdrdata):
-        data = OpenRTM_aist.ConnectorDataListenerT.__call__(
-            self, info, cdrdata, RTC.TimedLong(RTC.Time(0, 0), 0))
+    def __call__(self, info, data):
         print("------------------------------")
         print("Listener:       ", self._name)
         print("Profile::name:  ", info.name)
         print("Profile::id:    ", info.id)
         print("Data:           ", data.data)
         print("------------------------------")
+        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE, data
 
 
 class ConnListener(OpenRTM_aist.ConnectorListener):
@@ -51,6 +50,7 @@ class ConnListener(OpenRTM_aist.ConnectorListener):
         print("Profile::name:  ", info.name)
         print("Profile::id:    ", info.id)
         print("------------------------------")
+        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE
 
 
 class COCTestRTC(OpenRTM_aist.DataFlowComponentBase):

--- a/OpenRTM_aist/ext/local_service/nameservice_file/FileNameservice.py
+++ b/OpenRTM_aist/ext/local_service/nameservice_file/FileNameservice.py
@@ -103,7 +103,7 @@ class FileNameservice(OpenRTM_aist.LocalServiceBase):
         self._profile.properties.mergeProperties(profile)
 
         manager_ = OpenRTM_aist.Manager.instance()
-        manager_.addNamingActionListener(NamingAction(self), True)
+        manager_.addNamingActionListener(NamingAction(self))
         return True
 
     ##

--- a/OpenRTM_aist/ext/sdo/observer/COCTestRTC.py
+++ b/OpenRTM_aist/ext/sdo/observer/COCTestRTC.py
@@ -27,15 +27,14 @@ class DataListener(OpenRTM_aist.ConnectorDataListenerT):
     def __del__(self):
         print("dtor of ", self._name)
 
-    def __call__(self, info, cdrdata):
-        data = OpenRTM_aist.ConnectorDataListenerT.__call__(
-            self, info, cdrdata, RTC.TimedLong(RTC.Time(0, 0), 0))
+    def __call__(self, info, data):
         print("------------------------------")
         print("Listener:       ", self._name)
         print("Profile::name:  ", info.name)
         print("Profile::id:    ", info.id)
         print("Data:           ", data.data)
         print("------------------------------")
+        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE, data
 
 
 class ConnListener(OpenRTM_aist.ConnectorListener):
@@ -51,6 +50,7 @@ class ConnListener(OpenRTM_aist.ConnectorListener):
         print("Profile::name:  ", info.name)
         print("Profile::id:    ", info.id)
         print("------------------------------")
+        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE
 
 
 class COCTestRTC(OpenRTM_aist.DataFlowComponentBase):

--- a/OpenRTM_aist/ext/sdo/observer/ComponentObserverConsumer.py
+++ b/OpenRTM_aist/ext/sdo/observer/ComponentObserverConsumer.py
@@ -857,7 +857,7 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
     # @endif
     #
 
-    class DataPortAction(OpenRTM_aist.ConnectorDataListenerT):
+    class DataPortAction(OpenRTM_aist.ConnectorDataListener):
         """
         """
 
@@ -876,7 +876,7 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
                 self._last = curr
                 self._coc.updateStatus(OpenRTM.PORT_PROFILE, self._msg)
 
-            return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE
+            return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE, cdrdata
 
     ##
     # @if jp

--- a/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceInPort.py
+++ b/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceInPort.py
@@ -216,7 +216,7 @@ class OpenSpliceInPort(OpenRTM_aist.InPortProvider):
                 self.onReceiverError(data)
                 return OpenRTM.PORT_ERROR
 
-            self.onReceived(data)
+            data = self.onReceived(data)
 
             ret = self._connector.write(data)
 
@@ -235,7 +235,7 @@ class OpenSpliceInPort(OpenRTM_aist.InPortProvider):
             return
 
         elif status == OpenRTM_aist.BufferStatus.BUFFER_FULL:
-            self.onBufferFull(data)
+            data = self.onBufferFull(data)
             self.onReceiverFull(data)
             return
 
@@ -247,7 +247,7 @@ class OpenSpliceInPort(OpenRTM_aist.InPortProvider):
             return
 
         elif status == OpenRTM_aist.BufferStatus.TIMEOUT:
-            self.onBufferWriteTimeout(data)
+            data = self.onBufferWriteTimeout(data)
             self.onReceiverTimeout(data)
             return
 
@@ -262,72 +262,72 @@ class OpenSpliceInPort(OpenRTM_aist.InPortProvider):
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferFull(const cdrMemoryStream& data)
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferWriteTimeout(const cdrMemoryStream& data)
 
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferWriteOverwrite(const cdrMemoryStream& data)
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceived(const cdrMemoryStream& data)
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverFull(const cdrMemoryStream& data)
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
 
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverError(const cdrMemoryStream& data)
 
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
                 self._profile, data)
-        return
+        return data
 
 ##
 # @if jp

--- a/OpenRTM_aist/ext/transport/ROS2Transport/ROS2InPort.py
+++ b/OpenRTM_aist/ext/transport/ROS2Transport/ROS2InPort.py
@@ -235,7 +235,7 @@ class ROS2InPort(OpenRTM_aist.InPortProvider):
                 self.onReceiverError(data)
                 return OpenRTM.PORT_ERROR
 
-            self.onReceived(data)
+            data = self.onReceived(data)
 
             ret = self._connector.write(data)
 
@@ -254,7 +254,7 @@ class ROS2InPort(OpenRTM_aist.InPortProvider):
             return
 
         elif status == OpenRTM_aist.BufferStatus.BUFFER_FULL:
-            self.onBufferFull(data)
+            data = self.onBufferFull(data)
             self.onReceiverFull(data)
             return
 
@@ -266,7 +266,7 @@ class ROS2InPort(OpenRTM_aist.InPortProvider):
             return
 
         elif status == OpenRTM_aist.BufferStatus.TIMEOUT:
-            self.onBufferWriteTimeout(data)
+            data = self.onBufferWriteTimeout(data)
             self.onReceiverTimeout(data)
             return
 
@@ -281,72 +281,72 @@ class ROS2InPort(OpenRTM_aist.InPortProvider):
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferFull(const cdrMemoryStream& data)
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferWriteTimeout(const cdrMemoryStream& data)
 
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferWriteOverwrite(const cdrMemoryStream& data)
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceived(const cdrMemoryStream& data)
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverFull(const cdrMemoryStream& data)
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
 
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverError(const cdrMemoryStream& data)
 
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
                 self._profile, data)
-        return
+        return data
 
 
 ##

--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSInPort.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSInPort.py
@@ -439,7 +439,7 @@ class ROSInPort(OpenRTM_aist.InPortProvider):
 
             self._rtcout.RTC_PARANOID("received data size: %d", len(data))
 
-            self.onReceived(data)
+            data = self.onReceived(data)
 
             ret = self._connector.write(data)
 
@@ -458,7 +458,7 @@ class ROSInPort(OpenRTM_aist.InPortProvider):
             return
 
         elif status == OpenRTM_aist.BufferStatus.BUFFER_FULL:
-            self.onBufferFull(data)
+            data = self.onBufferFull(data)
             self.onReceiverFull(data)
             return
 
@@ -470,7 +470,7 @@ class ROSInPort(OpenRTM_aist.InPortProvider):
             return
 
         elif status == OpenRTM_aist.BufferStatus.TIMEOUT:
-            self.onBufferWriteTimeout(data)
+            data = self.onBufferWriteTimeout(data)
             self.onReceiverTimeout(data)
             return
 
@@ -485,72 +485,72 @@ class ROSInPort(OpenRTM_aist.InPortProvider):
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferFull(const cdrMemoryStream& data)
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferWriteTimeout(const cdrMemoryStream& data)
 
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onBufferWriteOverwrite(const cdrMemoryStream& data)
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceived(const cdrMemoryStream& data)
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverFull(const cdrMemoryStream& data)
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
 
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
                 self._profile, data)
-        return
+        return data
 
     # inline void onReceiverError(const cdrMemoryStream& data)
 
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
+            _, data = self._listeners.connectorData_[
                 OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
                 self._profile, data)
-        return
+        return data
 
     ##
     # @if jp


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#123 


## Description of the Change

コネクタリスナのコールバック関数の仕様を変更した。

- リスナが`ConnectorDataListenerT`を基底クラスにしている場合

コールバック関数にはデシリアライズしたデータを入力して、リターンコードとデータを返さなければならない。

```Python
class DataListener(OpenRTM_aist.ConnectorDataListenerT):
    def __init__(self, name):
        self._name = name

    def __del__(self):
        print("dtor of ", self._name)

    def __call__(self, info, data):
        print("------------------------------")
        print("Listener:       ", self._name)
        print("Profile::name:  ", info.name)
        print("Profile::id:    ", info.id)
        print("Data:           ", data.data)
        print("------------------------------")
        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE, data
```

- リスナが`ConnectorDataListener`を基底クラスにしている場合
コールバック関数にバイト列を入力してバイト列を返す。このためデータを変更するためには一旦デシリアライズ後にシリアライズしなければならない。

```
class DataListener(OpenRTM_aist.ConnectorDataListener):
    def __init__(self, name):
        self._name = name

    def __del__(self):
        print("dtor of ", self._name)

    def __call__(self, info, cdrdata):
        data = OpenRTM_aist.ConnectorDataListenerT.__call__(
            self, info, cdrdata, self._data_type, OpenRTM_aist.PortType.InPortType)
        print("------------------------------")
        print("Listener:       ", self._name)
        print("Profile::name:  ", info.name)
        print("Profile::id:    ", info.id)
        print("Data:           ", data.data)
        print("------------------------------")
        return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE, cdrdata
```

変更後のデータを返すようにしたため、`DATA_CHANGED`もしくは`BOTH_CHANGED`の場合にリスナの外側でもデータが変更されるようになった。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
