### PR TITLE
***ListenerHolder型のメンバ変数を直接操作しないようにする

### DIFF
--- a/OpenRTM_aist/CSPOutPort.py
+++ b/OpenRTM_aist/CSPOutPort.py
@@ -317,18 +317,15 @@ class CSPOutPort(OpenRTM_aist.OutPortBase):
         self._ctrl._connectors = []
         self._ctrl._searched_connectors = []
 
-        if not self._syncmode:
-            del guard
-            guard = None
-
         if self._ctrl._waiting:
             return True
         if self._ctrl._reading:
             self._ctrl._cond.wait(self._channeltimeout)
 
         if not self._syncmode:
-            del guard_con
-            guard_con = None
+            del guard
+            guard = None
+
         ret, self._writableConnector = self.dataWritable()
         return ret
 

--- a/OpenRTM_aist/ComponentActionListener.py
+++ b/OpenRTM_aist/ComponentActionListener.py
@@ -1041,6 +1041,18 @@ class ExecutionContextActionListenerHolder:
 class ComponentActionListeners:
     """
     """
+    ##
+    # @if jp
+    # @brief コンストラクタ
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @param self
+    #
+    # @endif
 
     def __init__(self):
 
@@ -1092,66 +1104,288 @@ class ComponentActionListeners:
         self.ecaction_ = [ExecutionContextActionListenerHolder()
                           for i in range(self.ecaction_num)]
 
+    ##
+    # @if jp
+    # @brief リスナーの追加
+    #
+    # 指定の種類のPreComponentActionListenerを追加する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 追加するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def addPreActionListener(self, ltype, listener):
         if ltype < len(self.preaction_):
             self.preaction_[ltype].addListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの追加
+    #
+    # 指定の種類のPostComponentActionListenerを追加する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 追加するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def addPostActionListener(self, ltype, listener):
         if ltype < len(self.postaction_):
             self.postaction_[ltype].addListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの追加
+    #
+    # 指定の種類のPortActionListenerを追加する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 追加するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def addPortActionListener(self, ltype, listener):
         if ltype < len(self.portaction_):
             self.portaction_[ltype].addListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの追加
+    #
+    # 指定の種類のExecutionContextActionListenerを追加する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 追加するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def addECActionListener(self, ltype, listener):
         if ltype < len(self.ecaction_):
             self.ecaction_[ltype].addListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの削除
+    #
+    # 指定の種類のPreComponentActionListenerを削除する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 削除するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def removePreActionListener(self, ltype, listener):
         if ltype < len(self.preaction_):
             self.preaction_[ltype].removeListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの削除
+    #
+    # 指定の種類のPostComponentActionListenerを削除する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 削除するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def removePostActionListener(self, ltype, listener):
         if ltype < len(self.postaction_):
             self.postaction_[ltype].removeListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの削除
+    #
+    # 指定の種類のPortActionListenerを削除する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 削除するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def removePortActionListener(self, ltype, listener):
         if ltype < len(self.portaction_):
             self.portaction_[ltype].removeListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの削除
+    #
+    # 指定の種類のExecutionContextActionListenerを削除する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 削除するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def removeECActionListener(self, ltype, listener):
         if ltype < len(self.ecaction_):
             self.ecaction_[ltype].removeListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーへ通知する
+    #
+    # 指定の種類のPreComponentActionListenerのコールバック関数を呼び出す。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param ec_id 実行コンテキストのID
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param ec_id
+    #
+    # @endif
     def notifyPreAction(self, ltype, ec_id):
         if ltype < len(self.preaction_):
             self.preaction_[ltype].notify(ec_id)
 
+    ##
+    # @if jp
+    # @brief リスナーへ通知する
+    #
+    # 指定の種類のPostComponentActionListenerのコールバック関数を呼び出す。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param ec_id 実行コンテキストのID
+    # @param ret リターンコード
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param ec_id
+    # @param ret
+    #
+    # @endif
     def notifyPostAction(self, ltype, ec_id, ret):
         if ltype < len(self.postaction_):
             self.postaction_[ltype].notify(ec_id, ret)
 
+    ##
+    # @if jp
+    # @brief リスナーへ通知する
+    #
+    # 指定の種類のPortActionListenerのコールバック関数を呼び出す。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param pprofile ポートプロファイル
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param pprofile
+    #
+    # @endif
     def notifyPortAction(self, ltype, pprofile):
         if ltype < len(self.portaction_):
             self.portaction_[ltype].notify(pprofile)
 
+    ##
+    # @if jp
+    # @brief リスナーへ通知する
+    #
+    # 指定の種類のExecutionContextActionListenerのコールバック関数を呼び出す。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param ec_id 実行コンテキストのID
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param ec_id
+    #
+    # @endif
     def notifyECAction(self, ltype, ec_id):
         if ltype < len(self.ecaction_):
             self.ecaction_[ltype].notify(ec_id)

--- a/OpenRTM_aist/ComponentActionListener.py
+++ b/OpenRTM_aist/ComponentActionListener.py
@@ -1091,3 +1091,67 @@ class ComponentActionListeners:
         self.ecaction_num = ExecutionContextActionListenerType.EC_ACTION_LISTENER_NUM
         self.ecaction_ = [ExecutionContextActionListenerHolder()
                           for i in range(self.ecaction_num)]
+
+    def addPreActionListener(self, ltype, listener):
+        if ltype < len(self.preaction_):
+            self.preaction_[ltype].addListener(listener)
+            return True
+        return False
+
+    def addPostActionListener(self, ltype, listener):
+        if ltype < len(self.postaction_):
+            self.postaction_[ltype].addListener(listener)
+            return True
+        return False
+
+    def addPortActionListener(self, ltype, listener):
+        if ltype < len(self.portaction_):
+            self.portaction_[ltype].addListener(listener)
+            return True
+        return False
+
+    def addECActionListener(self, ltype, listener):
+        if ltype < len(self.ecaction_):
+            self.ecaction_[ltype].addListener(listener)
+            return True
+        return False
+
+    def removePreActionListener(self, ltype, listener):
+        if ltype < len(self.preaction_):
+            self.preaction_[ltype].removeListener(listener)
+            return True
+        return False
+
+    def removePostActionListener(self, ltype, listener):
+        if ltype < len(self.postaction_):
+            self.postaction_[ltype].removeListener(listener)
+            return True
+        return False
+
+    def removePortActionListener(self, ltype, listener):
+        if ltype < len(self.portaction_):
+            self.portaction_[ltype].removeListener(listener)
+            return True
+        return False
+
+    def removeECActionListener(self, ltype, listener):
+        if ltype < len(self.ecaction_):
+            self.ecaction_[ltype].removeListener(listener)
+            return True
+        return False
+
+    def notifyPreAction(self, ltype, ec_id):
+        if ltype < len(self.preaction_):
+            self.preaction_[ltype].notify(ec_id)
+
+    def notifyPostAction(self, ltype, ec_id, ret):
+        if ltype < len(self.postaction_):
+            self.postaction_[ltype].notify(ec_id, ret)
+
+    def notifyPortAction(self, ltype, pprofile):
+        if ltype < len(self.portaction_):
+            self.portaction_[ltype].notify(pprofile)
+
+    def notifyECAction(self, ltype, ec_id):
+        if ltype < len(self.ecaction_):
+            self.ecaction_[ltype].notify(ec_id)

--- a/OpenRTM_aist/ConfigAdmin.py
+++ b/OpenRTM_aist/ConfigAdmin.py
@@ -1172,9 +1172,8 @@ class ConfigAdmin:
     def setOnUpdate(self, cb):
         print("setOnUpdate function is obsolete.")
         print("Use addConfigurationSetNameListener instead.")
-        self._listeners.configsetname_[
-            OpenRTM_aist.ConfigurationSetNameListenerType.ON_UPDATE_CONFIG_SET].addListener(
-            cb)
+        self._listeners.addConfigurationSetNameListener(
+            OpenRTM_aist.ConfigurationSetNameListenerType.ON_UPDATE_CONFIG_SET, cb)
         return
 
     ##
@@ -1201,9 +1200,8 @@ class ConfigAdmin:
     def setOnUpdateParam(self, cb):
         print("setOnUpdateParam function is obsolete.")
         print("Use addConfigurationParamListener instead.")
-        self._listeners.configparam_[
-            OpenRTM_aist.ConfigurationParamListenerType.ON_UPDATE_CONFIG_PARAM].addListener(
-            cb)
+        self._listeners.addConfigParamListener(
+            OpenRTM_aist.ConfigurationParamListenerType.ON_UPDATE_CONFIG_PARAM, cb)
         return
 
     ##
@@ -1230,9 +1228,8 @@ class ConfigAdmin:
     def setOnSetConfigurationSet(self, cb):
         print("setOnSetConfigurationSet function is obsolete.")
         print("Use addConfigurationSetListener instead.")
-        self._listeners.configset_[
-            OpenRTM_aist.ConfigurationSetListenerType.ON_SET_CONFIG_SET].addListener(
-            cb)
+        self._listeners.addConfigurationSetListener(
+            OpenRTM_aist.ConfigurationSetListenerType.ON_SET_CONFIG_SET, cb)
         return
 
     ##
@@ -1259,9 +1256,8 @@ class ConfigAdmin:
     def setOnAddConfigurationSet(self, cb):
         print("setOnAddConfigurationSet function is obsolete.")
         print("Use addConfigurationSetListener instead.")
-        self._listeners.configset_[
-            OpenRTM_aist.ConfigurationSetListenerType.ON_ADD_CONFIG_SET].addListener(
-            cb)
+        self._listeners.addConfigurationSetListener(
+            OpenRTM_aist.ConfigurationSetListenerType.ON_ADD_CONFIG_SET, cb)
         return
 
     ##
@@ -1288,9 +1284,8 @@ class ConfigAdmin:
     def setOnRemoveConfigurationSet(self, cb):
         print("setOnRemoveConfigurationSet function is obsolete.")
         print("Use addConfigurationSetNameListener instead.")
-        self._listeners.configsetname_[
-            OpenRTM_aist.ConfigurationSetNameListenerType.ON_REMOVE_CONFIG_SET].addListener(
-            cb)
+        self._listeners.addConfigurationSetNameListener(
+            OpenRTM_aist.ConfigurationSetNameListenerType.ON_REMOVE_CONFIG_SET, cb)
         return
 
     ##
@@ -1317,9 +1312,8 @@ class ConfigAdmin:
     def setOnActivateSet(self, cb):
         print("setOnActivateSet function is obsolete.")
         print("Use addConfigurationSetNameListener instead.")
-        self._listeners.configsetname_[
-            OpenRTM_aist.ConfigurationSetNameListenerType.ON_ACTIVATE_CONFIG_SET].addListener(
-            cb)
+        self._listeners.addConfigurationSetNameListener(
+            OpenRTM_aist.ConfigurationSetNameListenerType.ON_ACTIVATE_CONFIG_SET, cb)
         return
 
     #
@@ -1359,7 +1353,7 @@ class ConfigAdmin:
     # void addConfigurationParamListener(ConfigurationParamListenerType type,
     #                                    ConfigurationParamListener* listener);
     def addConfigurationParamListener(self, type, listener):
-        self._listeners.configparam_[type].addListener(listener)
+        self._listeners.addConfigParamListener(type, listener)
         return
 
     ##
@@ -1390,7 +1384,7 @@ class ConfigAdmin:
     # ConfigurationParamListener* listener);
 
     def removeConfigurationParamListener(self, type, listener):
-        self._listeners.configparam_[type].removeListener(listener)
+        self._listeners.removeConfigParamListener(type, listener)
         return
 
     ##
@@ -1426,7 +1420,7 @@ class ConfigAdmin:
     #                                  ConfigurationSetListener* listener);
 
     def addConfigurationSetListener(self, type, listener):
-        self._listeners.configset_[type].addListener(listener)
+        self._listeners.addConfigurationSetListener(type, listener)
         return
 
     ##
@@ -1454,7 +1448,7 @@ class ConfigAdmin:
     #                                     ConfigurationSetListener* listener);
 
     def removeConfigurationSetListener(self, type, listener):
-        self._listeners.configset_[type].removeListener(listener)
+        self._listeners.removeConfigurationSetListener(type, listener)
         return
 
     ##
@@ -1493,7 +1487,7 @@ class ConfigAdmin:
     #                                 ConfigurationSetNameListener* listener);
 
     def addConfigurationSetNameListener(self, type, listener):
-        self._listeners.configsetname_[type].addListener(listener)
+        self._listeners.addConfigurationSetNameListener(type, listener)
         return
 
     ##
@@ -1526,7 +1520,7 @@ class ConfigAdmin:
     # ConfigurationSetNameListener* listener);
 
     def removeConfigurationSetNameListener(self, type, listener):
-        self._listeners.configsetname_[type].removeListener(listener)
+        self._listeners.removeConfigurationSetNameListener(type, listener)
         return
 
     ##
@@ -1553,8 +1547,7 @@ class ConfigAdmin:
     # void onUpdate(const char* config_set);
 
     def onUpdate(self, config_set):
-        self._listeners.configsetname_[
-            OpenRTM_aist.ConfigurationSetNameListenerType.ON_UPDATE_CONFIG_SET].notify(config_set)
+        self._listeners.notifyConfigurationSetName(OpenRTM_aist.ConfigurationSetNameListenerType.ON_UPDATE_CONFIG_SET, config_set)
         return
 
     ##
@@ -1584,7 +1577,7 @@ class ConfigAdmin:
 
     def onUpdateParam(self, config_param, config_value):
         self._changedParam.append(config_param)
-        self._listeners.configparam_[OpenRTM_aist.ConfigurationParamListenerType.ON_UPDATE_CONFIG_PARAM].notify(config_param,
+        self._listeners.notifyConfigParam(OpenRTM_aist.ConfigurationParamListenerType.ON_UPDATE_CONFIG_PARAM, config_param,
                                                                                                                 config_value)
         return
 
@@ -1612,8 +1605,7 @@ class ConfigAdmin:
     # void onSetConfigurationSet(const coil::Properties& config_set);
 
     def onSetConfigurationSet(self, config_set):
-        self._listeners.configset_[
-            OpenRTM_aist.ConfigurationSetListenerType.ON_SET_CONFIG_SET].notify(config_set)
+        self._listeners.notifyConfigurationSet(OpenRTM_aist.ConfigurationSetListenerType.ON_SET_CONFIG_SET, config_set)
         return
 
     ##
@@ -1640,8 +1632,7 @@ class ConfigAdmin:
     # void onAddConfigurationSet(const coil::Properties& config_set);
 
     def onAddConfigurationSet(self, config_set):
-        self._listeners.configset_[
-            OpenRTM_aist.ConfigurationSetListenerType.ON_ADD_CONFIG_SET].notify(config_set)
+        self._listeners.notifyConfigurationSet(OpenRTM_aist.ConfigurationSetListenerType.ON_ADD_CONFIG_SET, config_set)
         return
 
     ##
@@ -1668,8 +1659,7 @@ class ConfigAdmin:
     # void onRemoveConfigurationSet(const char* config_id);
 
     def onRemoveConfigurationSet(self, config_id):
-        self._listeners.configsetname_[
-            OpenRTM_aist.ConfigurationSetNameListenerType.ON_REMOVE_CONFIG_SET].notify(config_id)
+        self._listeners.notifyConfigurationSetName(OpenRTM_aist.ConfigurationSetNameListenerType.ON_REMOVE_CONFIG_SET, config_id)
         return
 
     ##
@@ -1696,8 +1686,7 @@ class ConfigAdmin:
     # void onActivateSet(const char* config_id);
 
     def onActivateSet(self, config_id):
-        self._listeners.configsetname_[
-            OpenRTM_aist.ConfigurationSetNameListenerType.ON_ACTIVATE_CONFIG_SET].notify(config_id)
+        self._listeners.notifyConfigurationSetName(OpenRTM_aist.ConfigurationSetNameListenerType.ON_ACTIVATE_CONFIG_SET, config_id)
         return
 
     class find_conf:

--- a/OpenRTM_aist/ConfigurationListener.py
+++ b/OpenRTM_aist/ConfigurationListener.py
@@ -735,7 +735,18 @@ class ConfigurationSetNameListenerHolder:
 class ConfigurationListeners:
     """
     """
-
+    ##
+    # @if jp
+    # @brief コンストラクタ
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @param self
+    #
+    # @endif
     def __init__(self):
         ##
         # @if jp
@@ -773,50 +784,220 @@ class ConfigurationListeners:
         self.configsetname_ = [ConfigurationSetNameListenerHolder()
                                for i in range(self.configsetname_num)]
 
+    ##
+    # @if jp
+    # @brief リスナーの追加
+    #
+    # 指定の種類のConfigurationParamListenerを追加する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 追加するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def addConfigParamListener(self, ltype, listener):
         if ltype < len(self.configparam_):
             self.configparam_[ltype].addListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの追加
+    #
+    # 指定の種類のConfigurationSetListenerを追加する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 追加するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def addConfigurationSetListener(self, ltype, listener):
         if ltype < len(self.configset_):
             self.configset_[ltype].addListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの追加
+    #
+    # 指定の種類のConfigurationSetNameListenerを追加する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 追加するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def addConfigurationSetNameListener(self, ltype, listener):
         if ltype < len(self.configsetname_):
             self.configsetname_[ltype].addListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの削除
+    #
+    # 指定の種類のConfigParamListenerを削除する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 削除するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def removeConfigParamListener(self, ltype, listener):
         if ltype < len(self.configparam_):
             self.configparam_[ltype].removeListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの削除
+    #
+    # 指定の種類のConfigurationSetListenerを削除する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 削除するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def removeConfigurationSetListener(self, ltype, listener):
         if ltype < len(self.configset_):
             self.configset_[ltype].removeListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの削除
+    #
+    # 指定の種類のConfigurationSetNameListenerを削除する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 削除するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def removeConfigurationSetNameListener(self, ltype, listener):
         if ltype < len(self.configsetname_):
             self.configsetname_[ltype].removeListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーへ通知する
+    #
+    # 指定の種類のConfigurationParamListenerのコールバック関数を呼び出す。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param config_set_name コンフィギュレーションセット名
+    # @param config_param_name コンフィギュレーションパラメータ名
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param config_set_name
+    # @param config_param_name
+    # @return
+    #
+    # @endif
     def notifyConfigParam(self, ltype, config_set_name, config_param_name):
         if ltype < len(self.configparam_):
             self.configparam_[ltype].notify(config_set_name, config_param_name)
 
+    ##
+    # @if jp
+    # @brief リスナーへ通知する
+    #
+    # 指定の種類のConfigurationSetListenerのコールバック関数を呼び出す。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param config_set コンフィギュレーションセット
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param config_set
+    # @return
+    #
+    # @endif
     def notifyConfigurationSet(self, ltype, config_set):
         if ltype < len(self.configset_):
             self.configset_[ltype].notify(config_set)
 
+    ##
+    # @if jp
+    # @brief リスナーへ通知する
+    #
+    # 指定の種類のConfigurationSetNameListenerのコールバック関数を呼び出す。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param config_set_name コンフィギュレーションセット名
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param config_set_name
+    # @return
+    #
+    # @endif
     def notifyConfigurationSetName(self, ltype, config_set_name):
         if ltype < len(self.configsetname_):
             self.configsetname_[ltype].notify(config_set_name)

--- a/OpenRTM_aist/ConfigurationListener.py
+++ b/OpenRTM_aist/ConfigurationListener.py
@@ -772,3 +772,51 @@ class ConfigurationListeners:
         self.configsetname_num = ConfigurationSetNameListenerType.CONFIG_SET_NAME_LISTENER_NUM
         self.configsetname_ = [ConfigurationSetNameListenerHolder()
                                for i in range(self.configsetname_num)]
+
+    def addConfigParamListener(self, ltype, listener):
+        if ltype < len(self.configparam_):
+            self.configparam_[ltype].addListener(listener)
+            return True
+        return False
+
+    def addConfigurationSetListener(self, ltype, listener):
+        if ltype < len(self.configset_):
+            self.configset_[ltype].addListener(listener)
+            return True
+        return False
+
+    def addConfigurationSetNameListener(self, ltype, listener):
+        if ltype < len(self.configsetname_):
+            self.configsetname_[ltype].addListener(listener)
+            return True
+        return False
+
+    def removeConfigParamListener(self, ltype, listener):
+        if ltype < len(self.configparam_):
+            self.configparam_[ltype].removeListener(listener)
+            return True
+        return False
+
+    def removeConfigurationSetListener(self, ltype, listener):
+        if ltype < len(self.configset_):
+            self.configset_[ltype].removeListener(listener)
+            return True
+        return False
+
+    def removeConfigurationSetNameListener(self, ltype, listener):
+        if ltype < len(self.configsetname_):
+            self.configsetname_[ltype].removeListener(listener)
+            return True
+        return False
+
+    def notifyConfigParam(self, ltype, config_set_name, config_param_name):
+        if ltype < len(self.configparam_):
+            self.configparam_[ltype].notify(config_set_name, config_param_name)
+
+    def notifyConfigurationSet(self, ltype, config_set):
+        if ltype < len(self.configset_):
+            self.configset_[ltype].notify(config_set)
+
+    def notifyConfigurationSetName(self, ltype, config_set_name):
+        if ltype < len(self.configsetname_):
+            self.configsetname_[ltype].notify(config_set_name)

--- a/OpenRTM_aist/ConnectorListener.py
+++ b/OpenRTM_aist/ConnectorListener.py
@@ -996,3 +996,37 @@ class ConnectorListeners:
     def setPortType(self, porttype):
         for holder in self.connectorData_:
             holder.setPortType(porttype)
+
+    def notifyData(self, ltype, info, cdrdata):
+        if ltype < len(self.connectorData_):
+            return self.connectorData_[ltype].notify(info, cdrdata)
+        return ConnectorListenerStatus.NO_CHANGE, None
+
+    def notify(self, ltype, info):
+        if ltype < len(self.connector_):
+            return self.connector_[ltype].notify(info)
+        return ConnectorListenerStatus.NO_CHANGE
+
+    def addListener(self, ltype, listener):
+        if ltype < len(self.connector_):
+            self.connector_[ltype].addListener(listener)
+            return True
+        return False
+
+    def addDataListener(self, ltype, listener):
+        if ltype < len(self.connectorData_):
+            self.connectorData_[ltype].addListener(listener)
+            return True
+        return False
+
+    def removeListener(self, ltype, listener):
+        if ltype < len(self.connector_):
+            self.connector_[ltype].removeListener(listener)
+            return True
+        return False
+
+    def removeDataListener(self, ltype, listener):
+        if ltype < len(self.connectorData_):
+            self.connectorData_[ltype].removeListener(listener)
+            return True
+        return False

--- a/OpenRTM_aist/ConnectorListener.py
+++ b/OpenRTM_aist/ConnectorListener.py
@@ -982,51 +982,215 @@ class ConnectorListenerHolder:
 
 
 class ConnectorListeners:
+    ##
+    # @if jp
+    # @brief コンストラクタ
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @param self
+    #
+    # @endif
     def __init__(self):
         self.connectorData_ = [OpenRTM_aist.ConnectorDataListenerHolder() for i in range(
             OpenRTM_aist.ConnectorDataListenerType.CONNECTOR_DATA_LISTENER_NUM)]
         self.connector_ = [OpenRTM_aist.ConnectorListenerHolder() for i in range(
             OpenRTM_aist.ConnectorListenerType.CONNECTOR_LISTENER_NUM)]
         return
+    ##
+    # @if jp
+    # @brief データ型の設定
+    #
+    # OutPort、InPortで初期化する際にデータ型を指定すると、
+    # ConnectorDataListenerTを継承したリスナでコールバック関数に
+    # 指定データ型にデシリアライズしたデータを入力する。
+    # データ型を指定しない場合はコールバック関数で明示的にデシリアライズする必要がある。
+    #
+    # @param self
+    # @param dataType データ型
+    #
+    # @else
+    #
+    # @param self
+    # @param dataType
+    #
+    # @endif
 
     def setDataType(self, dataType):
         for holder in self.connectorData_:
             holder.setDataType(dataType)
 
+    ##
+    # @if jp
+    # @brief ポート型の指定
+    #
+    # OutPortの場合はPortType.OutPortType、InPortの場合はPortType.InPortTypeを指定する
+    #
+    # @param self
+    # @param porttype ポート型
+    #
+    # @else
+    #
+    # @param self
+    # @param porttype
+    #
+    # @endif
     def setPortType(self, porttype):
         for holder in self.connectorData_:
             holder.setPortType(porttype)
 
-    def notifyData(self, ltype, info, cdrdata):
-        if ltype < len(self.connectorData_):
-            return self.connectorData_[ltype].notify(info, cdrdata)
-        return ConnectorListenerStatus.NO_CHANGE, None
-
-    def notify(self, ltype, info):
-        if ltype < len(self.connector_):
-            return self.connector_[ltype].notify(info)
-        return ConnectorListenerStatus.NO_CHANGE
-
+    ##
+    # @if jp
+    # @brief リスナーの追加
+    #
+    # 指定の種類のConnectorListenerを追加する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 追加するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def addListener(self, ltype, listener):
         if ltype < len(self.connector_):
             self.connector_[ltype].addListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの追加
+    #
+    # 指定の種類のConnectorDataListenerを追加する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 追加するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def addDataListener(self, ltype, listener):
         if ltype < len(self.connectorData_):
             self.connectorData_[ltype].addListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの削除
+    #
+    # 指定の種類のConnectorListenerを削除する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 削除するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def removeListener(self, ltype, listener):
         if ltype < len(self.connector_):
             self.connector_[ltype].removeListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの削除
+    #
+    # 指定の種類のConnectorDataListenerを削除する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 削除するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def removeDataListener(self, ltype, listener):
         if ltype < len(self.connectorData_):
             self.connectorData_[ltype].removeListener(listener)
             return True
         return False
+
+    ##
+    # @if jp
+    # @brief リスナーへ通知する
+    #
+    # 指定の種類のConnectorDataListenerのコールバック関数を呼び出す。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param info ConnectorInfo
+    # @param cdrdata バイト列のデータ
+    # @return ret, data
+    # ret：ConnectorListenerStatus
+    # data：バイト列のデータ。リスナで変更する場合がある。
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param info
+    # @param cdrdata
+    # @return
+    #
+    # @endif
+    def notifyData(self, ltype, info, cdrdata):
+        if ltype < len(self.connectorData_):
+            return self.connectorData_[ltype].notify(info, cdrdata)
+        return ConnectorListenerStatus.NO_CHANGE, None
+
+    ##
+    # @if jp
+    # @brief リスナーへ通知する
+    #
+    # 指定の種類のConnectorListenerのコールバック関数を呼び出す。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param info ConnectorInfo
+    # @return ret：ConnectorListenerStatus
+    #
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param info
+    # @return
+    #
+    # @endif
+    def notify(self, ltype, info):
+        if ltype < len(self.connector_):
+            return self.connector_[ltype].notify(info)
+        return ConnectorListenerStatus.NO_CHANGE

--- a/OpenRTM_aist/FsmActionListener.py
+++ b/OpenRTM_aist/FsmActionListener.py
@@ -1541,3 +1541,68 @@ class FsmActionListeners:
         self.structure_num = FsmStructureListenerType.FSM_STRUCTURE_LISTENER_NUM
         self.structure_ = [FsmStructureListenerHolder()
                            for i in range(self.structure_num)]
+
+
+    def addPreActionListener(self, ltype, listener):
+        if ltype < len(self.preaction_):
+            self.preaction_[ltype].addListener(listener)
+            return True
+        return False
+
+    def addPostActionListener(self, ltype, listener):
+        if ltype < len(self.postaction_):
+            self.postaction_[ltype].addListener(listener)
+            return True
+        return False
+
+    def addProfileListener(self, ltype, listener):
+        if ltype < len(self.profile_):
+            self.profile_[ltype].addListener(listener)
+            return True
+        return False
+
+    def addStructureListener(self, ltype, listener):
+        if ltype < len(self.structure_):
+            self.structure_[ltype].addListener(listener)
+            return True
+        return False
+
+    def removePreActionListener(self, ltype, listener):
+        if ltype < len(self.preaction_):
+            self.preaction_[ltype].removeListener(listener)
+            return True
+        return False
+
+    def removePostActionListener(self, ltype, listener):
+        if ltype < len(self.postaction_):
+            self.postaction_[ltype].removeListener(listener)
+            return True
+        return False
+
+    def removeProfileListener(self, ltype, listener):
+        if ltype < len(self.profile_):
+            self.profile_[ltype].removeListener(listener)
+            return True
+        return False
+
+    def removeStructureListener(self, ltype, listener):
+        if ltype < len(self.structure_):
+            self.structure_[ltype].removeListener(listener)
+            return True
+        return False
+
+    def notifyPreAction(self, ltype, ec_id):
+        if ltype < len(self.preaction_):
+            self.preaction_[ltype].notify(ec_id)
+
+    def notifyPostAction(self, ltype, ec_id, ret):
+        if ltype < len(self.postaction_):
+            self.postaction_[ltype].notify(ec_id, ret)
+
+    def notifyProfile(self, ltype, pprofile):
+        if ltype < len(self.profile_):
+            self.profile_[ltype].notify(pprofile)
+
+    def notifyStructure(self, ltype, ec_id):
+        if ltype < len(self.structure_):
+            self.structure_[ltype].notify(ec_id)

--- a/OpenRTM_aist/FsmActionListener.py
+++ b/OpenRTM_aist/FsmActionListener.py
@@ -1492,6 +1492,18 @@ class FsmStructureListenerHolder:
 #
 # @endif
 class FsmActionListeners:
+    ##
+    # @if jp
+    # @brief コンストラクタ
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @param self
+    #
+    # @endif
     def __init__(self):
 
         ##
@@ -1542,67 +1554,288 @@ class FsmActionListeners:
         self.structure_ = [FsmStructureListenerHolder()
                            for i in range(self.structure_num)]
 
-
+    ##
+    # @if jp
+    # @brief リスナーの追加
+    #
+    # 指定の種類のPreFsmActionListenerを追加する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 追加するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def addPreActionListener(self, ltype, listener):
         if ltype < len(self.preaction_):
             self.preaction_[ltype].addListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの追加
+    #
+    # 指定の種類のPostFsmActionListenerを追加する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 追加するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def addPostActionListener(self, ltype, listener):
         if ltype < len(self.postaction_):
             self.postaction_[ltype].addListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの追加
+    #
+    # 指定の種類のFsmProfileListenerを追加する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 追加するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def addProfileListener(self, ltype, listener):
         if ltype < len(self.profile_):
             self.profile_[ltype].addListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの追加
+    #
+    # 指定の種類のFsmStructureListenerを追加する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 追加するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def addStructureListener(self, ltype, listener):
         if ltype < len(self.structure_):
             self.structure_[ltype].addListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの削除
+    #
+    # 指定の種類のPreFsmActionListenerを削除する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 削除するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def removePreActionListener(self, ltype, listener):
         if ltype < len(self.preaction_):
             self.preaction_[ltype].removeListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの削除
+    #
+    # 指定の種類のPostFsmActionListenerを削除する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 削除するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def removePostActionListener(self, ltype, listener):
         if ltype < len(self.postaction_):
             self.postaction_[ltype].removeListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの削除
+    #
+    # 指定の種類のFsmProfileListenerを削除する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 削除するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def removeProfileListener(self, ltype, listener):
         if ltype < len(self.profile_):
             self.profile_[ltype].removeListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの削除
+    #
+    # 指定の種類のFsmStructureListenerを削除する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 削除するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def removeStructureListener(self, ltype, listener):
         if ltype < len(self.structure_):
             self.structure_[ltype].removeListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーへ通知する
+    #
+    # 指定の種類のPreFsmActionListenerのコールバック関数を呼び出す。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param ec_id 実行コンテキストのID
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param ec_id
+    #
+    # @endif
     def notifyPreAction(self, ltype, ec_id):
         if ltype < len(self.preaction_):
             self.preaction_[ltype].notify(ec_id)
 
+    ##
+    # @if jp
+    # @brief リスナーへ通知する
+    #
+    # 指定の種類のPostFsmActionListenerのコールバック関数を呼び出す。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param ec_id 実行コンテキストのID
+    # @param ret リターンコード
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param ec_id
+    # @param ret 
+    #
+    # @endif
     def notifyPostAction(self, ltype, ec_id, ret):
         if ltype < len(self.postaction_):
             self.postaction_[ltype].notify(ec_id, ret)
 
+    ##
+    # @if jp
+    # @brief リスナーへ通知する
+    #
+    # 指定の種類のFsmStructureListenerのコールバック関数を呼び出す。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param pprofile ポートプロファイル
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param pprofile
+    #
+    # @endif
     def notifyProfile(self, ltype, pprofile):
         if ltype < len(self.profile_):
             self.profile_[ltype].notify(pprofile)
 
+    ##
+    # @if jp
+    # @brief リスナーへ通知する
+    #
+    # 指定の種類のFsmStructureListenerのコールバック関数を呼び出す。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param ec_id 実行コンテキストのID
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param ec_id
+    #
+    # @endif
     def notifyStructure(self, ltype, ec_id):
         if ltype < len(self.structure_):
             self.structure_[ltype].notify(ec_id)

--- a/OpenRTM_aist/InPortBase.py
+++ b/OpenRTM_aist/InPortBase.py
@@ -734,8 +734,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
     def addConnectorDataListener(self, listener_type, listener):
         self._rtcout.RTC_TRACE("addConnectorDataListener()")
 
-        if listener_type < OpenRTM_aist.ConnectorDataListenerType.CONNECTOR_DATA_LISTENER_NUM:
-            self._listeners.connectorData_[listener_type].addListener(listener)
+        if self._listeners.addDataListener(listener_type, listener):
             return
 
         self._rtcout.RTC_ERROR(
@@ -767,9 +766,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
     def removeConnectorDataListener(self, listener_type, listener):
         self._rtcout.RTC_TRACE("removeConnectorDataListener()")
 
-        if listener_type < OpenRTM_aist.ConnectorDataListenerType.CONNECTOR_DATA_LISTENER_NUM:
-            self._listeners.connectorData_[
-                listener_type].removeListener(listener)
+        if self._listeners.removeDataListener(listener_type, listener):
             return
 
         self._rtcout.RTC_ERROR(
@@ -833,7 +830,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
         self._rtcout.RTC_TRACE("addConnectorListener()")
 
         if listener_type < OpenRTM_aist.ConnectorListenerType.CONNECTOR_LISTENER_NUM:
-            self._listeners.connector_[listener_type].addListener(listener)
+            self._listeners.addListener(listener_type, listener)
             return
 
         self._rtcout.RTC_ERROR(
@@ -866,7 +863,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
         self._rtcout.RTC_TRACE("removeConnectorListener()")
 
         if listener_type < OpenRTM_aist.ConnectorListenerType.CONNECTOR_LISTENER_NUM:
-            self._listeners.connector_[listener_type].removeListener(listener)
+            self._listeners.removeListener(listener_type, listener)
             return
 
         self._rtcout.RTC_ERROR(

--- a/OpenRTM_aist/InPortCSPProvider.py
+++ b/OpenRTM_aist/InPortCSPProvider.py
@@ -193,58 +193,50 @@ class InPortCSPProvider(OpenRTM_aist.InPortProvider, CSP__POA.InPortCsp):
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE, self._profile, data)
         return data
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL, self._profile, data)
         return data
 
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT, self._profile, data)
         return data
 
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE, self._profile, data)
         return data
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED, self._profile, data)
         return data
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
-                self._profile, data)
+            self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL, self._profile, data)
         return
 
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT, self._profile, data)
         return data
 
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR, self._profile, data)
         return data
 
     def convertReturn(self, status, data):

--- a/OpenRTM_aist/InPortCorbaCdrProvider.py
+++ b/OpenRTM_aist/InPortCorbaCdrProvider.py
@@ -225,71 +225,63 @@ class InPortCorbaCdrProvider(OpenRTM_aist.InPortProvider,
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE, self._profile, data)
         return data
 
     # inline void onBufferFull(const cdrMemoryStream& data)
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL, self._profile, data)
         return data
 
     # inline void onBufferWriteTimeout(const cdrMemoryStream& data)
 
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT, self._profile, data)
         return data
 
     # inline void onBufferWriteOverwrite(const cdrMemoryStream& data)
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE, self._profile, data)
         return data
 
     # inline void onReceived(const cdrMemoryStream& data)
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED, self._profile, data)
         return data
 
     # inline void onReceiverFull(const cdrMemoryStream& data)
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL, self._profile, data)
         return data
 
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
 
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT, self._profile, data)
         return data
 
     # inline void onReceiverError(const cdrMemoryStream& data)
 
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
-                self._profile, data)
+            self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR, self._profile, data)
         return data
 
 

--- a/OpenRTM_aist/InPortDSProvider.py
+++ b/OpenRTM_aist/InPortDSProvider.py
@@ -228,71 +228,63 @@ class InPortDSProvider(OpenRTM_aist.InPortProvider,
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE, self._profile, data)
         return data
 
     # inline void onBufferFull(const cdrMemoryStream& data)
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL, self._profile, data)
         return data
 
     # inline void onBufferWriteTimeout(const cdrMemoryStream& data)
 
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT, self._profile, data)
         return data
 
     # inline void onBufferWriteOverwrite(const cdrMemoryStream& data)
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE, self._profile, data)
         return data
 
     # inline void onReceived(const cdrMemoryStream& data)
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED, self._profile, data)
         return data
 
     # inline void onReceiverFull(const cdrMemoryStream& data)
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL, self._profile, data)
         return data
 
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
 
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT, self._profile, data)
         return data
 
     # inline void onReceiverError(const cdrMemoryStream& data)
 
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR, self._profile, data)
         return data
 
 

--- a/OpenRTM_aist/InPortDirectProvider.py
+++ b/OpenRTM_aist/InPortDirectProvider.py
@@ -119,71 +119,63 @@ class InPortDirectProvider(OpenRTM_aist.InPortProvider):
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE, self._profile, data)
         return data
 
     # inline void onBufferFull(const cdrMemoryStream& data)
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL, self._profile, data)
         return data
 
     # inline void onBufferWriteTimeout(const cdrMemoryStream& data)
 
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT, self._profile, data)
         return data
 
     # inline void onBufferWriteOverwrite(const cdrMemoryStream& data)
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE, self._profile, data)
         return data
 
     # inline void onReceived(const cdrMemoryStream& data)
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED, self._profile, data)
         return data
 
     # inline void onReceiverFull(const cdrMemoryStream& data)
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL, self._profile, data)
         return data
 
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
 
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT, self._profile, data)
         return data
 
     # inline void onReceiverError(const cdrMemoryStream& data)
 
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR, self._profile, data)
         return data
 
 

--- a/OpenRTM_aist/InPortDuplexConnector.py
+++ b/OpenRTM_aist/InPortDuplexConnector.py
@@ -385,8 +385,7 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
     # void onConnect()
     def onConnect(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_CONNECT].notify(self._profile)
+            self._listeners.notify(OpenRTM_aist.ConnectorListenerType.ON_CONNECT, self._profile)
         return
 
     ##
@@ -398,8 +397,7 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
     # void onDisconnect()
     def onDisconnect(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_DISCONNECT].notify(self._profile)
+            self._listeners.notify(OpenRTM_aist.ConnectorListenerType.ON_DISCONNECT, self._profile)
         return
 
     ##
@@ -414,20 +412,17 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
 
     def onBufferRead(self, data):
         if self._listeners and self._profile:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(self._profile, data)
+            _, data = self._listeners.notifyData(OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ, self._profile, data)
         return data
 
     def onBufferEmpty(self, data):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY].notify(self._profile)
+            self._listeners.notify(OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY, self._profile)
         return
 
     def onBufferReadTimeout(self, data):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_READ_TIMEOUT].notify(self._profile)
+            self._listeners.notify(OpenRTM_aist.ConnectorListenerType.ON_BUFFER_READ_TIMEOUT, self._profile)
         return
 
     ##

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -209,27 +209,25 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
 
         if self._directOutPort is not None:
             if self._directOutPort.isEmpty():
-                self._listeners.connector_[
-                    OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY].notify(
-                    self._profile)
-                self._outPortListeners.connector_[
-                    OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY].notify(
-                    self._profile)
+                self._listeners.notify(
+                    OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY, self._profile)
+                self._outPortListeners.notify(
+                    OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY, self._profile)
                 self._rtcout.RTC_TRACE("ON_BUFFER_EMPTY(InPort,OutPort), ")
                 self._rtcout.RTC_TRACE("ON_SENDER_EMPTY(InPort,OutPort) ")
                 self._rtcout.RTC_TRACE("callback called in direct mode.")
 
             data = self._directOutPort.read()
-            #self._outPortListeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(self._profile, data)
+            #self._outPortListeners.notifyData(OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ, self._profile, data)
             self._rtcout.RTC_TRACE("ON_BUFFER_READ(OutPort), ")
             self._rtcout.RTC_TRACE("callback called in direct mode.")
-            #self._outPortListeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(self._profile, data)
+            #self._outPortListeners.notifyData(OpenRTM_aist.ConnectorDataListenerType.ON_SEND, self._profile, data)
             self._rtcout.RTC_TRACE("ON_SEND(OutPort), ")
             self._rtcout.RTC_TRACE("callback called in direct mode.")
-            #self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(self._profile, data)
+            #self._listeners.notifyData(OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED, self._profile, data)
             self._rtcout.RTC_TRACE("ON_RECEIVED(InPort), ")
             self._rtcout.RTC_TRACE("callback called in direct mode.")
-            #self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(self._profile, data)
+            #self._listeners.notifyData(OpenRTM_aist.ConnectorDataListenerType.ON_SEND, self._profile, data)
             self._rtcout.RTC_TRACE("ON_BUFFER_WRITE(InPort), ")
             self._rtcout.RTC_TRACE("callback called in direct mode.")
             return self.PORT_OK, data
@@ -357,9 +355,8 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
     # void onConnect()
     def onConnect(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_CONNECT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_CONNECT, self._profile)
         return
 
     ##
@@ -371,9 +368,8 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
     # void onDisconnect()
     def onDisconnect(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_DISCONNECT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_DISCONNECT, self._profile)
         return
 
     ##

--- a/OpenRTM_aist/InPortPushConnector.py
+++ b/OpenRTM_aist/InPortPushConnector.py
@@ -481,9 +481,8 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
 
     def onConnect(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_CONNECT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_CONNECT, self._profile)
         return
 
     ##
@@ -495,30 +494,26 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
     # void onDisconnect()
     def onDisconnect(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_DISCONNECT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_DISCONNECT, self._profile)
         return
 
     def onBufferRead(self, data):
         if self._listeners and self._profile:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ, self._profile, data)
         return data
 
     def onBufferEmpty(self, data):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY, self._profile)
         return
 
     def onBufferReadTimeout(self, data):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_READ_TIMEOUT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_READ_TIMEOUT, self._profile)
         return
 
     class WorkerThreadCtrl:

--- a/OpenRTM_aist/InPortSHMProvider.py
+++ b/OpenRTM_aist/InPortSHMProvider.py
@@ -167,58 +167,50 @@ class InPortSHMProvider(OpenRTM_aist.InPortProvider,
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE, self._profile, data)
         return data
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL, self._profile, data)
         return data
 
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT, self._profile, data)
         return data
 
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE, self._profile, data)
         return data
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED, self._profile, data)
         return data
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL, self._profile, data)
         return data
 
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT, self._profile, data)
         return data
 
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR, self._profile, data)
         return data
 
     def convertReturn(self, status, data):

--- a/OpenRTM_aist/OutPortBase.py
+++ b/OpenRTM_aist/OutPortBase.py
@@ -798,10 +798,9 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
 
     def addConnectorDataListener(self, listener_type, listener):
         self._rtcout.RTC_TRACE("addConnectorDataListener()")
-        if listener_type < OpenRTM_aist.ConnectorDataListenerType.CONNECTOR_DATA_LISTENER_NUM:
+        if self._listeners.addDataListener(listener_type, listener):
             self._rtcout.RTC_TRACE("addConnectorDataListener(%s)",
                                    OpenRTM_aist.ConnectorDataListener.toString(listener_type))
-            self._listeners.connectorData_[listener_type].addListener(listener)
             return
 
         self._rtcout.RTC_ERROR(
@@ -833,11 +832,9 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
     def removeConnectorDataListener(self, listener_type, listener):
         self._rtcout.RTC_TRACE("removeConnectorDataListener()")
 
-        if listener_type < OpenRTM_aist.ConnectorDataListenerType.CONNECTOR_DATA_LISTENER_NUM:
+        if self._listeners.removeDataListener(listener_type, listener):
             self._rtcout.RTC_TRACE("removeConnectorDataListener(%s)",
                                    OpenRTM_aist.ConnectorDataListener.toString(listener_type))
-            self._listeners.connectorData_[
-                listener_type].removeListener(listener)
             return
 
         self._rtcout.RTC_ERROR(
@@ -900,10 +897,9 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
     def addConnectorListener(self, callback_type, listener):
         self._rtcout.RTC_TRACE("addConnectorListener()")
 
-        if callback_type < OpenRTM_aist.ConnectorListenerType.CONNECTOR_LISTENER_NUM:
+        if self._listeners.addListener(callback_type, listener):
             self._rtcout.RTC_TRACE("addConnectorListener(%s)",
                                    OpenRTM_aist.ConnectorListener.toString(callback_type))
-            self._listeners.connector_[callback_type].addListener(listener)
             return
         self._rtcout.RTC_ERROR("addConnectorListener(): Unknown Listener Type")
         return
@@ -933,10 +929,9 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
     def removeConnectorListener(self, callback_type, listener):
         self._rtcout.RTC_TRACE("removeConnectorListener()")
 
-        if callback_type < OpenRTM_aist.ConnectorListenerType.CONNECTOR_LISTENER_NUM:
+        if self._listeners.removeListener(callback_type, listener):
             self._rtcout.RTC_TRACE("removeConnectorListener(%s)",
                                    OpenRTM_aist.ConnectorListener.toString(callback_type))
-            self._listeners.connector_[callback_type].removeListener(listener)
             return
         self._rtcout.RTC_ERROR(
             "removeConnectorListener(): Unknown Listener Type")

--- a/OpenRTM_aist/OutPortCSPProvider.py
+++ b/OpenRTM_aist/OutPortCSPProvider.py
@@ -193,51 +193,44 @@ class OutPortCSPProvider(OpenRTM_aist.OutPortProvider, CSP__POA.OutPortCsp):
 
     def onBufferRead(self, data):
         if self._listeners and self._profile:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ, self._profile, data)
         return data
 
     def onSend(self, data):
         if self._listeners and self._profile:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_SEND, self._profile, data)
         return data
 
     def onBufferEmpty(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY, self._profile)
         return
 
     def onBufferReadTimeout(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_READ_TIMEOUT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_READ_TIMEOUT, self._profile)
         return
 
     def onSenderEmpty(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY, self._profile)
         return
 
     def onSenderTimeout(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_TIMEOUT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_TIMEOUT, self._profile)
         return
 
     def onSenderError(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR, self._profile)
         return
 
     def convertReturn(self, status, data):

--- a/OpenRTM_aist/OutPortCorbaCdrConsumer.py
+++ b/OpenRTM_aist/OutPortCorbaCdrConsumer.py
@@ -375,9 +375,8 @@ class OutPortCorbaCdrConsumer(
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE, self._profile, data)
 
         return data
 
@@ -385,9 +384,8 @@ class OutPortCorbaCdrConsumer(
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL, self._profile, data)
 
         return data
 
@@ -395,9 +393,8 @@ class OutPortCorbaCdrConsumer(
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED, self._profile, data)
 
         return data
 
@@ -405,9 +402,8 @@ class OutPortCorbaCdrConsumer(
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL, self._profile, data)
 
         return data
 
@@ -418,9 +414,8 @@ class OutPortCorbaCdrConsumer(
 
     def onSenderEmpty(self):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY, self._profile)
 
         return
 
@@ -428,9 +423,8 @@ class OutPortCorbaCdrConsumer(
 
     def onSenderTimeout(self):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_TIMEOUT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_TIMEOUT, self._profile)
 
         return
 
@@ -438,9 +432,8 @@ class OutPortCorbaCdrConsumer(
 
     def onSenderError(self):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR, self._profile)
 
         return
 

--- a/OpenRTM_aist/OutPortCorbaCdrProvider.py
+++ b/OpenRTM_aist/OutPortCorbaCdrProvider.py
@@ -315,9 +315,8 @@ class OutPortCorbaCdrProvider(OpenRTM_aist.OutPortProvider,
     # inline void onBufferRead(const cdrMemoryStream& data)
     def onBufferRead(self, data):
         if self._listeners and self._profile:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ, self._profile, data)
         return data
 
     ##
@@ -332,9 +331,8 @@ class OutPortCorbaCdrProvider(OpenRTM_aist.OutPortProvider,
     # inline void onSend(const cdrMemoryStream& data)
     def onSend(self, data):
         if self._listeners and self._profile:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_SEND, self._profile, data)
         return data
 
     ##
@@ -347,9 +345,8 @@ class OutPortCorbaCdrProvider(OpenRTM_aist.OutPortProvider,
     # inline void onBufferEmpty()
     def onBufferEmpty(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY, self._profile)
         return
 
     ##
@@ -362,9 +359,8 @@ class OutPortCorbaCdrProvider(OpenRTM_aist.OutPortProvider,
     # inline void onBufferReadTimeout()
     def onBufferReadTimeout(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_READ_TIMEOUT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_READ_TIMEOUT, self._profile)
         return
 
     ##
@@ -377,9 +373,8 @@ class OutPortCorbaCdrProvider(OpenRTM_aist.OutPortProvider,
     # inline void onSenderEmpty()
     def onSenderEmpty(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY, self._profile)
         return
 
     ##
@@ -392,9 +387,8 @@ class OutPortCorbaCdrProvider(OpenRTM_aist.OutPortProvider,
     # inline void onSenderTimeout()
     def onSenderTimeout(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_TIMEOUT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_TIMEOUT, self._profile)
         return
 
     ##
@@ -407,9 +401,8 @@ class OutPortCorbaCdrProvider(OpenRTM_aist.OutPortProvider,
     # inline void onSenderError()
     def onSenderError(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR, self._profile)
         return
 
     ##

--- a/OpenRTM_aist/OutPortDSConsumer.py
+++ b/OpenRTM_aist/OutPortDSConsumer.py
@@ -375,9 +375,8 @@ class OutPortDSConsumer(OpenRTM_aist.OutPortConsumer,
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE, self._profile, data)
 
         return data
 
@@ -385,9 +384,8 @@ class OutPortDSConsumer(OpenRTM_aist.OutPortConsumer,
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL, self._profile, data)
 
         return data
 
@@ -395,9 +393,8 @@ class OutPortDSConsumer(OpenRTM_aist.OutPortConsumer,
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED, self._profile, data)
 
         return data
 
@@ -405,9 +402,8 @@ class OutPortDSConsumer(OpenRTM_aist.OutPortConsumer,
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL, self._profile, data)
 
         return data
 
@@ -418,9 +414,8 @@ class OutPortDSConsumer(OpenRTM_aist.OutPortConsumer,
 
     def onSenderEmpty(self):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY, self._profile)
 
         return
 
@@ -428,9 +423,8 @@ class OutPortDSConsumer(OpenRTM_aist.OutPortConsumer,
 
     def onSenderTimeout(self):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_TIMEOUT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_TIMEOUT, self._profile)
 
         return
 
@@ -438,9 +432,8 @@ class OutPortDSConsumer(OpenRTM_aist.OutPortConsumer,
 
     def onSenderError(self):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR, self._profile)
 
         return
 

--- a/OpenRTM_aist/OutPortDSProvider.py
+++ b/OpenRTM_aist/OutPortDSProvider.py
@@ -316,9 +316,8 @@ class OutPortDSProvider(OpenRTM_aist.OutPortProvider,
     # inline void onBufferRead(const cdrMemoryStream& data)
     def onBufferRead(self, data):
         if self._listeners and self._profile:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ, self._profile, data)
         return data
 
     ##
@@ -333,9 +332,8 @@ class OutPortDSProvider(OpenRTM_aist.OutPortProvider,
     # inline void onSend(const cdrMemoryStream& data)
     def onSend(self, data):
         if self._listeners and self._profile:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_SEND, self._profile, data)
         return data
 
     ##
@@ -348,9 +346,8 @@ class OutPortDSProvider(OpenRTM_aist.OutPortProvider,
     # inline void onBufferEmpty()
     def onBufferEmpty(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY, self._profile)
         return
 
     ##
@@ -363,9 +360,8 @@ class OutPortDSProvider(OpenRTM_aist.OutPortProvider,
     # inline void onBufferReadTimeout()
     def onBufferReadTimeout(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_READ_TIMEOUT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_READ_TIMEOUT, self._profile)
         return
 
     ##
@@ -378,9 +374,8 @@ class OutPortDSProvider(OpenRTM_aist.OutPortProvider,
     # inline void onSenderEmpty()
     def onSenderEmpty(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY, self._profile)
         return
 
     ##
@@ -393,9 +388,8 @@ class OutPortDSProvider(OpenRTM_aist.OutPortProvider,
     # inline void onSenderTimeout()
     def onSenderTimeout(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_TIMEOUT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_TIMEOUT, self._profile)
         return
 
     ##
@@ -408,9 +402,8 @@ class OutPortDSProvider(OpenRTM_aist.OutPortProvider,
     # inline void onSenderError()
     def onSenderError(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR, self._profile)
         return
 
     ##

--- a/OpenRTM_aist/OutPortDirectConsumer.py
+++ b/OpenRTM_aist/OutPortDirectConsumer.py
@@ -193,9 +193,8 @@ class OutPortDirectConsumer(OpenRTM_aist.OutPortConsumer):
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE, self._profile, data)
 
         return data
 
@@ -203,9 +202,8 @@ class OutPortDirectConsumer(OpenRTM_aist.OutPortConsumer):
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL, self._profile, data)
 
         return data
 
@@ -213,9 +211,8 @@ class OutPortDirectConsumer(OpenRTM_aist.OutPortConsumer):
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED, self._profile, data)
 
         return data
 
@@ -223,9 +220,8 @@ class OutPortDirectConsumer(OpenRTM_aist.OutPortConsumer):
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL, self._profile, data)
 
         return data
 
@@ -236,9 +232,8 @@ class OutPortDirectConsumer(OpenRTM_aist.OutPortConsumer):
 
     def onSenderEmpty(self):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY, self._profile)
 
         return
 
@@ -246,9 +241,8 @@ class OutPortDirectConsumer(OpenRTM_aist.OutPortConsumer):
 
     def onSenderTimeout(self):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_TIMEOUT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_TIMEOUT, self._profile)
 
         return
 
@@ -256,9 +250,8 @@ class OutPortDirectConsumer(OpenRTM_aist.OutPortConsumer):
 
     def onSenderError(self):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR, self._profile)
 
         return
 

--- a/OpenRTM_aist/OutPortDirectProvider.py
+++ b/OpenRTM_aist/OutPortDirectProvider.py
@@ -119,63 +119,56 @@ class OutPortDirectProvider(OpenRTM_aist.OutPortProvider):
 
     def onBufferRead(self, data):
         if self._listeners and self._profile:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ, self._profile, data)
         return data
 
     # inline void onSend(const cdrMemoryStream& data)
 
     def onSend(self, data):
         if self._listeners and self._profile:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_SEND, self._profile, data)
         return data
 
     # inline void onBufferEmpty()
 
     def onBufferEmpty(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY, self._profile)
         return
 
     # inline void onBufferReadTimeout()
 
     def onBufferReadTimeout(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_READ_TIMEOUT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_READ_TIMEOUT, self._profile)
         return
 
     # inline void onSenderEmpty()
 
     def onSenderEmpty(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY, self._profile)
         return
 
     # inline void onSenderTimeout()
 
     def onSenderTimeout(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_TIMEOUT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_TIMEOUT, self._profile)
         return
 
     # inline void onSenderError()
 
     def onSenderError(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR, self._profile)
         return
 
 

--- a/OpenRTM_aist/OutPortDuplexConnector.py
+++ b/OpenRTM_aist/OutPortDuplexConnector.py
@@ -388,8 +388,7 @@ class OutPortDuplexConnector(OpenRTM_aist.OutPortConnector):
 
     def onConnect(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_CONNECT].notify(self._profile)
+            self._listeners.notify(OpenRTM_aist.ConnectorListenerType.ON_CONNECT, self._profile)
         return
 
     ##
@@ -402,8 +401,7 @@ class OutPortDuplexConnector(OpenRTM_aist.OutPortConnector):
 
     def onDisconnect(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_DISCONNECT].notify(self._profile)
+            self._listeners.notify(OpenRTM_aist.ConnectorListenerType.ON_DISCONNECT, self._profile)
         return
 
     ##

--- a/OpenRTM_aist/OutPortPullConnector.py
+++ b/OpenRTM_aist/OutPortPullConnector.py
@@ -391,9 +391,8 @@ class OutPortPullConnector(OpenRTM_aist.OutPortConnector):
 
     def onConnect(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_CONNECT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_CONNECT, self._profile)
         return
 
     ##
@@ -406,9 +405,8 @@ class OutPortPullConnector(OpenRTM_aist.OutPortConnector):
 
     def onDisconnect(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_DISCONNECT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_DISCONNECT, self._profile)
         return
 
     ##

--- a/OpenRTM_aist/OutPortPushConnector.py
+++ b/OpenRTM_aist/OutPortPushConnector.py
@@ -248,20 +248,20 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
 
         if self._directInPort is not None:
             if self._directInPort.isNew():
-                #self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(self._profile, data)
-                #self._inPortListeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(self._profile, data)
-                #self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(self._profile, data)
-                #self._inPortListeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(self._profile, data)
+                #self._listeners.notifyData(OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE, self._profile, data)
+                #self._inPortListeners.notifyData(OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE, self._profile, data)
+                #self._listeners.notifyData(OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL, self._profile, data)
+                #self._inPortListeners.notifyData(OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL, self._profile, data)
                 self._rtcout.RTC_TRACE("ONBUFFER_OVERWRITE(InPort,OutPort), ")
                 self._rtcout.RTC_TRACE("ON_RECEIVER_FULL(InPort,OutPort) ")
                 self._rtcout.RTC_TRACE("callback called in direct mode.")
-            #self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(self._profile, data)
-            #self._inPortListeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(self._profile, data)
+            #self._listeners.notifyData(OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE, self._profile, data)
+            #self._inPortListeners.notifyData(OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE, self._profile, data)
             self._rtcout.RTC_TRACE("ON_BUFFER_WRITE(InPort,OutPort), ")
             self._rtcout.RTC_TRACE("callback called in direct mode.")
             self._directInPort.write(data)
-            #self._listeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(self._profile, data)
-            #self._inPortListeners.connectorData_[OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(self._profile, data)
+            #self._listeners.notifyData(OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED, self._profile, data)
+            #self._inPortListeners.notifyData(OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED, self._profile, data)
             self._rtcout.RTC_TRACE("ON_RECEIVED(InPort,OutPort), ")
             self._rtcout.RTC_TRACE("callback called in direct mode.")
             return self.PORT_OK
@@ -467,9 +467,8 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
 
     def onConnect(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_CONNECT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_CONNECT, self._profile)
         return
 
     ##
@@ -481,9 +480,8 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
     # void onDisconnect()
     def onDisconnect(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_DISCONNECT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_DISCONNECT, self._profile)
         return
 
     ##

--- a/OpenRTM_aist/OutPortSHMProvider.py
+++ b/OpenRTM_aist/OutPortSHMProvider.py
@@ -180,51 +180,44 @@ class OutPortSHMProvider(OpenRTM_aist.OutPortProvider,
 
     def onBufferRead(self, data):
         if self._listeners and self._profile:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ, self._profile, data)
         return data
 
     def onSend(self, data):
         if self._listeners and self._profile:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_SEND, self._profile, data)
         return data
 
     def onBufferEmpty(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY, self._profile)
         return
 
     def onBufferReadTimeout(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_READ_TIMEOUT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_READ_TIMEOUT, self._profile)
         return
 
     def onSenderEmpty(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY, self._profile)
         return
 
     def onSenderTimeout(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_TIMEOUT].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_TIMEOUT, self._profile)
         return
 
     def onSenderError(self):
         if self._listeners and self._profile:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR, self._profile)
         return
 
     def convertReturn(self, status, data):

--- a/OpenRTM_aist/PortBase.py
+++ b/OpenRTM_aist/PortBase.py
@@ -2318,8 +2318,7 @@ class PortBase(RTC__POA.PortService):
     def onNotifyConnect(self, portname, profile):
         if self._portconnListeners is not None:
             type = OpenRTM_aist.PortConnectListenerType.ON_NOTIFY_CONNECT
-            self._portconnListeners.portconnect_[
-                type].notify(portname, profile)
+            self._portconnListeners.notify(type, portname, profile)
         return
 
     # inline void onNotifyDisconnect(const char* portname,
@@ -2328,8 +2327,7 @@ class PortBase(RTC__POA.PortService):
     def onNotifyDisconnect(self, portname, profile):
         if self._portconnListeners is not None:
             type = OpenRTM_aist.PortConnectListenerType.ON_NOTIFY_DISCONNECT
-            self._portconnListeners.portconnect_[
-                type].notify(portname, profile)
+            self._portconnListeners.notify(type, portname, profile)
         return
 
     # inline void onUnsubscribeInterfaces(const char* portname,
@@ -2338,8 +2336,7 @@ class PortBase(RTC__POA.PortService):
     def onUnsubscribeInterfaces(self, portname, profile):
         if self._portconnListeners is not None:
             type = OpenRTM_aist.PortConnectListenerType.ON_UNSUBSCRIBE_INTERFACES
-            self._portconnListeners.portconnect_[
-                type].notify(portname, profile)
+            self._portconnListeners.notify(type, portname, profile)
         return
 
     # inline void onPublishInterfaces(const char* portname,
@@ -2349,8 +2346,7 @@ class PortBase(RTC__POA.PortService):
     def onPublishInterfaces(self, portname, profile, ret):
         if self._portconnListeners is not None:
             type = OpenRTM_aist.PortConnectRetListenerType.ON_PUBLISH_INTERFACES
-            self._portconnListeners.portconnret_[
-                type].notify(portname, profile, ret)
+            self._portconnListeners.notifyRet(type, portname, profile, ret)
         return
 
     # inline void onConnectNextport(const char* portname,
@@ -2360,8 +2356,7 @@ class PortBase(RTC__POA.PortService):
     def onConnectNextport(self, portname, profile, ret):
         if self._portconnListeners is not None:
             type = OpenRTM_aist.PortConnectRetListenerType.ON_CONNECT_NEXTPORT
-            self._portconnListeners.portconnret_[
-                type].notify(portname, profile, ret)
+            self._portconnListeners.notifyRet(type, portname, profile, ret)
         return
 
     # inline void onSubscribeInterfaces(const char* portname,
@@ -2371,8 +2366,7 @@ class PortBase(RTC__POA.PortService):
     def onSubscribeInterfaces(self, portname, profile, ret):
         if self._portconnListeners is not None:
             type = OpenRTM_aist.PortConnectRetListenerType.ON_SUBSCRIBE_INTERFACES
-            self._portconnListeners.portconnret_[
-                type].notify(portname, profile, ret)
+            self._portconnListeners.notifyRet(type, portname, profile, ret)
         return
 
     # inline void onConnected(const char* portname,
@@ -2382,8 +2376,7 @@ class PortBase(RTC__POA.PortService):
     def onConnected(self, portname, profile, ret):
         if self._portconnListeners is not None:
             type = OpenRTM_aist.PortConnectRetListenerType.ON_CONNECTED
-            self._portconnListeners.portconnret_[
-                type].notify(portname, profile, ret)
+            self._portconnListeners.notifyRet(type, portname, profile, ret)
         return
 
     # inline void onDisconnectNextport(const char* portname,
@@ -2393,8 +2386,7 @@ class PortBase(RTC__POA.PortService):
     def onDisconnectNextport(self, portname, profile, ret):
         if self._portconnListeners is not None:
             type = OpenRTM_aist.PortConnectRetListenerType.ON_DISCONNECT_NEXT
-            self._portconnListeners.portconnret_[
-                type].notify(portname, profile, ret)
+            self._portconnListeners.notifyRet(type, portname, profile, ret)
         return
 
     # inline void onDisconnected(const char* portname,
@@ -2404,8 +2396,7 @@ class PortBase(RTC__POA.PortService):
     def onDisconnected(self, portname, profile, ret):
         if self._portconnListeners is not None:
             type = OpenRTM_aist.PortConnectRetListenerType.ON_DISCONNECTED
-            self._portconnListeners.portconnret_[
-                type].notify(portname, profile, ret)
+            self._portconnListeners.notifyRet(type, portname, profile, ret)
         return
 
     # ============================================================

--- a/OpenRTM_aist/PortConnectListener.py
+++ b/OpenRTM_aist/PortConnectListener.py
@@ -611,34 +611,150 @@ class PortConnectListeners:
         self.portconnret_ = [PortConnectRetListenerHolder()
                              for i in range(self.portconnret_num)]
 
+    ##
+    # @if jp
+    # @brief リスナーの追加
+    #
+    # 指定の種類のPortConnectListenerを追加する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 追加するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def addListener(self, ltype, listener):
         if ltype < len(self.portconnect_):
             self.portconnect_[ltype].addListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの削除
+    #
+    # 指定の種類のPortConnectListenerを削除する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 削除するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def removeListener(self, ltype, listener):
         if ltype < len(self.portconnect_):
             self.portconnect_[ltype].removeListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの追加
+    #
+    # 指定の種類のPortConnectRetListenerを追加する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 追加するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def addRetListener(self, ltype, listener):
         if ltype < len(self.portconnret_):
             self.portconnret_[ltype].addListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーの削除
+    #
+    # 指定の種類のPortConnectRetListenerを削除する。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param listener 削除するリスナ
+    # @return False：指定の種類のリスナが存在しない
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param listener
+    # @return
+    #
+    # @endif
     def removeRetListener(self, ltype, listener):
         if ltype < len(self.portconnret_):
             self.portconnret_[ltype].removeListener(listener)
             return True
         return False
 
+    ##
+    # @if jp
+    # @brief リスナーへ通知する
+    #
+    # 指定の種類のPortConnectListenerのコールバック関数を呼び出す。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param portname ポート名
+    # @param profile ConnectorProfile
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param portname
+    # @param profile
+    #
+    # @endif
     def notify(self, ltype, portname, profile):
         if ltype < len(self.portconnect_):
             self.portconnect_[ltype].notify(portname, profile)
 
+    ##
+    # @if jp
+    # @brief リスナーへ通知する
+    #
+    # 指定の種類のPortConnectRetListenerのコールバック関数を呼び出す。
+    #
+    # @param self
+    # @param ltype リスナの種類
+    # @param portname ポート名
+    # @param profile ConnectorProfile
+    # @param ret リターンコード
+    #
+    # @else
+    #
+    # @param self
+    # @param ltype
+    # @param portname
+    # @param profile
+    # @param ret
+    #
+    # @endif
     def notifyRet(self, ltype, portname, profile, ret):
         if ltype < len(self.portconnret_):
             self.portconnret_[ltype].notify(portname, profile, ret)

--- a/OpenRTM_aist/PortConnectListener.py
+++ b/OpenRTM_aist/PortConnectListener.py
@@ -610,3 +610,35 @@ class PortConnectListeners:
         self.portconnret_num = PortConnectRetListenerType.PORT_CONNECT_RET_LISTENER_NUM
         self.portconnret_ = [PortConnectRetListenerHolder()
                              for i in range(self.portconnret_num)]
+
+    def addListener(self, ltype, listener):
+        if ltype < len(self.portconnect_):
+            self.portconnect_[ltype].addListener(listener)
+            return True
+        return False
+
+    def removeListener(self, ltype, listener):
+        if ltype < len(self.portconnect_):
+            self.portconnect_[ltype].removeListener(listener)
+            return True
+        return False
+
+    def addRetListener(self, ltype, listener):
+        if ltype < len(self.portconnret_):
+            self.portconnret_[ltype].addListener(listener)
+            return True
+        return False
+
+    def removeRetListener(self, ltype, listener):
+        if ltype < len(self.portconnret_):
+            self.portconnret_[ltype].removeListener(listener)
+            return True
+        return False
+
+    def notify(self, ltype, portname, profile):
+        if ltype < len(self.portconnect_):
+            self.portconnect_[ltype].notify(portname, profile)
+
+    def notifyRet(self, ltype, portname, profile, ret):
+        if ltype < len(self.portconnret_):
+            self.portconnret_[ltype].notify(portname, profile, ret)

--- a/OpenRTM_aist/PublisherFlush.py
+++ b/OpenRTM_aist/PublisherFlush.py
@@ -422,9 +422,8 @@ class PublisherFlush(OpenRTM_aist.PublisherBase):
     # inline void onSend(const cdrMemoryStream& data)
     def onSend(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_SEND, self._profile, data)
         return data
 
     ##
@@ -439,9 +438,8 @@ class PublisherFlush(OpenRTM_aist.PublisherBase):
     # inline void onReceived(const cdrMemoryStream& data)
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED, self._profile, data)
         return data
 
     ##
@@ -456,9 +454,8 @@ class PublisherFlush(OpenRTM_aist.PublisherBase):
     # inline void onReceiverFull(const cdrMemoryStream& data)
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL, self._profile, data)
         return data
 
     ##
@@ -473,9 +470,8 @@ class PublisherFlush(OpenRTM_aist.PublisherBase):
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT, self._profile, data)
         return data
 
     ##
@@ -490,9 +486,8 @@ class PublisherFlush(OpenRTM_aist.PublisherBase):
     # inline void onReceiverError(const cdrMemoryStream& data)
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR, self._profile, data)
         return data
 
 

--- a/OpenRTM_aist/PublisherNew.py
+++ b/OpenRTM_aist/PublisherNew.py
@@ -912,9 +912,8 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onBufferWrite(const cdrMemoryStream& data)
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE, self._profile, data)
         return data
 
     ##
@@ -929,9 +928,8 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onBufferFull(const cdrMemoryStream& data)
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL, self._profile, data)
         return data
 
     ##
@@ -946,9 +944,8 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onBufferWriteTimeout(const cdrMemoryStream& data)
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT, self._profile, data)
         return data
 
     ##
@@ -963,9 +960,8 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onBufferWriteOverwrite(const cdrMemoryStream& data)
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE, self._profile, data)
         return data
 
     ##
@@ -980,9 +976,8 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onBufferRead(const cdrMemoryStream& data)
     def onBufferRead(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ, self._profile, data)
         return data
 
     ##
@@ -997,9 +992,8 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onSend(const cdrMemoryStream& data)
     def onSend(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_SEND, self._profile, data)
         return data
 
     ##
@@ -1014,9 +1008,8 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onReceived(const cdrMemoryStream& data)
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED, self._profile, data)
         return data
 
     ##
@@ -1031,9 +1024,8 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onReceiverFull(const cdrMemoryStream& data)
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL, self._profile, data)
         return data
 
     ##
@@ -1048,9 +1040,8 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT, self._profile, data)
         return data
 
     ##
@@ -1065,9 +1056,8 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onReceiverError(const cdrMemoryStream& data)
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR, self._profile, data)
         return data
 
     ##
@@ -1082,9 +1072,8 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # inline void onSenderError()
     def onSenderError(self):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR, self._profile)
         return
 
 

--- a/OpenRTM_aist/PublisherPeriodic.py
+++ b/OpenRTM_aist/PublisherPeriodic.py
@@ -931,9 +931,8 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onBufferWrite(const cdrMemoryStream& data)
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE, self._profile, data)
         return data
 
     ##
@@ -948,9 +947,8 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onBufferFull(const cdrMemoryStream& data)
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL, self._profile, data)
         return data
 
     ##
@@ -965,9 +963,8 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onBufferWriteTimeout(const cdrMemoryStream& data)
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT, self._profile, data)
         return data
 
     ##
@@ -982,9 +979,8 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     #  inline void onBufferRead(const cdrMemoryStream& data)
     def onBufferRead(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_READ, self._profile, data)
         return data
 
     ##
@@ -999,9 +995,8 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onSend(const cdrMemoryStream& data)
     def onSend(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_SEND].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_SEND, self._profile, data)
         return data
 
     ##
@@ -1016,9 +1011,8 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onReceived(const cdrMemoryStream& data)
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED, self._profile, data)
         return data
 
     ##
@@ -1033,9 +1027,8 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onReceiverFull(const cdrMemoryStream& data)
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL, self._profile, data)
         return data
 
     ##
@@ -1050,9 +1043,8 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT, self._profile, data)
         return data
 
     ##
@@ -1067,9 +1059,8 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onReceiverError(const cdrMemoryStream& data)
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR, self._profile, data)
         return data
 
     ##
@@ -1083,9 +1074,8 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
 
     def onBufferEmpty(self):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_BUFFER_EMPTY, self._profile)
         return
 
     ##
@@ -1098,9 +1088,8 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onSenderEmpty()
     def onSenderEmpty(self):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_EMPTY, self._profile)
         return
 
     ##
@@ -1113,9 +1102,8 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # inline void onSenderError()
     def onSenderError(self):
         if self._listeners is not None and self._profile is not None:
-            self._listeners.connector_[
-                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR].notify(
-                self._profile)
+            self._listeners.notify(
+                OpenRTM_aist.ConnectorListenerType.ON_SENDER_ERROR, self._profile)
         return
 
     ##

--- a/OpenRTM_aist/RTObject.py
+++ b/OpenRTM_aist/RTObject.py
@@ -3541,7 +3541,7 @@ class RTObject_impl:
                 return
 
         listener = Noname(memfunc)
-        self._actionListeners.preaction_[listener_type].addListener(listener)
+        self._actionListeners.addPreActionListener(listener_type, listener)
         return listener
 
     ##
@@ -3568,8 +3568,7 @@ class RTObject_impl:
     #                                  PreComponentActionListener* listener);
 
     def removePreComponentActionListener(self, listener_type, listener):
-        self._actionListeners.preaction_[
-            listener_type].removeListener(listener)
+        self._actionListeners.removePreActionListener(listener_type, listener)
         return
 
     ##
@@ -3660,7 +3659,7 @@ class RTObject_impl:
                 return
 
         listener = Noname(memfunc)
-        self._actionListeners.postaction_[listener_type].addListener(listener)
+        self._actionListeners.addPostActionListener(listener_type, listener)
         return listener
 
     ##
@@ -3687,8 +3686,7 @@ class RTObject_impl:
     #                                   PostComponentActionListener* listener);
 
     def removePostComponentActionListener(self, listener_type, listener):
-        self._actionListeners.postaction_[
-            listener_type].removeListener(listener)
+        self._actionListeners.removePostActionListener(listener_type, listener)
         return
 
     ##
@@ -3760,7 +3758,7 @@ class RTObject_impl:
 
         listener = Noname(memfunc)
 
-        self._actionListeners.portaction_[listener_type].addListener(listener)
+        self._actionListeners.addPortActionListener(listener_type, listener)
         return listener
 
     ##
@@ -3786,8 +3784,7 @@ class RTObject_impl:
     #                          PortActionListener* listener);
 
     def removePortActionListener(self, listener_type, listener):
-        self._actionListeners.portaction_[
-            listener_type].removeListener(listener)
+        self._actionListeners.removePortActionListener(listener_type, listener)
         return
 
     ##
@@ -3858,7 +3855,7 @@ class RTObject_impl:
                 return
 
         listener = Noname(memfunc)
-        self._actionListeners.ecaction_[listener_type].addListener(listener)
+        self._actionListeners.addECActionListener(listener_type, listener)
         return listener
 
     ##
@@ -3885,7 +3882,7 @@ class RTObject_impl:
     #                                      ECActionListener* listener);
 
     def removeExecutionContextActionListener(self, listener_type, listener):
-        self._actionListeners.ecaction_[listener_type].removeListener(listener)
+        self._actionListeners.removeECActionListener(listener_type, listener)
         return
 
     ##
@@ -3958,8 +3955,7 @@ class RTObject_impl:
                 return
 
         listener = Noname(memfunc)
-        self._portconnListeners.portconnect_[
-            listener_type].addListener(listener)
+        self._portconnListeners.addListener(listener_type, listener)
         return listener
 
     ##
@@ -3986,8 +3982,7 @@ class RTObject_impl:
     #                           PortConnectListener* listener);
 
     def removePortConnectListener(self, listener_type, listener):
-        self._portconnListeners.portconnect_[
-            listener_type].removeListener(listener)
+        self._portconnListeners.removeListener(listener_type, listener)
         return
 
     ##
@@ -4065,8 +4060,7 @@ class RTObject_impl:
                 return
 
         listener = Noname(memfunc)
-        self._portconnListeners.portconnret_[
-            listener_type].addListener(listener)
+        self._portconnListeners.addRetListener(listener_type, listener)
         return listener
 
     ##
@@ -4093,8 +4087,7 @@ class RTObject_impl:
     #                              PortConnectRetListener* listener);
 
     def removePortConnectRetListener(self, listener_type, listener):
-        self._portconnListeners.portconnret_[
-            listener_type].removeListener(listener)
+        self._portconnListeners.removeRetListener(listener_type, listener)
         return
 
     ##
@@ -4456,8 +4449,7 @@ class RTObject_impl:
                 return
 
         listener = Noname(memfunc)
-        self._fsmActionListeners.preaction_[
-            listener_type].addListener(listener)
+        self._fsmActionListeners.addPreActionListener(listener_type, listener)
         return listener
 
     ##
@@ -4480,8 +4472,7 @@ class RTObject_impl:
     # @endif
     #
     def removePreFsmActionListener(self, listener_type, listener):
-        self._fsmActionListeners.preaction_[
-            listener_type].removeListener(listener)
+        self._fsmActionListeners.removePreActionListener(listener_type, listener)
         return
 
     ##
@@ -4567,8 +4558,7 @@ class RTObject_impl:
                 return
 
         listener = Noname(memfunc)
-        self._fsmActionListeners.postaction_[
-            listener_type].addListener(listener)
+        self._fsmActionListeners.addPostActionListener(listener_type, listener)
         return listener
 
     ##
@@ -4592,8 +4582,7 @@ class RTObject_impl:
     #
 
     def removePostFsmActionListener(self, listener_type, listener):
-        self._fsmActionListeners.postaction_[
-            listener_type].removeListener(listener)
+        self._fsmActionListeners.removePostActionListener(listener_type, listener)
         return
 
     ##
@@ -4675,7 +4664,7 @@ class RTObject_impl:
                 return
 
         listener = Noname(memfunc)
-        self._fsmActionListeners.profile_[listener_type].addListener(listener)
+        self._fsmActionListeners.addProfileListener(listener_type, listener)
         return listener
 
     ##
@@ -4699,8 +4688,7 @@ class RTObject_impl:
     #
 
     def removeFsmProfileListener(self, listener_type, listener):
-        self._fsmActionListeners.profile_[
-            listener_type].removeListener(listener)
+        self._fsmActionListeners.removeProfileListener(listener_type, listener)
         return
 
     ##
@@ -4768,8 +4756,7 @@ class RTObject_impl:
                 return
 
         listener = Noname(memfunc)
-        self._fsmActionListeners.structure_[
-            listener_type].addListener(listener)
+        self._fsmActionListeners.addStructureListener(listener_type, listener)
         return listener
 
     ##
@@ -4793,8 +4780,7 @@ class RTObject_impl:
     #
 
     def removeFsmStructureListener(self, listener_type, listener):
-        self._fsmActionListeners.structure_[
-            listener_type].removeListener(listener)
+        self._fsmActionListeners.removeStructureListener(listener_type, listener)
         return
 
     ##
@@ -4839,253 +4825,215 @@ class RTObject_impl:
 
     # inline void preOnInitialize(UniqueId ec_id)
     def preOnInitialize(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_INITIALIZE].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_INITIALIZE, ec_id)
         return
 
     # inline void preOnFinalize(UniqueId ec_id)
     def preOnFinalize(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_FINALIZE].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_FINALIZE, ec_id)
         return
 
     # inline void preOnStartup(UniqueId ec_id)
     def preOnStartup(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_STARTUP].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_STARTUP, ec_id)
         return
 
     # inline void preOnShutdown(UniqueId ec_id)
     def preOnShutdown(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_SHUTDOWN].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_SHUTDOWN, ec_id)
         return
 
     # inline void preOnActivated(UniqueId ec_id)
     def preOnActivated(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_ACTIVATED].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_ACTIVATED, ec_id)
         return
 
     # inline void preOnDeactivated(UniqueId ec_id)
     def preOnDeactivated(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_DEACTIVATED].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_DEACTIVATED, ec_id)
         return
 
     # inline void preOnAborting(UniqueId ec_id)
     def preOnAborting(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_ABORTING].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_ABORTING, ec_id)
         return
 
     # inline void preOnError(UniqueId ec_id)
     def preOnError(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_ERROR].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_ERROR, ec_id)
         return
 
     # inline void preOnReset(UniqueId ec_id)
     def preOnReset(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_RESET].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_RESET, ec_id)
         return
 
     # inline void preOnExecute(UniqueId ec_id)
     def preOnExecute(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_EXECUTE].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_EXECUTE, ec_id)
         return
 
     # inline void preOnStateUpdate(UniqueId ec_id)
     def preOnStateUpdate(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_STATE_UPDATE].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_STATE_UPDATE, ec_id)
         return
 
     # inline void preOnRateChanged(UniqueId ec_id)
 
     def preOnRateChanged(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_RATE_CHANGED].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_RATE_CHANGED, ec_id)
         return
 
     # inline void postOnInitialize(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnInitialize(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_INITIALIZE].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_INITIALIZE, ec_id, ret)
         return
 
     # inline void postOnFinalize(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnFinalize(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_FINALIZE].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_FINALIZE, ec_id, ret)
         return
 
     # inline void postOnStartup(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnStartup(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_STARTUP].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_STARTUP, ec_id, ret)
         return
 
     # inline void postOnShutdown(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnShutdown(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_SHUTDOWN].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_SHUTDOWN, ec_id, ret)
         return
 
     # inline void postOnActivated(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnActivated(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_ACTIVATED].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_ACTIVATED, ec_id, ret)
         return
 
     # inline void postOnDeactivated(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnDeactivated(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_DEACTIVATED].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_DEACTIVATED, ec_id, ret)
         return
 
     # inline void postOnAborting(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnAborting(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_ABORTING].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_ABORTING, ec_id, ret)
         return
 
     # inline void postOnError(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnError(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_ERROR].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_ERROR, ec_id, ret)
         return
 
     # inline void postOnReset(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnReset(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_RESET].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_RESET, ec_id, ret)
         return
 
     # inline void postOnExecute(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnExecute(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_EXECUTE].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_EXECUTE, ec_id, ret)
         return
 
     # inline void postOnStateUpdate(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnStateUpdate(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_STATE_UPDATE].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_STATE_UPDATE, ec_id, ret)
         return
 
     # inline void postOnRateChanged(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnRateChanged(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_RATE_CHANGED].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_RATE_CHANGED, ec_id, ret)
         return
 
     # inline void onAddPort(const PortProfile& pprof)
 
     def onAddPort(self, pprof):
-        self._actionListeners.portaction_[
-            OpenRTM_aist.PortActionListenerType.ADD_PORT].notify(pprof)
+        self._actionListeners.notifyPortAction(OpenRTM_aist.PortActionListenerType.ADD_PORT, pprof)
         return
 
     # inline void onRemovePort(const PortProfile& pprof)
 
     def onRemovePort(self, pprof):
-        self._actionListeners.portaction_[
-            OpenRTM_aist.PortActionListenerType.REMOVE_PORT].notify(pprof)
+        self._actionListeners.notifyPortAction(OpenRTM_aist.PortActionListenerType.REMOVE_PORT, pprof)
         return
 
     # inline void onAttachExecutionContext(UniqueId ec_id)
 
     def onAttachExecutionContext(self, ec_id):
-        self._actionListeners.ecaction_[
-            OpenRTM_aist.ExecutionContextActionListenerType.EC_ATTACHED].notify(ec_id)
+        self._actionListeners.notifyECAction(OpenRTM_aist.ExecutionContextActionListenerType.EC_ATTACHED, ec_id)
         return
 
     # inline void onDetachExecutionContext(UniqueId ec_id)
 
     def onDetachExecutionContext(self, ec_id):
-        self._actionListeners.ecaction_[
-            OpenRTM_aist.ExecutionContextActionListenerType.EC_DETACHED].notify(ec_id)
+        self._actionListeners.notifyECAction(OpenRTM_aist.ExecutionContextActionListenerType.EC_DETACHED, ec_id)
         return
 
     def preOnFsmInit(self, state):
-        self._fsmActionListeners.preaction_[
-            OpenRTM_aist.PreFsmActionListenerType.PRE_ON_INIT].notify(state)
+        self._fsmActionListeners.notifyPreAction(OpenRTM_aist.PreFsmActionListenerType.PRE_ON_INIT, state)
         return
 
     def preOnFsmEntry(self, state):
-        self._fsmActionListeners.preaction_[
-            OpenRTM_aist.PreFsmActionListenerType.PRE_ON_ENTRY].notify(state)
+        self._fsmActionListeners.notifyPreAction(OpenRTM_aist.PreFsmActionListenerType.PRE_ON_ENTRY, state)
         return
 
     def preOnFsmDo(self, state):
-        self._fsmActionListeners.preaction_[
-            OpenRTM_aist.PreFsmActionListenerType.PRE_ON_DO].notify(state)
+        self._fsmActionListeners.notifyPreAction(OpenRTM_aist.PreFsmActionListenerType.PRE_ON_DO, state)
         return
 
     def preOnFsmExit(self, state):
-        self._fsmActionListeners.preaction_[
-            OpenRTM_aist.PreFsmActionListenerType.PRE_ON_EXIT].notify(state)
+        self._fsmActionListeners.notifyPreAction(OpenRTM_aist.PreFsmActionListenerType.PRE_ON_EXIT, state)
         return
 
     def preOnFsmStateChange(self, state):
-        self._fsmActionListeners.preaction_[
-            OpenRTM_aist.PreFsmActionListenerType.PRE_ON_STATE_CHANGE].notify(state)
+        self._fsmActionListeners.notifyPreAction(OpenRTM_aist.PreFsmActionListenerType.PRE_ON_STATE_CHANGE, state)
         return
 
     def postOnFsmInit(self, state, ret):
-        self._fsmActionListeners.postaction_[
-            OpenRTM_aist.PostFsmActionListenerType.POST_ON_INIT].notify(
-            state, ret)
+        self._fsmActionListeners.notifyPostAction(
+            OpenRTM_aist.PostFsmActionListenerType.POST_ON_INIT, state, ret)
         return
 
     def postOnFsmEntry(self, state, ret):
-        self._fsmActionListeners.postaction_[
-            OpenRTM_aist.PostFsmActionListenerType.POST_ON_ENTRY].notify(
-            state, ret)
+        self._fsmActionListeners.notifyPostAction(
+            OpenRTM_aist.PostFsmActionListenerType.POST_ON_ENTRY, state, ret)
         return
 
     def postOnFsmDo(self, state, ret):
-        self._fsmActionListeners.postaction_[
-            OpenRTM_aist.PostFsmActionListenerType.POST_ON_DO].notify(state, ret)
+        self._fsmActionListeners.notifyPostAction(OpenRTM_aist.PostFsmActionListenerType.POST_ON_DO, state, ret)
         return
 
     def postOnFsmExit(self, state, ret):
-        self._fsmActionListeners.postaction_[
-            OpenRTM_aist.PostFsmActionListenerType.POST_ON_EXIT].notify(
-            state, ret)
+        self._fsmActionListeners.notifyPostAction(
+            OpenRTM_aist.PostFsmActionListenerType.POST_ON_EXIT, state, ret)
         return
 
     def postOnFsmStateChange(self, state, ret):
-        self._fsmActionListeners.postaction_[
-            OpenRTM_aist.PostFsmActionListenerType.POST_ON_STATE_CHANGE].notify(
-            state, ret)
+        self._fsmActionListeners.notifyPostAction(
+            OpenRTM_aist.PostFsmActionListenerType.POST_ON_STATE_CHANGE, state, ret)
         return
 
     # ReturnCode_t getInheritedECOptions(coil::Properties& default_opts);

--- a/OpenRTM_aist/RTObjectBase.py
+++ b/OpenRTM_aist/RTObjectBase.py
@@ -3510,7 +3510,7 @@ class RTObjectBase:
                 return
 
         listener = Noname(memfunc)
-        self._actionListeners.preaction_[listener_type].addListener(listener)
+        self._actionListeners.addPreActionListener(listener_type, listener)
         return listener
 
     ##
@@ -3537,8 +3537,7 @@ class RTObjectBase:
     #                                  PreComponentActionListener* listener);
 
     def removePreComponentActionListener(self, listener_type, listener):
-        self._actionListeners.preaction_[
-            listener_type].removeListener(listener)
+        self._actionListeners.removePreActionListener(listener_type, listener)
         return
 
     ##
@@ -3629,7 +3628,7 @@ class RTObjectBase:
                 return
 
         listener = Noname(memfunc)
-        self._actionListeners.postaction_[listener_type].addListener(listener)
+        self._actionListeners.addPostActionListener(listener_type, listener)
         return listener
 
     ##
@@ -3656,8 +3655,7 @@ class RTObjectBase:
     #                                   PostComponentActionListener* listener);
 
     def removePostComponentActionListener(self, listener_type, listener):
-        self._actionListeners.postaction_[
-            listener_type].removeListener(listener)
+        self._actionListeners.removePostActionListener(listener_type, listener)
         return
 
     ##
@@ -3729,7 +3727,7 @@ class RTObjectBase:
 
         listener = Noname(memfunc)
 
-        self._actionListeners.portaction_[listener_type].addListener(listener)
+        self._actionListeners.addPortActionListener(listener_type, listener)
         return listener
 
     ##
@@ -3755,8 +3753,7 @@ class RTObjectBase:
     #                          PortActionListener* listener);
 
     def removePortActionListener(self, listener_type, listener):
-        self._actionListeners.portaction_[
-            listener_type].removeListener(listener)
+        self._actionListeners.removePortActionListener(listener_type, listener)
         return
 
     ##
@@ -3827,7 +3824,7 @@ class RTObjectBase:
                 return
 
         listener = Noname(memfunc)
-        self._actionListeners.ecaction_[listener_type].addListener(listener)
+        self._actionListeners.addECActionListener(listener_type, listener)
         return listener
 
     ##
@@ -3854,7 +3851,7 @@ class RTObjectBase:
     #                                      ECActionListener* listener);
 
     def removeExecutionContextActionListener(self, listener_type, listener):
-        self._actionListeners.ecaction_[listener_type].removeListener(listener)
+        self._actionListeners.removeECActionListener(listener_type, listener)
         return
 
     ##
@@ -3927,8 +3924,7 @@ class RTObjectBase:
                 return
 
         listener = Noname(memfunc)
-        self._portconnListeners.portconnect_[
-            listener_type].addListener(listener)
+        self._portconnListeners.addListener(listener_type, listener)
         return listener
 
     ##
@@ -3955,8 +3951,7 @@ class RTObjectBase:
     #                           PortConnectListener* listener);
 
     def removePortConnectListener(self, listener_type, listener):
-        self._portconnListeners.portconnect_[
-            listener_type].removeListener(listener)
+        self._portconnListeners.removeListener(listener_type, listener)
         return
 
     ##
@@ -4034,8 +4029,7 @@ class RTObjectBase:
                 return
 
         listener = Noname(memfunc)
-        self._portconnListeners.portconnret_[
-            listener_type].addListener(listener)
+        self._portconnListeners.addRetListener(listener_type, listener)
         return listener
 
     ##
@@ -4062,8 +4056,7 @@ class RTObjectBase:
     #                              PortConnectRetListener* listener);
 
     def removePortConnectRetListener(self, listener_type, listener):
-        self._portconnListeners.portconnret_[
-            listener_type].removeListener(listener)
+        self._portconnListeners.removeRetListener(listener_type, listener)
         return
 
     ##
@@ -4393,8 +4386,7 @@ class RTObjectBase:
                 return
 
         listener = Noname(memfunc)
-        self._fsmActionListeners.preaction_[
-            listener_type].addListener(listener)
+        self._fsmActionListeners.addPreActionListener(listener_type, listener)
         return listener
 
     ##
@@ -4417,8 +4409,7 @@ class RTObjectBase:
     # @endif
     #
     def removePreFsmActionListener(self, listener_type, listener):
-        self._fsmActionListeners.preaction_[
-            listener_type].removeListener(listener)
+        self._fsmActionListeners.removePreActionListener(listener_type, listener)
         return
 
     ##
@@ -4504,8 +4495,7 @@ class RTObjectBase:
                 return
 
         listener = Noname(memfunc)
-        self._fsmActionListeners.postaction_[
-            listener_type].addListener(listener)
+        self._fsmActionListeners.addPostActionListener(listener_type, listener)
         return listener
 
     ##
@@ -4529,8 +4519,7 @@ class RTObjectBase:
     #
 
     def removePostFsmActionListener(self, listener_type, listener):
-        self._fsmActionListeners.postaction_[
-            listener_type].removeListener(listener)
+        self._fsmActionListeners.removePostActionListener(listener_type, listener)
         return
 
     ##
@@ -4612,7 +4601,7 @@ class RTObjectBase:
                 return
 
         listener = Noname(memfunc)
-        self._fsmActionListeners.profile_[listener_type].addListener(listener)
+        self._fsmActionListeners.addProfileListener(listener_type, listener)
         return listener
 
     ##
@@ -4636,8 +4625,7 @@ class RTObjectBase:
     #
 
     def removeFsmProfileListener(self, listener_type, listener):
-        self._fsmActionListeners.profile_[
-            listener_type].removeListener(listener)
+        self._fsmActionListeners.removeProfileListener(listener_type, listener)
         return
 
     ##
@@ -4772,253 +4760,215 @@ class RTObjectBase:
 
     # inline void preOnInitialize(UniqueId ec_id)
     def preOnInitialize(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_INITIALIZE].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_INITIALIZE, ec_id)
         return
 
     # inline void preOnFinalize(UniqueId ec_id)
     def preOnFinalize(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_FINALIZE].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_FINALIZE, ec_id)
         return
 
     # inline void preOnStartup(UniqueId ec_id)
     def preOnStartup(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_STARTUP].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_STARTUP, ec_id)
         return
 
     # inline void preOnShutdown(UniqueId ec_id)
     def preOnShutdown(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_SHUTDOWN].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_SHUTDOWN, ec_id)
         return
 
     # inline void preOnActivated(UniqueId ec_id)
     def preOnActivated(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_ACTIVATED].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_ACTIVATED, ec_id)
         return
 
     # inline void preOnDeactivated(UniqueId ec_id)
     def preOnDeactivated(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_DEACTIVATED].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_DEACTIVATED, ec_id)
         return
 
     # inline void preOnAborting(UniqueId ec_id)
     def preOnAborting(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_ABORTING].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_ABORTING, ec_id)
         return
 
     # inline void preOnError(UniqueId ec_id)
     def preOnError(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_ERROR].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_ERROR, ec_id)
         return
 
     # inline void preOnReset(UniqueId ec_id)
     def preOnReset(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_RESET].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_RESET, ec_id)
         return
 
     # inline void preOnExecute(UniqueId ec_id)
     def preOnExecute(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_EXECUTE].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_EXECUTE, ec_id)
         return
 
     # inline void preOnStateUpdate(UniqueId ec_id)
     def preOnStateUpdate(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_STATE_UPDATE].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_STATE_UPDATE, ec_id)
         return
 
     # inline void preOnRateChanged(UniqueId ec_id)
 
     def preOnRateChanged(self, ec_id):
-        self._actionListeners.preaction_[
-            OpenRTM_aist.PreComponentActionListenerType.PRE_ON_RATE_CHANGED].notify(ec_id)
+        self._actionListeners.notifyPreAction(OpenRTM_aist.PreComponentActionListenerType.PRE_ON_RATE_CHANGED, ec_id)
         return
 
     # inline void postOnInitialize(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnInitialize(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_INITIALIZE].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_INITIALIZE, ec_id, ret)
         return
 
     # inline void postOnFinalize(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnFinalize(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_FINALIZE].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_FINALIZE, ec_id, ret)
         return
 
     # inline void postOnStartup(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnStartup(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_STARTUP].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_STARTUP, ec_id, ret)
         return
 
     # inline void postOnShutdown(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnShutdown(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_SHUTDOWN].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_SHUTDOWN, ec_id, ret)
         return
 
     # inline void postOnActivated(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnActivated(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_ACTIVATED].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_ACTIVATED, ec_id, ret)
         return
 
     # inline void postOnDeactivated(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnDeactivated(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_DEACTIVATED].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_DEACTIVATED, ec_id, ret)
         return
 
     # inline void postOnAborting(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnAborting(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_ABORTING].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_ABORTING, ec_id, ret)
         return
 
     # inline void postOnError(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnError(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_ERROR].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_ERROR, ec_id, ret)
         return
 
     # inline void postOnReset(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnReset(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_RESET].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_RESET, ec_id, ret)
         return
 
     # inline void postOnExecute(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnExecute(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_EXECUTE].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_EXECUTE, ec_id, ret)
         return
 
     # inline void postOnStateUpdate(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnStateUpdate(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_STATE_UPDATE].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_STATE_UPDATE, ec_id, ret)
         return
 
     # inline void postOnRateChanged(UniqueId ec_id, ReturnCode_t ret)
 
     def postOnRateChanged(self, ec_id, ret):
-        self._actionListeners.postaction_[
-            OpenRTM_aist.PostComponentActionListenerType.POST_ON_RATE_CHANGED].notify(
-            ec_id, ret)
+        self._actionListeners.notifyPostAction(
+            OpenRTM_aist.PostComponentActionListenerType.POST_ON_RATE_CHANGED, ec_id, ret)
         return
 
     # inline void onAddPort(const PortProfile& pprof)
 
     def onAddPort(self, pprof):
-        self._actionListeners.portaction_[
-            OpenRTM_aist.PortActionListenerType.ADD_PORT].notify(pprof)
+        self._actionListeners.notifyPortAction(OpenRTM_aist.PortActionListenerType.ADD_PORT, pprof)
         return
 
     # inline void onRemovePort(const PortProfile& pprof)
 
     def onRemovePort(self, pprof):
-        self._actionListeners.portaction_[
-            OpenRTM_aist.PortActionListenerType.REMOVE_PORT].notify(pprof)
+        self._actionListeners.notifyPortAction(OpenRTM_aist.PortActionListenerType.REMOVE_PORT, pprof)
         return
 
     # inline void onAttachExecutionContext(UniqueId ec_id)
 
     def onAttachExecutionContext(self, ec_id):
-        self._actionListeners.ecaction_[
-            OpenRTM_aist.ExecutionContextActionListenerType.EC_ATTACHED].notify(ec_id)
+        self._actionListeners.notifyECAction(OpenRTM_aist.ExecutionContextActionListenerType.EC_ATTACHED, ec_id)
         return
 
     # inline void onDetachExecutionContext(UniqueId ec_id)
 
     def onDetachExecutionContext(self, ec_id):
-        self._actionListeners.ecaction_[
-            OpenRTM_aist.ExecutionContextActionListenerType.EC_DETACHED].notify(ec_id)
+        self._actionListeners.notifyECAction(OpenRTM_aist.ExecutionContextActionListenerType.EC_DETACHED, ec_id)
         return
 
     def preOnFsmInit(self, state):
-        self._fsmActionListeners.preaction_[
-            OpenRTM_aist.PreFsmActionListenerType.PRE_ON_INIT].notify(state)
+        self._fsmActionListeners.notifyPreAction(OpenRTM_aist.PreFsmActionListenerType.PRE_ON_INIT, state)
         return
 
     def preOnFsmEntry(self, state):
-        self._fsmActionListeners.preaction_[
-            OpenRTM_aist.PreFsmActionListenerType.PRE_ON_ENTRY].notify(state)
+        self._fsmActionListeners.notifyPreAction(OpenRTM_aist.PreFsmActionListenerType.PRE_ON_ENTRY, state)
         return
 
     def preOnFsmDo(self, state):
-        self._fsmActionListeners.preaction_[
-            OpenRTM_aist.PreFsmActionListenerType.PRE_ON_DO].notify(state)
+        self._fsmActionListeners.notifyPreAction(OpenRTM_aist.PreFsmActionListenerType.PRE_ON_DO, state)
         return
 
     def preOnFsmExit(self, state):
-        self._fsmActionListeners.preaction_[
-            OpenRTM_aist.PreFsmActionListenerType.PRE_ON_EXIT].notify(state)
+        self._fsmActionListeners.notifyPreAction(OpenRTM_aist.PreFsmActionListenerType.PRE_ON_EXIT, state)
         return
 
     def preOnFsmStateChange(self, state):
-        self._fsmActionListeners.preaction_[
-            OpenRTM_aist.PreFsmActionListenerType.PRE_ON_STATE_CHANGE].notify(state)
+        self._fsmActionListeners.notifyPreAction(OpenRTM_aist.PreFsmActionListenerType.PRE_ON_STATE_CHANGE, state)
         return
 
     def postOnFsmInit(self, state, ret):
-        self._fsmActionListeners.postaction_[
-            OpenRTM_aist.PostFsmActionListenerType.POST_ON_INIT].notify(
-            state, ret)
+        self._fsmActionListeners.notifyPostAction(
+            OpenRTM_aist.PostFsmActionListenerType.POST_ON_INIT, state, ret)
         return
 
     def postOnFsmEntry(self, state, ret):
-        self._fsmActionListeners.postaction_[
-            OpenRTM_aist.PostFsmActionListenerType.POST_ON_ENTRY].notify(
-            state, ret)
+        self._fsmActionListeners.notifyPostAction(
+            OpenRTM_aist.PostFsmActionListenerType.POST_ON_ENTRY, state, ret)
         return
 
     def postOnFsmDo(self, state, ret):
-        self._fsmActionListeners.postaction_[
-            OpenRTM_aist.PostFsmActionListenerType.POST_ON_DO].notify(state, ret)
+        self._fsmActionListeners.notifyPostAction(OpenRTM_aist.PostFsmActionListenerType.POST_ON_DO, state, ret)
         return
 
     def postOnFsmExit(self, state, ret):
-        self._fsmActionListeners.postaction_[
-            OpenRTM_aist.PostFsmActionListenerType.POST_ON_EXIT].notify(
-            state, ret)
+        self._fsmActionListeners.notifyPostAction(
+            OpenRTM_aist.PostFsmActionListenerType.POST_ON_EXIT, state, ret)
         return
 
     def postOnFsmStateChange(self, state, ret):
-        self._fsmActionListeners.postaction_[
-            OpenRTM_aist.PostFsmActionListenerType.POST_ON_STATE_CHANGE].notify(
-            state, ret)
+        self._fsmActionListeners.notifyPostAction(
+            OpenRTM_aist.PostFsmActionListenerType.POST_ON_STATE_CHANGE, state, ret)
         return
 
     # ReturnCode_t getInheritedECOptions(coil::Properties& default_opts);

--- a/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceInPort.py
+++ b/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceInPort.py
@@ -262,71 +262,63 @@ class OpenSpliceInPort(OpenRTM_aist.InPortProvider):
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE, self._profile, data)
         return data
 
     # inline void onBufferFull(const cdrMemoryStream& data)
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL, self._profile, data)
         return data
 
     # inline void onBufferWriteTimeout(const cdrMemoryStream& data)
 
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT, self._profile, data)
         return data
 
     # inline void onBufferWriteOverwrite(const cdrMemoryStream& data)
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE, self._profile, data)
         return data
 
     # inline void onReceived(const cdrMemoryStream& data)
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED, self._profile, data)
         return data
 
     # inline void onReceiverFull(const cdrMemoryStream& data)
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL, self._profile, data)
         return data
 
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
 
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT, self._profile, data)
         return data
 
     # inline void onReceiverError(const cdrMemoryStream& data)
 
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR, self._profile, data)
         return data
 
 ##

--- a/OpenRTM_aist/ext/transport/ROS2Transport/ROS2InPort.py
+++ b/OpenRTM_aist/ext/transport/ROS2Transport/ROS2InPort.py
@@ -281,71 +281,63 @@ class ROS2InPort(OpenRTM_aist.InPortProvider):
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
-                self._profile, data)
+            _, data = self._listeners..notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE, self._profile, data)
         return data
 
     # inline void onBufferFull(const cdrMemoryStream& data)
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL, self._profile, data)
         return data
 
     # inline void onBufferWriteTimeout(const cdrMemoryStream& data)
 
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT, self._profile, data)
         return data
 
     # inline void onBufferWriteOverwrite(const cdrMemoryStream& data)
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE, self._profile, data)
         return data
 
     # inline void onReceived(const cdrMemoryStream& data)
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED, self._profile, data)
         return data
 
     # inline void onReceiverFull(const cdrMemoryStream& data)
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL, self._profile, data)
         return data
 
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
 
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT, self._profile, data)
         return data
 
     # inline void onReceiverError(const cdrMemoryStream& data)
 
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR, self._profile, data)
         return data
 
 

--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSInPort.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSInPort.py
@@ -487,71 +487,63 @@ class ROSInPort(OpenRTM_aist.InPortProvider):
 
     def onBufferWrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE, self._profile, data)
         return data
 
     # inline void onBufferFull(const cdrMemoryStream& data)
 
     def onBufferFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_FULL, self._profile, data)
         return data
 
     # inline void onBufferWriteTimeout(const cdrMemoryStream& data)
 
     def onBufferWriteTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_WRITE_TIMEOUT, self._profile, data)
         return data
 
     # inline void onBufferWriteOverwrite(const cdrMemoryStream& data)
     def onBufferWriteOverwrite(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_BUFFER_OVERWRITE, self._profile, data)
         return data
 
     # inline void onReceived(const cdrMemoryStream& data)
 
     def onReceived(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVED, self._profile, data)
         return data
 
     # inline void onReceiverFull(const cdrMemoryStream& data)
 
     def onReceiverFull(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_FULL, self._profile, data)
         return data
 
     # inline void onReceiverTimeout(const cdrMemoryStream& data)
 
     def onReceiverTimeout(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_TIMEOUT, self._profile, data)
         return data
 
     # inline void onReceiverError(const cdrMemoryStream& data)
 
     def onReceiverError(self, data):
         if self._listeners is not None and self._profile is not None:
-            _, data = self._listeners.connectorData_[
-                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR].notify(
-                self._profile, data)
+            _, data = self._listeners.notifyData(
+                OpenRTM_aist.ConnectorDataListenerType.ON_RECEIVER_ERROR, self._profile, data)
         return data
 
     ##


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
以下と同じ。

- https://github.com/OpenRTM/OpenRTM-aist/pull/682

リスナのコールバック関数を実行する際に外からメンバ変数を操作しているが、リストの長さ以上の値を指定した場合等の対応が面倒なため、関数化して直接操作すべきではない。


## Description of the Change

`***Listeners`クラスに`addXXXListener`関数、`removeXXXListener`関数、`notifyXXX`関数を定義した。

`ManagerActionListeners`は関数でListenerHolderを取得するようにすると記述が複雑になるだけのようなので未修正。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
