### PR TITLE
デシリアライズ後のデータ型の指定方法の見直し

### DIFF
--- a/OpenRTM_aist/InPort.py
+++ b/OpenRTM_aist/InPort.py
@@ -358,22 +358,21 @@ class InPort(OpenRTM_aist.InPortBase):
             return self._value
 
         _val = copy.deepcopy(self._value)
-        cdr = _val
 
         if name is None:
-            ret, cdr = self._connectors[0].read(cdr)
+            ret, _val = self._connectors[0].read(_val)
         else:
             ret = OpenRTM_aist.DataPortStatus.PRECONDITION_NOT_MET
             for con in self._connectors:
                 if con.name() == name:
-                    ret, cdr = con.read(cdr)
+                    ret, _val = con.read(_val)
             if ret == OpenRTM_aist.DataPortStatus.PRECONDITION_NOT_MET:
                 self._rtcout.RTC_DEBUG("not found %s", name)
                 return self._value
 
         if ret == OpenRTM_aist.DataPortStatus.PORT_OK:
             self._rtcout.RTC_DEBUG("data read succeeded")
-            self._value = cdr
+            self._value = _val
 
             if self._OnReadConvert is not None:
                 self._value = self._OnReadConvert(self._value)

--- a/OpenRTM_aist/InPortBase.py
+++ b/OpenRTM_aist/InPortBase.py
@@ -1067,6 +1067,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
 
             # create InPortPullConnector
             connector = self.createConnector(cprof, prop, consumer_=consumer)
+            connector.setDataType(self._value)
             if not connector:
                 return RTC.RTC_ERROR
 
@@ -1092,6 +1093,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
 
             connector.setConsumer(consumer)
             ret = connector.setConnectorInfo(profile)
+            connector.setDataType(self._value)
 
             if ret == RTC.RTC_OK:
                 self._rtcout.RTC_DEBUG(

--- a/OpenRTM_aist/InPortBase.py
+++ b/OpenRTM_aist/InPortBase.py
@@ -1067,9 +1067,11 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
 
             # create InPortPullConnector
             connector = self.createConnector(cprof, prop, consumer_=consumer)
-            connector.setDataType(self._value)
+            
             if not connector:
                 return RTC.RTC_ERROR
+
+            connector.setDataType(self._value)
 
             ret = connector.setConnectorInfo(profile)
 

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -241,7 +241,7 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
         if datatype is None:
             if data is None:
                 self._rtcout.RTC_ERROR("invalid data type")
-                return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET, data
+                return OpenRTM_aist.UNKNOWN_ERROR, data
             datatype = data
 
         ret, cdr_data = self._consumer.get()
@@ -250,20 +250,20 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
 
             if self._serializer is None:
                 self._rtcout.RTC_ERROR("serializer creation failure.")
-                return OpenRTM_aist.BufferStatus.UNKNOWN_ERROR, data
+                return OpenRTM_aist.UNKNOWN_ERROR, data
             
             self._serializer.isLittleEndian(self._endian)
             ser_ret, data = self._serializer.deserialize(cdr_data, datatype)
 
             if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:
                 self._rtcout.RTC_ERROR("unknown endian from connector")
-                return OpenRTM_aist.BufferStatus.UNKNOWN_ERROR, data
+                return OpenRTM_aist.UNKNOWN_ERROR, data
             elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR:
                 self._rtcout.RTC_ERROR("unknown error")
-                return OpenRTM_aist.BufferStatus.UNKNOWN_ERROR, data
+                return OpenRTM_aist.UNKNOWN_ERROR, data
             elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOTFOUND:
                 self._rtcout.RTC_ERROR("unknown serializer from connector")
-                return OpenRTM_aist.BufferStatus.UNKNOWN_ERROR, data
+                return OpenRTM_aist.UNKNOWN_ERROR, data
 
         return ret, data
 

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -241,7 +241,7 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
         if datatype is None:
             if data is None:
                 self._rtcout.RTC_ERROR("invalid data type")
-                return OpenRTM_aist.UNKNOWN_ERROR, data
+                return self.UNKNOWN_ERROR, data
             datatype = data
 
         ret, cdr_data = self._consumer.get()
@@ -250,20 +250,20 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
 
             if self._serializer is None:
                 self._rtcout.RTC_ERROR("serializer creation failure.")
-                return OpenRTM_aist.UNKNOWN_ERROR, data
+                return self.UNKNOWN_ERROR, data
             
             self._serializer.isLittleEndian(self._endian)
             ser_ret, data = self._serializer.deserialize(cdr_data, datatype)
 
             if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:
                 self._rtcout.RTC_ERROR("unknown endian from connector")
-                return OpenRTM_aist.UNKNOWN_ERROR, data
+                return self.UNKNOWN_ERROR, data
             elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR:
                 self._rtcout.RTC_ERROR("unknown error")
-                return OpenRTM_aist.UNKNOWN_ERROR, data
+                return self.UNKNOWN_ERROR, data
             elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOTFOUND:
                 self._rtcout.RTC_ERROR("unknown serializer from connector")
-                return OpenRTM_aist.UNKNOWN_ERROR, data
+                return self.UNKNOWN_ERROR, data
 
         return ret, data
 

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -235,15 +235,20 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
         if not self._consumer:
             return self.PORT_ERROR, data
 
+        datatype = self._dataType
+        if datatype is None:
+            if data is None:
+                self._rtcout.RTC_ERROR("invalid data type")
+                return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET, data
+            datatype = data
+
         ret, cdr_data = self._consumer.get()
 
         if ret == self.PORT_OK:
-            if data is None:
-                self._rtcout.RTC_ERROR("argument is invalid")
                 return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET, data
 
             self._serializer.isLittleEndian(self._endian)
-            ser_ret, data = self._serializer.deserialize(cdr_data, data)
+            ser_ret, data = self._serializer.deserialize(cdr_data, datatype)
 
             if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:
                 self._rtcout.RTC_ERROR("unknown endian from connector")

--- a/OpenRTM_aist/InPortPushConnector.py
+++ b/OpenRTM_aist/InPortPushConnector.py
@@ -280,8 +280,12 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
     def read(self, data=None):
         self._rtcout.RTC_TRACE("read()")
 
-        if not self._dataType:
-            return self.PRECONDITION_NOT_MET, data
+        datatype = self._dataType
+        if datatype is None:
+            if data is None:
+                self._rtcout.RTC_ERROR("invalid data type")
+                return self.PRECONDITION_NOT_MET, data
+            datatype = data
 
         ret, cdr = self.readBuff()
 
@@ -290,7 +294,7 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
         else:
             cdr = self.onBufferRead(cdr)
             self._serializer.isLittleEndian(self._endian)
-            ser_ret, _data = self._serializer.deserialize(cdr, self._dataType)
+            ser_ret, _data = self._serializer.deserialize(cdr, datatype)
 
             if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK:
                 data = _data


### PR DESCRIPTION
…s changed.

<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

InPortPullConnector、InPortPushConnectorのread関数内でデシリアライズを実行するが、デシリアライズ後のデータ型の指定方法は以下の2つがある。

- read関数の引数で指定する
- InPortConnectorのsetDataType関数で設定する

しかしInPortPullConnectorではsetDataType関数が呼ばれておらず、InPortPushConnectorのread関数では引数で指定した型でデシリアライズを実行しないようになっており、方法が統一されていない。

## Description of the Change

デシリアライズ後のデータ型の指定は以下の方法に統一した。

- ポートにデータ型設定されている場合は、InPortPullConnector、InPortPushConnectorのどちらでもsetDataType関数で設定する
- read関数の引数でデータ型を指定した場合は、setDataType関数で指定した型ではなく引数のデータ型にデシリアライズする

## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
