### PR TITLE
IDを文字列に変換するtoString関数の修正

### DIFF
--- a/OpenRTM_aist/BufferStatus.py
+++ b/OpenRTM_aist/BufferStatus.py
@@ -31,11 +31,13 @@ class BufferStatus:
     PRECONDITION_NOT_MET = 6
 
     def toString(self, status):
-        str = ["BUFFER_OK",
-               "BUFFER_ERROR",
-               "BUFFER_FULL",
-               "BUFFER_EMPTY",
-               "NOT_SUPPORTED",
-               "TIMEOUT",
-               "PRECONDITION_NOT_MET"]
-        return str[status]
+        typeString = ["BUFFER_OK",
+                      "BUFFER_ERROR",
+                      "BUFFER_FULL",
+                      "BUFFER_EMPTY",
+                      "NOT_SUPPORTED",
+                      "TIMEOUT",
+                      "PRECONDITION_NOT_MET"]
+        if status < len(typeString):
+            return typeString[status]
+        return ""

--- a/OpenRTM_aist/ComponentActionListener.py
+++ b/OpenRTM_aist/ComponentActionListener.py
@@ -134,7 +134,7 @@ class PreComponentActionListener:
     #
     # @endif
     # static const char* toString(PreComponentActionListenerType type)
-    def toString(type):
+    def toString(status):
         typeString = ["PRE_ON_INITIALIZE",
                       "PRE_ON_FINALIZE",
                       "PRE_ON_STARTUP",
@@ -148,8 +148,8 @@ class PreComponentActionListener:
                       "PRE_ON_STATE_UPDATE",
                       "PRE_ON_RATE_CHANGED",
                       "PRE_COMPONENT_ACTION_LISTENER_NUM"]
-        if type < PreComponentActionListenerType.PRE_COMPONENT_ACTION_LISTENER_NUM:
-            return typeString[type]
+        if status < len(typeString):
+            return typeString[status]
 
         return ""
     toString = staticmethod(toString)

--- a/OpenRTM_aist/ComponentActionListener.py
+++ b/OpenRTM_aist/ComponentActionListener.py
@@ -146,8 +146,7 @@ class PreComponentActionListener:
                       "PRE_ON_RESET",
                       "PRE_ON_EXECUTE",
                       "PRE_ON_STATE_UPDATE",
-                      "PRE_ON_RATE_CHANGED",
-                      "PRE_COMPONENT_ACTION_LISTENER_NUM"]
+                      "PRE_ON_RATE_CHANGED"]
         if status < len(typeString):
             return typeString[status]
 
@@ -302,7 +301,7 @@ class PostComponentActionListener:
     #
     # @endif
     # static const char* toString(PostComponentActionListenerType type)
-    def toString(type):
+    def toString(status):
         typeString = ["POST_ON_INITIALIZE",
                       "POST_ON_FINALIZE",
                       "POST_ON_STARTUP",
@@ -314,10 +313,9 @@ class PostComponentActionListener:
                       "POST_ON_RESET",
                       "POST_ON_EXECUTE",
                       "POST_ON_STATE_UPDATE",
-                      "POST_ON_RATE_CHANGED",
-                      "POST_COMPONENT_ACTION_LISTENER_NUM"]
-        if type < PostComponentActionListenerType.POST_COMPONENT_ACTION_LISTENER_NUM:
-            return typeString[type]
+                      "POST_ON_RATE_CHANGED"]
+        if status < len(typeString):
+            return typeString[status]
         return ""
 
     toString = staticmethod(toString)
@@ -424,12 +422,11 @@ class PortActionListener:
     #
     # @endif
     # static const char* toString(PortActionListenerType type)
-    def toString(type):
+    def toString(status):
         typeString = ["ADD_PORT",
-                      "REMOVE_PORT",
-                      "PORT_ACTION_LISTENER_NUM"]
-        if type < PortActionListenerType.PORT_ACTION_LISTENER_NUM:
-            return typeString[type]
+                      "REMOVE_PORT"]
+        if status < len(typeString):
+            return typeString[status]
         return ""
 
     toString = staticmethod(toString)
@@ -538,12 +535,11 @@ class ExecutionContextActionListener:
     # @endif
     # static const char* toString(ExecutionContextActionListenerType type)
 
-    def toString(type):
+    def toString(status):
         typeString = ["ATTACH_EC",
-                      "DETACH_EC",
-                      "EC_ACTION_LISTENER_NUM"]
-        if type < ExecutionContextActionListenerType.EC_ACTION_LISTENER_NUM:
-            return typeString[type]
+                      "DETACH_EC"]
+        if status < len(typeString):
+            return typeString[status]
         return ""
 
     toString = staticmethod(toString)

--- a/OpenRTM_aist/ConfigurationListener.py
+++ b/OpenRTM_aist/ConfigurationListener.py
@@ -89,12 +89,11 @@ class ConfigurationParamListener:
     #
     # @endif
     # static const char* toString(ConfigurationParamListenerType type)
-    def toString(type):
-        typeString = ["ON_UPDATE_CONFIG_PARAM",
-                      "CONFIG_PARAM_LISTENER_NUM"]
+    def toString(status):
+        typeString = ["ON_UPDATE_CONFIG_PARAM"]
 
-        if type < ConfigurationParamListenerType.CONFIG_PARAM_LISTENER_NUM:
-            return typeString[type]
+        if status < len(typeString):
+            return typeString[status]
 
         return ""
 
@@ -212,12 +211,11 @@ class ConfigurationSetListener:
     # @endif
     # static const char* toString(ConfigurationSetListenerType type)
 
-    def toString(type):
+    def toString(status):
         typeString = ["ON_SET_CONFIG_SET",
-                      "ON_ADD_CONFIG_SET",
-                      "CONFIG_SET_LISTENER_NUM"]
-        if type < ConfigurationSetListenerType.CONFIG_SET_LISTENER_NUM:
-            return typeString[type]
+                      "ON_ADD_CONFIG_SET"]
+        if status < len(typeString):
+            return typeString[status]
 
         return ""
 
@@ -330,13 +328,12 @@ class ConfigurationSetNameListener:
     # @endif
     # static const char* toString(ConfigurationSetNameListenerType type)
 
-    def toString(type):
+    def toString(status):
         typeString = ["ON_UPDATE_CONFIG_SET",
                       "ON_REMOVE_CONFIG_SET",
-                      "ON_ACTIVATE_CONFIG_SET",
-                      "CONFIG_SET_NAME_LISTENER_NUM"]
-        if type < ConfigurationSetNameListenerType.CONFIG_SET_NAME_LISTENER_NUM:
-            return typeString[type]
+                      "ON_ACTIVATE_CONFIG_SET"]
+        if status < len(typeString):
+            return typeString[status]
 
         return ""
 

--- a/OpenRTM_aist/ConnectorListener.py
+++ b/OpenRTM_aist/ConnectorListener.py
@@ -249,7 +249,7 @@ class ConnectorDataListener(object):
     #
     # @endif
     #
-    def toString(type):
+    def toString(status):
         typeString = ["ON_BUFFER_WRITE",
                       "ON_BUFFER_FULL",
                       "ON_BUFFER_WRITE_TIMEOUT",
@@ -262,8 +262,8 @@ class ConnectorDataListener(object):
                       "ON_RECEIVER_ERROR",
                       "CONNECTOR_DATA_LISTENER_NUM"]
 
-        if type < ConnectorDataListenerType.CONNECTOR_DATA_LISTENER_NUM:
-            return typeString[type]
+        if status < len(typeString):
+            return typeString[status]
 
         return ""
 
@@ -642,7 +642,7 @@ class ConnectorListener:
     #
     # @endif
     #
-    def toString(type):
+    def toString(status):
         typeString = ["ON_BUFFER_EMPTY",
                       "ON_BUFFER_READ_TIMEOUT",
                       "ON_SENDER_EMPTY",
@@ -652,8 +652,8 @@ class ConnectorListener:
                       "ON_DISCONNECT",
                       "CONNECTOR_LISTENER_NUM"]
 
-        if type < ConnectorListenerType.CONNECTOR_LISTENER_NUM:
-            return typeString[type]
+        if status < len(typeString):
+            return typeString[status]
 
         return ""
 

--- a/OpenRTM_aist/ConnectorListener.py
+++ b/OpenRTM_aist/ConnectorListener.py
@@ -259,8 +259,7 @@ class ConnectorDataListener(object):
                       "ON_RECEIVED",
                       "ON_RECEIVER_FULL",
                       "ON_RECEIVER_TIMEOUT",
-                      "ON_RECEIVER_ERROR",
-                      "CONNECTOR_DATA_LISTENER_NUM"]
+                      "ON_RECEIVER_ERROR"]
 
         if status < len(typeString):
             return typeString[status]
@@ -649,8 +648,7 @@ class ConnectorListener:
                       "ON_SENDER_TIMEOUT",
                       "ON_SENDER_ERROR",
                       "ON_CONNECT",
-                      "ON_DISCONNECT",
-                      "CONNECTOR_LISTENER_NUM"]
+                      "ON_DISCONNECT"]
 
         if status < len(typeString):
             return typeString[status]

--- a/OpenRTM_aist/DataPortStatus.py
+++ b/OpenRTM_aist/DataPortStatus.py
@@ -176,20 +176,21 @@ class DataPortStatus:
     # @endif
     #
     def toString(status):
-        str = ["PORT_OK",
-               "PORT_ERROR",
-               "BUFFER_ERROR",
-               "BUFFER_FULL",
-               "BUFFER_EMPTY",
-               "BUFFER_TIMEOUT",
-               "SEND_FULL",
-               "SEND_TIMEOUT",
-               "RECV_EMPTY",
-               "RECV_TIMEOUT",
-               "INVALID_ARGS",
-               "PRECONDITION_NOT_MET",
-               "CONNECTION_LOST",
-               "UNKNOWN_ERROR"]
-        return str[status]
+        typeString = ["PORT_OK",
+                      "PORT_ERROR",
+                      "BUFFER_ERROR",
+                      "BUFFER_FULL",
+                      "BUFFER_EMPTY",
+                      "BUFFER_TIMEOUT",
+                      "SEND_FULL",
+                      "SEND_TIMEOUT",
+                      "RECV_EMPTY",
+                      "RECV_TIMEOUT",
+                      "INVALID_ARGS",
+                      "PRECONDITION_NOT_MET",
+                      "CONNECTION_LOST",
+                      "UNKNOWN_ERROR"]
+        if status < len(typeString):
+            return typeString[status]
 
     toString = staticmethod(toString)

--- a/OpenRTM_aist/DataPortStatus.py
+++ b/OpenRTM_aist/DataPortStatus.py
@@ -192,5 +192,6 @@ class DataPortStatus:
                       "UNKNOWN_ERROR"]
         if status < len(typeString):
             return typeString[status]
+        return ""
 
     toString = staticmethod(toString)

--- a/OpenRTM_aist/FsmActionListener.py
+++ b/OpenRTM_aist/FsmActionListener.py
@@ -290,15 +290,15 @@ class PreFsmActionListener:
     #
     # @endif
     #
-    def toString(type):
+    def toString(status):
         typeString = ["PRE_ON_INIT",
                       "PRE_ON_ENTRY",
                       "PRE_ON_DO",
                       "PRE_ON_EXIT",
                       "PRE_ON_STATE_CHANGE",
                       "PRE_FSM_ACTION_LISTENER_NUM"]
-        if type < PreFsmActionListenerType.PRE_FSM_ACTION_LISTENER_NUM:
-            return typeString[type]
+        if status < len(typeString):
+            return typeString[status]
 
         return ""
     toString = staticmethod(toString)
@@ -542,15 +542,15 @@ class PostFsmActionListener:
     #
     # @endif
     #
-    def toString(type):
+    def toString(status):
         typeString = ["POST_ON_INIT",
                       "POST_ON_ENTRY",
                       "POST_ON_DO",
                       "POST_ON_EXIT",
                       "POST_ON_STATE_CHANGE",
                       "POST_FSM_ACTION_LISTENER_NUM"]
-        if type < PostFsmActionListenerType.POST_FSM_ACTION_LISTENER_NUM:
-            return typeString[type]
+        if status < len(typeString):
+            return typeString[status]
 
         return ""
     toString = staticmethod(toString)
@@ -798,7 +798,7 @@ class FsmProfileListener:
     #
     # @endif
     #
-    def toString(type):
+    def toString(status):
         typeString = ["SET_FSM_PROFILE",
                       "GET_FSM_PROFILE",
                       "ADD_FSM_STATE",
@@ -808,8 +808,8 @@ class FsmProfileListener:
                       "BIND_FSM_EVENT",
                       "UNBIND_FSM_EVENT",
                       "PRE_FSM_ACTION_LISTENER_NUM"]
-        if type < FsmProfileListenerType.FSM_PROFILE_LISTENER_NUM:
-            return typeString[type]
+        if status < len(typeString):
+            return typeString[status]
 
         return ""
     toString = staticmethod(toString)
@@ -1028,12 +1028,12 @@ class FsmStructureListener:
     #
     # @endif
     #
-    def toString(type):
+    def toString(status):
         typeString = ["SET_FSM_STRUCTURE",
                       "GET_FSM_STRUCTURE",
                       "FSM_STRUCTURE_LISTENER_NUM"]
-        if type < FsmStructureListenerType.FSM_STRUCTURE_LISTENER_NUM:
-            return typeString[type]
+        if status < FsmStructureListenerType.FSM_STRUCTURE_LISTENER_NUM:
+            return typeString[status]
 
         return ""
     toString = staticmethod(toString)

--- a/OpenRTM_aist/FsmActionListener.py
+++ b/OpenRTM_aist/FsmActionListener.py
@@ -295,8 +295,7 @@ class PreFsmActionListener:
                       "PRE_ON_ENTRY",
                       "PRE_ON_DO",
                       "PRE_ON_EXIT",
-                      "PRE_ON_STATE_CHANGE",
-                      "PRE_FSM_ACTION_LISTENER_NUM"]
+                      "PRE_ON_STATE_CHANGE"]
         if status < len(typeString):
             return typeString[status]
 
@@ -547,8 +546,7 @@ class PostFsmActionListener:
                       "POST_ON_ENTRY",
                       "POST_ON_DO",
                       "POST_ON_EXIT",
-                      "POST_ON_STATE_CHANGE",
-                      "POST_FSM_ACTION_LISTENER_NUM"]
+                      "POST_ON_STATE_CHANGE"]
         if status < len(typeString):
             return typeString[status]
 
@@ -806,8 +804,7 @@ class FsmProfileListener:
                       "ADD_FSM_TRANSITION",
                       "REMOVE_FSM_TRANSITION",
                       "BIND_FSM_EVENT",
-                      "UNBIND_FSM_EVENT",
-                      "PRE_FSM_ACTION_LISTENER_NUM"]
+                      "UNBIND_FSM_EVENT"]
         if status < len(typeString):
             return typeString[status]
 
@@ -1030,9 +1027,8 @@ class FsmStructureListener:
     #
     def toString(status):
         typeString = ["SET_FSM_STRUCTURE",
-                      "GET_FSM_STRUCTURE",
-                      "FSM_STRUCTURE_LISTENER_NUM"]
-        if status < FsmStructureListenerType.FSM_STRUCTURE_LISTENER_NUM:
+                      "GET_FSM_STRUCTURE"]
+        if status < len(typeString):
             return typeString[status]
 
         return ""

--- a/OpenRTM_aist/PortConnectListener.py
+++ b/OpenRTM_aist/PortConnectListener.py
@@ -78,7 +78,8 @@ class PortConnectListenerType:
     ON_NOTIFY_CONNECT = 0
     ON_NOTIFY_DISCONNECT = 1
     ON_UNSUBSCRIBE_INTERFACES = 2
-    PORT_CONNECT_LISTENER_NUM = 3
+    ON_UPDATE_CONFIG_PARAM = 3
+    PORT_CONNECT_LISTENER_NUM = 4
 
     def __init__(self):
         pass
@@ -138,15 +139,14 @@ class PortConnectListener:
     #
     # @endif
     # static const char* toString(PortConnectListenerType type);
-    def toString(type):
+    def toString(status):
         typeString = ["ON_NOTIFY_CONNECT",
                       "ON_NOTIFY_DISCONNECT",
                       "ON_UNSUBSCRIBE_INTERFACES",
-                      "ON_UPDATE_CONFIG_PARAM",
-                      ""]
+                      "ON_UPDATE_CONFIG_PARAM"]
 
-        if type < PortConnectListenerType.PORT_CONNECT_LISTENER_NUM:
-            return typeString[type]
+        if status < len(typeString):
+            return typeString[status]
 
         return ""
 
@@ -280,17 +280,16 @@ class PortConnectRetListener:
     # @endif
     # static const char* toString(PortConnectRetListenerType type);
 
-    def toString(type):
+    def toString(status):
         typeString = ["ON_PUBLISH_INTERFACES",
                       "ON_CONNECT_NEXTPORT",
                       "ON_SUBSCRIBE_INTERFACES",
                       "ON_CONNECTED",
                       "ON_DISCONNECT_NEXT",
-                      "ON_DISCONNECTED",
-                      ""]
+                      "ON_DISCONNECTED"]
 
-        if type < PortConnectRetListenerType.PORT_CONNECT_RET_LISTENER_NUM:
-            return typeString[type]
+        if status < len(typeString):
+            return typeString[status]
 
         return ""
     toString = staticmethod(toString)


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

BufferStatus.py等にIDを文字列に変換する`toString`関数が定義してあるが、以下の問題がある。

- `type`等、予約語を変数名にしている箇所が多数ある
- `PRE_COMPONENT_ACTION_LISTENER_NUM`等のIDの数を表す定数を定義して入力したIDと比較しているが、文字列のリストの長さと比較(`if status < len(typeString):`)すれば他のtoString関数と同じ記述になるため簡単になる。


## Description of the Change


- `type`を変数名に称している箇所を修正
- 文字列のリストに`***_NUM`というIDの数を定義した変数名が含まれている箇所があるが、無意味のため削除
- 入力した番号と文字列のリストの長さを比較する方法に変更
- `PortConnectListenerType`が間違っていたため修正


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
