### PR TITLE
ConnectorDataListenerクラスがobject型を継承していないためPython2でエラーが発生する問題の修正

### DIFF
--- a/OpenRTM_aist/ConnectorListener.py
+++ b/OpenRTM_aist/ConnectorListener.py
@@ -213,6 +213,7 @@ class ConnectorDataListenerType:
 #
 # @endif
 #
+# TODO: The "obbject" class inheritance must be removed in Python3
 class ConnectorDataListener(object):
     """
     """

--- a/OpenRTM_aist/ConnectorListener.py
+++ b/OpenRTM_aist/ConnectorListener.py
@@ -213,7 +213,7 @@ class ConnectorDataListenerType:
 #
 # @endif
 #
-class ConnectorDataListener:
+class ConnectorDataListener(object):
     """
     """
 

--- a/OpenRTM_aist/ConnectorListener.py
+++ b/OpenRTM_aist/ConnectorListener.py
@@ -213,7 +213,7 @@ class ConnectorDataListenerType:
 #
 # @endif
 #
-# TODO: The "obbject" class inheritance must be removed in Python3
+# TODO: The "object" class inheritance must be removed in Python3
 class ConnectorDataListener(object):
     """
     """


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug


ConnectorDataListenerクラスがobject型を継承していないため、Python2でissubclassの判定が正常に実行されない。

## Description of the Change

ConnectorDataListenerクラスがobject型を継承するようにした。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
