### PR TITLE
指定のシリアライザが生成できなかった場合に適切に処理する

### DIFF
--- a/OpenRTM_aist/ConnectorListener.py
+++ b/OpenRTM_aist/ConnectorListener.py
@@ -811,6 +811,9 @@ class ConnectorDataListenerHolder:
 
         serializer = OpenRTM_aist.SerializerFactory.instance().createObject(marshaling_type)
 
+        if serializer is None:
+            return ret, cdrdata
+
         serializer.isLittleEndian(endian)
         data = self._data
 

--- a/OpenRTM_aist/InPortDuplexConnector.py
+++ b/OpenRTM_aist/InPortDuplexConnector.py
@@ -444,6 +444,10 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
     # @return
     # @endif
     def deserializeData(self, cdr):
+        if self._serializer is None:
+            self._rtcout.RTC_ERROR("serializer creation failure.")
+            return self.PRECONDITION_NOT_MET, None
+
         self._serializer.isLittleEndian(self._endian)
         ser_ret, data = self._serializer.deserialize(cdr, self._dataType)
 

--- a/OpenRTM_aist/InPortDuplexConnector.py
+++ b/OpenRTM_aist/InPortDuplexConnector.py
@@ -446,7 +446,7 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
     def deserializeData(self, cdr):
         if self._serializer is None:
             self._rtcout.RTC_ERROR("serializer creation failure.")
-            return self.PRECONDITION_NOT_MET, None
+            return self.UNKNOWN_ERROR, None
 
         self._serializer.isLittleEndian(self._endian)
         ser_ret, data = self._serializer.deserialize(cdr, self._dataType)
@@ -462,7 +462,7 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
         elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOTFOUND:
             self._rtcout.RTC_ERROR("unknown serializer from connector")
             return self.UNKNOWN_ERROR, None
-        return self.PRECONDITION_NOT_MET, None
+        return self.UNKNOWN_ERROR, None
 
     ##
     # @if jp

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -178,12 +178,13 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
     # OutPortConsumer からデータを取得する。正常に読み出せた場合、戻り
     # 値は PORT_OK となり、data に読み出されたデータが格納される。それ
     # 以外の場合には、エラー値として BUFFER_EMPTY, TIMEOUT,
-    # PRECONDITION_NOT_MET, PORT_ERROR が返される。
+    # PRECONDITION_NOT_MET, UNKNOWN_ERROR, PORT_ERROR が返される。
     #
     # @return PORT_OK              正常終了
     #         BUFFER_EMPTY         バッファは空である
     #         TIMEOUT              タイムアウトした
     #         PRECONDITION_NOT_MET 事前条件を満たさない
+    #         UNKNOWN_ERROR        不明のエラー
     #         PORT_ERROR           その他のエラー
     #
     # @else
@@ -191,13 +192,14 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
     #
     # This function get data from OutPortConsumer.  If data is read
     # properly, this function will return PORT_OK return code. Except
-    # normal return, BUFFER_EMPTY, TIMEOUT, PRECONDITION_NOT_MET and
-    # PORT_ERROR will be returned as error codes.
+    # normal return, BUFFER_EMPTY, TIMEOUT, PRECONDITION_NOT_MET,
+    # UNKNOWN_ERROR and PORT_ERROR will be returned as error codes.
     #
     # @return PORT_OK              Normal return
     #         BUFFER_EMPTY         Buffer empty
     #         TIMEOUT              Timeout
     #         PRECONDITION_NOT_MET Preconditin not met
+    #         UNKNOWN_ERROR        Unknown errot
     #         PORT_ERROR           Other error
     #
     # @endif
@@ -243,20 +245,20 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
 
             if self._serializer is None:
                 self._rtcout.RTC_ERROR("serializer creation failure.")
-                return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET, data
+                return OpenRTM_aist.BufferStatus.UNKNOWN_ERROR, data
 
             self._serializer.isLittleEndian(self._endian)
             ser_ret, data = self._serializer.deserialize(cdr_data, data)
 
             if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:
                 self._rtcout.RTC_ERROR("unknown endian from connector")
-                return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET, data
+                return OpenRTM_aist.BufferStatus.UNKNOWN_ERROR, data
             elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR:
                 self._rtcout.RTC_ERROR("unknown error")
-                return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET, data
+                return OpenRTM_aist.BufferStatus.UNKNOWN_ERROR, data
             elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOTFOUND:
                 self._rtcout.RTC_ERROR("unknown serializer from connector")
-                return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET, data
+                return OpenRTM_aist.BufferStatus.UNKNOWN_ERROR, data
 
         return ret, data
 

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -240,6 +240,9 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
         if ret == self.PORT_OK:
             if data is None:
                 self._rtcout.RTC_ERROR("argument is invalid")
+
+            if self._serializer is None:
+                self._rtcout.RTC_ERROR("serializer creation failure.")
                 return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET, data
 
             self._serializer.isLittleEndian(self._endian)

--- a/OpenRTM_aist/InPortPushConnector.py
+++ b/OpenRTM_aist/InPortPushConnector.py
@@ -289,6 +289,9 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
             return ret, data
         else:
             cdr = self.onBufferRead(cdr)
+            if self._serializer is None:
+                self._rtcout.RTC_ERROR("serializer creation failure.")
+                return self.PRECONDITION_NOT_MET, data
             self._serializer.isLittleEndian(self._endian)
             ser_ret, _data = self._serializer.deserialize(cdr, self._dataType)
 

--- a/OpenRTM_aist/InPortPushConnector.py
+++ b/OpenRTM_aist/InPortPushConnector.py
@@ -251,12 +251,13 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
     # バッファからデータを読み出す。正常に読み出せた場合、戻り値は
     # PORT_OK となり、data に読み出されたデータが格納される。それ以外
     # の場合には、エラー値として BUFFER_EMPTY, TIMEOUT,
-    # PRECONDITION_NOT_MET, PORT_ERROR が返される。
+    # PRECONDITION_NOT_MET, UNKNOWN_ERROR, PORT_ERROR が返される。
     #
     # @return PORT_OK              正常終了
     #         BUFFER_EMPTY         バッファは空である
     #         TIMEOUT              タイムアウトした
     #         PRECONDITION_NOT_MET 事前条件を満たさない
+    #         UNKNOWN_ERROR        不明のエラー
     #         PORT_ERROR           その他のエラー
     #
     # @else
@@ -265,13 +266,14 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
     #
     # This function reads data from the buffer. If data is read
     # properly, this function will return PORT_OK return code. Except
-    # normal return, BUFFER_EMPTY, TIMEOUT, PRECONDITION_NOT_MET and
-    # PORT_ERROR will be returned as error codes.
+    # normal return, BUFFER_EMPTY, TIMEOUT, PRECONDITION_NOT_MET,
+    # UNKNOWN_ERROR and PORT_ERROR will be returned as error codes.
     #
     # @return PORT_OK              Normal return
     #         BUFFER_EMPTY         Buffer empty
     #         TIMEOUT              Timeout
     #         PRECONDITION_NOT_MET Preconditin not met
+    #         UNKNOWN_ERROR        Unknown errot
     #         PORT_ERROR           Other error
     #
     # @endif
@@ -291,7 +293,7 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
             cdr = self.onBufferRead(cdr)
             if self._serializer is None:
                 self._rtcout.RTC_ERROR("serializer creation failure.")
-                return self.PRECONDITION_NOT_MET, data
+                return self.UNKNOWN_ERROR, data
             self._serializer.isLittleEndian(self._endian)
             ser_ret, _data = self._serializer.deserialize(cdr, self._dataType)
 
@@ -300,13 +302,13 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
                 return self.PORT_OK, data
             elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:
                 self._rtcout.RTC_ERROR("unknown endian from connector")
-                return self.PRECONDITION_NOT_MET, data
+                return self.UNKNOWN_ERROR, data
             elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR:
                 self._rtcout.RTC_ERROR("unknown error")
-                return self.PRECONDITION_NOT_MET, data
+                return self.UNKNOWN_ERROR, data
             elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOTFOUND:
                 self._rtcout.RTC_ERROR("unknown serializer from connector")
-                return self.PRECONDITION_NOT_MET, data
+                return self.UNKNOWN_ERROR, data
 
         return self.PORT_ERROR, data
 

--- a/OpenRTM_aist/OutPortDuplexConnector.py
+++ b/OpenRTM_aist/OutPortDuplexConnector.py
@@ -434,6 +434,9 @@ class OutPortDuplexConnector(OpenRTM_aist.OutPortConnector):
     # @endif
 
     def serializeData(self, data):
+        if self._serializer is None:
+            self._rtcout.RTC_ERROR("serializer creation failure.")
+            return self.UNKNOWN_ERROR, cdr_data
         self._serializer.isLittleEndian(self._endian)
         ser_ret, cdr_data = self._serializer.serialize(data)
         if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:

--- a/OpenRTM_aist/OutPortPullConnector.py
+++ b/OpenRTM_aist/OutPortPullConnector.py
@@ -204,6 +204,10 @@ class OutPortPullConnector(OpenRTM_aist.OutPortConnector):
         if self._directMode:
             return self.PORT_OK
         # data -> (conversion) -> CDR stream
+        if self._serializer is None:
+            self._rtcout.RTC_ERROR("serializer creation failure.")
+            return self.UNKNOWN_ERROR
+
         self._serializer.isLittleEndian(self._endian)
         ser_ret, cdr_data = self._serializer.serialize(data)
         if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:

--- a/OpenRTM_aist/OutPortPushConnector.py
+++ b/OpenRTM_aist/OutPortPushConnector.py
@@ -266,6 +266,10 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
             self._rtcout.RTC_TRACE("callback called in direct mode.")
             return self.PORT_OK
         # data -> (conversion) -> CDR stream
+        if self._serializer is None:
+            self._rtcout.RTC_ERROR("serializer creation failure.")
+            return self.UNKNOWN_ERROR
+
         self._serializer.isLittleEndian(self._endian)
         ser_ret, cdr_data = self._serializer.serialize(data)
         if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

InPortPushConnector等で指定のシリアライザが存在しなかった場合にNoneの変数を操作しようとする。


## Description of the Change

指定のシリアライザが存在しない場合はUNKNOWN_ERRORを返すように修正した。
ConnectorDataListenerではデシリアライズせずにバイト列のデータのままコールバック関数を実行する場合があるため、シリアライザが存在しない場合でも処理を続行するようにしている。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
