### PR TITLE
Timerクラスがobject型を継承していないためPython2でエラーが発生する問題の修正

### DIFF
--- a/OpenRTM_aist/Timer.py
+++ b/OpenRTM_aist/Timer.py
@@ -181,7 +181,7 @@ class PeriodicFunction(object):
 #
 # @endif
 
-
+# TODO: The "object" class inheritance must be removed in Python3
 class Timer(object):
     """
     """

--- a/OpenRTM_aist/Timer.py
+++ b/OpenRTM_aist/Timer.py
@@ -182,7 +182,7 @@ class PeriodicFunction(object):
 # @endif
 
 
-class Timer:
+class Timer(object):
     """
     """
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#132 でTimerの仕様を大幅に変更したが、Timerクラスがobject型を継承していないためPython2でエラーが出るようになった。
Python3ではobject型の継承は明示する必要がないためエラーは出ない。

## Description of the Change

Timerクラスがobject型を継承するようにした。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
