### PR TITLE
Factoryの仕様変更

### DIFF
--- a/OpenRTM_aist/CORBA_CdrMemoryStream.py
+++ b/OpenRTM_aist/CORBA_CdrMemoryStream.py
@@ -182,5 +182,4 @@ class CORBA_CdrMemoryStream(OpenRTM_aist.ByteDataStreamBase):
 
 def CORBA_CdrMemoryStreamInit():
     OpenRTM_aist.SerializerFactory.instance().addFactory("corba",
-                                                         OpenRTM_aist.CORBA_CdrMemoryStream,
-                                                         OpenRTM_aist.Delete)
+                                                         OpenRTM_aist.CORBA_CdrMemoryStream)

--- a/OpenRTM_aist/CSPEventPort.py
+++ b/OpenRTM_aist/CSPEventPort.py
@@ -117,8 +117,6 @@ class CSPEventPort(OpenRTM_aist.InPortBase):
 
     def __del__(self):
         super(CSPEventPort, self).__del__()
-        if self._eventbuffer is not None:
-            OpenRTM_aist.CdrBufferFactory.instance().deleteObject(self._eventbuffer)
 
     ##
     # @if jp

--- a/OpenRTM_aist/CdrRingBuffer.py
+++ b/OpenRTM_aist/CdrRingBuffer.py
@@ -30,5 +30,4 @@ class CdrRingBuffer(OpenRTM_aist.RingBuffer):
 
 def CdrRingBufferInit():
     OpenRTM_aist.CdrBufferFactory.instance().addFactory("ring_buffer",
-                                                        OpenRTM_aist.CdrRingBuffer,
-                                                        OpenRTM_aist.Delete)
+                                                        OpenRTM_aist.CdrRingBuffer)

--- a/OpenRTM_aist/ConnectorListener.py
+++ b/OpenRTM_aist/ConnectorListener.py
@@ -360,8 +360,6 @@ class ConnectorDataListenerT(ConnectorDataListener):
         serializer.isLittleEndian(endian)
         ret, data = serializer.deserialize(cdrdata, data)
 
-        OpenRTM_aist.SerializerFactory.instance().deleteObject(serializer)
-
         return data
 
 
@@ -842,8 +840,6 @@ class ConnectorDataListenerHolder:
                         if deserialize_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK:
                             data = _data
                 ret = ret | listener_ret
-        if serializer is not None:
-            OpenRTM_aist.SerializerFactory.instance().deleteObject(serializer)
         return ret, cdrdata
 
     def setDataType(self, dataType):

--- a/OpenRTM_aist/CorbaConsumer.py
+++ b/OpenRTM_aist/CorbaConsumer.py
@@ -242,7 +242,6 @@ class CorbaConsumer(CorbaConsumerBase):
 
     def __del__(self):
         pass
-        # self.releaseObject()
 
     ##
     # @if jp

--- a/OpenRTM_aist/DefaultPeriodicTask.py
+++ b/OpenRTM_aist/DefaultPeriodicTask.py
@@ -22,5 +22,4 @@ import OpenRTM_aist
 
 def DefaultPeriodicTaskInit():
     OpenRTM_aist.PeriodicTaskFactory.instance().addFactory("default",
-                                                           OpenRTM_aist.PeriodicTask,
-                                                           OpenRTM_aist.Delete)
+                                                           OpenRTM_aist.PeriodicTask)

--- a/OpenRTM_aist/EventDrivenExecutionContext.py
+++ b/OpenRTM_aist/EventDrivenExecutionContext.py
@@ -68,6 +68,5 @@ class EventDrivenExecutionContext(OpenRTM_aist.PeriodicExecutionContext):
 # @endif
 def EventDrivenExecutionContextInit(manager):
     OpenRTM_aist.ExecutionContextFactory.instance().addFactory("EventDrivenExecutionContext",
-                                                               OpenRTM_aist.EventDrivenExecutionContext,
-                                                               OpenRTM_aist.ECDelete)
+                                                               OpenRTM_aist.EventDrivenExecutionContext)
     return

--- a/OpenRTM_aist/ExtTrigExecutionContext.py
+++ b/OpenRTM_aist/ExtTrigExecutionContext.py
@@ -525,5 +525,4 @@ class ExtTrigExecutionContext(OpenRTM_aist.ExecutionContextBase,
 # @endif
 def ExtTrigExecutionContextInit(manager):
     OpenRTM_aist.ExecutionContextFactory.instance().addFactory("ExtTrigExecutionContext",
-                                                               OpenRTM_aist.ExtTrigExecutionContext,
-                                                               OpenRTM_aist.ECDelete)
+                                                               OpenRTM_aist.ExtTrigExecutionContext)

--- a/OpenRTM_aist/GlobalFactory.py
+++ b/OpenRTM_aist/GlobalFactory.py
@@ -28,52 +28,8 @@ class Factory:
     INVALID_ARG = 4
     UNKNOWN_ERROR = 5
 
-    ##
-    # @if jp
-    #
-    # @class FactoryEntry
-    # @brief FactoryEntry クラス
-    #
-    # @else
-    #
-    # @class FactoryEntry
-    # @brief FactoryEntry class
-    #
-    # @endif
-    class FactoryEntry:
-        """
-        """
-
-        ##
-        # @if jp
-        #
-        # @brief コンストラクタ
-        #
-        # コンストラクタ。
-        #
-        # @param creator クリエータ用ファンクタ
-        # @param destructor デストラクタ用ファンクタ
-        #
-        # @else
-        #
-        # @brief Constructor
-        #
-        # Constructor
-        #
-        # @param creator Functor for creator.
-        # @param destructor Functor for destructor.
-        #
-        # @endif
-        # FactoryEntry(Identifier id, Creator creator, Destructor destructor)
-        def __init__(self, id, creator, destructor):
-            self.id_ = id
-            self.creator_ = creator
-            self.destructor_ = destructor
-            return
-
     def __init__(self):
         self._creators = {}
-        self._objects = {}
 
     # bool hasFactory(const Identifier& id)
 
@@ -93,17 +49,16 @@ class Factory:
         return idlist
 
     # ReturnCode addFactory(const Identifier& id,
-    # Creator creator,
-    # Destructor destructor)
+    # Creator creator)
 
-    def addFactory(self, id, creator, destructor):
-        if not creator or not destructor:
+    def addFactory(self, id, creator):
+        if not creator:
             return self.INVALID_ARG
 
         if id in self._creators:
             return self.ALREADY_EXISTS
 
-        self._creators[id] = Factory.FactoryEntry(id, creator, destructor)
+        self._creators[id] = creator
         return self.FACTORY_OK
 
     # ReturnCode removeFactory(const Identifier& id)
@@ -121,168 +76,8 @@ class Factory:
         if not id in self._creators:
             print("Factory.createObject return None id: ", id)
             return None
-        obj_ = self._creators[id].creator_()
-        #assert(not obj_ in self._objects)
-        self._objects[obj_] = self._creators[id]
+        obj_ = self._creators[id]()
         return obj_
-
-    # ReturnCode deleteObject(const Identifier& id, AbstractClass*& obj)
-
-    def deleteObject(self, obj, id=None):
-        if id:
-            if id in self._creators:
-                self._creators[id].destructor_(obj)
-                del self._objects[obj]
-                return self.FACTORY_OK
-
-        if not obj in self._objects:
-            return self.NOT_FOUND
-
-        tmp = obj
-        self._objects[obj].destructor_(obj)
-        del self._objects[tmp]
-        return self.FACTORY_OK
-
-    ##
-    # @if jp
-    #
-    # @brief 生成済みオブジェクトリストの取得
-    #
-    # このファクトリで生成されたオブジェクトのリストを取得する。
-    #
-    # @return 生成済みオブジェクトリスト
-    #
-    # @else
-    #
-    # @brief Getting created objects
-    #
-    # This operation returns a list of created objects by the factory.
-    #
-    # @return created object list
-    #
-    # @endif
-    # std::vector<AbstractClass*> createdObjects()
-
-    def createdObjects(self):
-        objects_ = []
-        for id_ in self._objects.keys():
-            objects_.append(id_)
-
-        return objects_
-
-    ##
-    # @if jp
-    #
-    # @brief オブジェクトがこのファクトリの生成物かどうか調べる
-    #
-    # @param obj 対象オブジェクト
-    # @return true: このファクトリの生成物
-    #         false: このファクトリの生成物ではない
-    #
-    # @else
-    #
-    # @brief Whether a object is a product of this factory
-    #
-    # @param obj A target object
-    # @return true: The object is a product of the factory
-    #         false: The object is not a product of the factory
-    #
-    # @return created object list
-    #
-    # @endif
-    # bool isProducerOf(AbstractClass* obj)
-
-    def isProducerOf(self, obj):
-        return obj in self._objects
-
-    ##
-    # @if jp
-    #
-    # @brief オブジェクトからクラス識別子(ID)を取得する
-    #
-    # 当該オブジェクトのクラス識別子(ID)を取得する。
-    #
-    # @param obj [in] クラス識別子(ID)を取得したいオブジェクト
-    # @param id [out] クラス識別子(ID)
-    # @return リターンコード NOT_FOUND: 識別子が存在しない
-    #                        FACTORY_OK: 正常終了
-    # @else
-    #
-    # @brief Getting class identifier (ID) from a object
-    #
-    # This operation returns a class identifier (ID) from a object.
-    #
-    # @param obj [in] An object to investigate its class ID.
-    # @param id [out] Class identifier (ID)
-    # @return Return code NOT_FOUND: ID not found
-    #                        FACTORY_OK: normal return
-    # @endif
-    # ReturnCode objectToIdentifier(AbstractClass* obj, Identifier& id)
-
-    def objectToIdentifier(self, obj):
-        if not obj in self._objects:
-            return self.NOT_FOUND, -1
-
-        id = self._objects[obj].id_
-        return self.FACTORY_OK, id
-
-    ##
-    # @if jp
-    #
-    # @brief オブジェクトのコンストラクタを取得する
-    #
-    # このファクトリで生成されたオブジェクトのコンストラクタを取得する。
-    # obj はこのファクトリで生成されたものでなければならない。予め
-    # isProducerOf() 関数で当該オブジェクトがこのファクトリの生成物で
-    # あるかどうかをチェックしなければならない。
-    #
-    # @return オブジェクトのデストラクタ
-    #
-    # @else
-    #
-    # @brief Getting destructor of the object
-    #
-    # This operation returns a constructor of the object created by
-    # the factory.  obj must be a product of the factory.  User must
-    # check if the object is a product of the factory by using
-    # isProducerOf()-function, before using this function.
-    #
-    # @return destructor of the object
-    #
-    # @endif
-    # Creator objectToCreator(AbstractClass* obj)
-
-    def objectToCreator(self, obj):
-        return self._objects[obj].creator_
-
-    ##
-    # @if jp
-    #
-    # @brief オブジェクトのデストラクタを取得する
-    #
-    # このファクトリで生成されたオブジェクトのデストラクタを取得する。
-    # obj はこのファクトリで生成されたものでなければならない。予め
-    # isProducerOf() 関数で当該オブジェクトがこのファクトリの生成物で
-    # あるかどうかをチェックしなければならない。
-    #
-    # @return オブジェクトのデストラクタ
-    #
-    # @else
-    #
-    # @brief Getting destructor of the object
-    #
-    # This operation returns a destructor of the object created by
-    # the factory.  obj must be a product of the factory.  User must
-    # check if the object is a product of the factory by using
-    # isProducerOf()-function, before using this function.
-    #
-    # @return destructor of the object
-    #
-    # @endif
-    # Destructor objectToDestructor(AbstractClass* obj)
-
-    def objectToDestructor(self, obj):
-        return self._objects[obj].destructor_
 
 
 gfactory = None

--- a/OpenRTM_aist/InPort.py
+++ b/OpenRTM_aist/InPort.py
@@ -358,22 +358,21 @@ class InPort(OpenRTM_aist.InPortBase):
             return self._value
 
         _val = copy.deepcopy(self._value)
-        cdr = _val
 
         if name is None:
-            ret, cdr = self._connectors[0].read(cdr)
+            ret, _val = self._connectors[0].read(_val)
         else:
             ret = OpenRTM_aist.DataPortStatus.PRECONDITION_NOT_MET
             for con in self._connectors:
                 if con.name() == name:
-                    ret, cdr = con.read(cdr)
+                    ret, _val = con.read(_val)
             if ret == OpenRTM_aist.DataPortStatus.PRECONDITION_NOT_MET:
                 self._rtcout.RTC_DEBUG("not found %s", name)
                 return self._value
 
         if ret == OpenRTM_aist.DataPortStatus.PORT_OK:
             self._rtcout.RTC_DEBUG("data read succeeded")
-            self._value = cdr
+            self._value = _val
 
             if self._OnReadConvert is not None:
                 self._value = self._OnReadConvert(self._value)

--- a/OpenRTM_aist/InPortBase.py
+++ b/OpenRTM_aist/InPortBase.py
@@ -159,7 +159,6 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
                 connector.disconnect()
 
         if self._thebuffer is not None:
-            OpenRTM_aist.CdrBufferFactory.instance().deleteObject(self._thebuffer)
             if not self._singlebuffer:
                 self._rtcout.RTC_ERROR(
                     "Although singlebuffer flag is true, the buffer != 0")
@@ -1279,7 +1278,6 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
             if not provider.publishInterface(cprof.properties):
                 self._rtcout.RTC_ERROR(
                     "publishing interface information error")
-                OpenRTM_aist.InPortProviderFactory.instance().deleteObject(provider)
                 return None
             return provider
 
@@ -1323,7 +1321,6 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
 
             if not consumer.subscribeInterface(cprof.properties):
                 self._rtcout.RTC_ERROR("interface subscription failed.")
-                OpenRTM_aist.OutPortConsumerFactory.instance().deleteObject(consumer)
                 return None
             return consumer
 

--- a/OpenRTM_aist/InPortBase.py
+++ b/OpenRTM_aist/InPortBase.py
@@ -1067,6 +1067,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
 
             # create InPortPullConnector
             connector = self.createConnector(cprof, prop, consumer_=consumer)
+            connector.setDataType(self._value)
             if not connector:
                 return RTC.RTC_ERROR
 
@@ -1092,6 +1093,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
 
             connector.setConsumer(consumer)
             ret = connector.setConnectorInfo(profile)
+            connector.setDataType(self._value)
 
             if ret == RTC.RTC_OK:
                 self._rtcout.RTC_DEBUG(

--- a/OpenRTM_aist/InPortBase.py
+++ b/OpenRTM_aist/InPortBase.py
@@ -1067,9 +1067,11 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
 
             # create InPortPullConnector
             connector = self.createConnector(cprof, prop, consumer_=consumer)
-            connector.setDataType(self._value)
+            
             if not connector:
                 return RTC.RTC_ERROR
+
+            connector.setDataType(self._value)
 
             ret = connector.setConnectorInfo(profile)
 

--- a/OpenRTM_aist/InPortCSPConsumer.py
+++ b/OpenRTM_aist/InPortCSPConsumer.py
@@ -191,5 +191,4 @@ class InPortCSPConsumer(OpenRTM_aist.InPortCorbaCdrConsumer):
 def InPortCSPConsumerInit():
     factory = OpenRTM_aist.InPortConsumerFactory.instance()
     factory.addFactory("csp_channel",
-                       OpenRTM_aist.InPortCSPConsumer,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.InPortCSPConsumer)

--- a/OpenRTM_aist/InPortCSPProvider.py
+++ b/OpenRTM_aist/InPortCSPProvider.py
@@ -273,5 +273,4 @@ class InPortCSPProvider(OpenRTM_aist.InPortProvider, CSP__POA.InPortCsp):
 def InPortCSPProviderInit():
     factory = OpenRTM_aist.InPortProviderFactory.instance()
     factory.addFactory("csp_channel",
-                       OpenRTM_aist.InPortCSPProvider,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.InPortCSPProvider)

--- a/OpenRTM_aist/InPortCorbaCdrConsumer.py
+++ b/OpenRTM_aist/InPortCorbaCdrConsumer.py
@@ -456,5 +456,4 @@ class InPortCorbaCdrConsumer(
 def InPortCorbaCdrConsumerInit():
     factory = OpenRTM_aist.InPortConsumerFactory.instance()
     factory.addFactory("corba_cdr",
-                       OpenRTM_aist.InPortCorbaCdrConsumer,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.InPortCorbaCdrConsumer)

--- a/OpenRTM_aist/InPortCorbaCdrProvider.py
+++ b/OpenRTM_aist/InPortCorbaCdrProvider.py
@@ -288,5 +288,4 @@ class InPortCorbaCdrProvider(OpenRTM_aist.InPortProvider,
 def InPortCorbaCdrProviderInit():
     factory = OpenRTM_aist.InPortProviderFactory.instance()
     factory.addFactory("corba_cdr",
-                       OpenRTM_aist.InPortCorbaCdrProvider,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.InPortCorbaCdrProvider)

--- a/OpenRTM_aist/InPortDSConsumer.py
+++ b/OpenRTM_aist/InPortDSConsumer.py
@@ -452,5 +452,4 @@ class InPortDSConsumer(OpenRTM_aist.InPortConsumer,
 def InPortDSConsumerInit():
     factory = OpenRTM_aist.InPortConsumerFactory.instance()
     factory.addFactory("data_service",
-                       OpenRTM_aist.InPortDSConsumer,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.InPortDSConsumer)

--- a/OpenRTM_aist/InPortDSProvider.py
+++ b/OpenRTM_aist/InPortDSProvider.py
@@ -291,5 +291,4 @@ class InPortDSProvider(OpenRTM_aist.InPortProvider,
 def InPortDSProviderInit():
     factory = OpenRTM_aist.InPortProviderFactory.instance()
     factory.addFactory("data_service",
-                       OpenRTM_aist.InPortDSProvider,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.InPortDSProvider)

--- a/OpenRTM_aist/InPortDirectConsumer.py
+++ b/OpenRTM_aist/InPortDirectConsumer.py
@@ -195,5 +195,4 @@ class InPortDirectConsumer(OpenRTM_aist.InPortConsumer):
 def InPortDirectConsumerInit():
     factory = OpenRTM_aist.InPortConsumerFactory.instance()
     factory.addFactory("direct",
-                       OpenRTM_aist.InPortDirectConsumer,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.InPortDirectConsumer)

--- a/OpenRTM_aist/InPortDirectProvider.py
+++ b/OpenRTM_aist/InPortDirectProvider.py
@@ -182,5 +182,4 @@ class InPortDirectProvider(OpenRTM_aist.InPortProvider):
 def InPortDirectProviderInit():
     factory = OpenRTM_aist.InPortProviderFactory.instance()
     factory.addFactory("direct",
-                       OpenRTM_aist.InPortDirectProvider,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.InPortDirectProvider)

--- a/OpenRTM_aist/InPortDuplexConnector.py
+++ b/OpenRTM_aist/InPortDuplexConnector.py
@@ -175,7 +175,6 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
         else:
             cdr = self.onBufferRead(cdr)
             ret, _data = self.deserializeData(cdr)
-                
             return ret, _data
 
     #
@@ -223,14 +222,11 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
         # delete consumer
         if self._provider:
             cfactory = OpenRTM_aist.InPortProviderFactory.instance()
-            cfactory.deleteObject(self._provider)
 
             self._provider.exit()
 
         self._provider = None
 
-        if self._consumer:
-            OpenRTM_aist.OutPortConsumerFactory.instance().deleteObject(self._consumer)
         self._consumer = None
 
         return self.PORT_OK

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -251,7 +251,7 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
             if self._serializer is None:
                 self._rtcout.RTC_ERROR("serializer creation failure.")
                 return self.UNKNOWN_ERROR, data
-            
+
             self._serializer.isLittleEndian(self._endian)
             ser_ret, data = self._serializer.deserialize(cdr_data, datatype)
 
@@ -285,13 +285,8 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
     def disconnect(self):
         self._rtcout.RTC_TRACE("disconnect()")
         self.onDisconnect()
-        # delete consumer
-        if self._consumer:
-            OpenRTM_aist.OutPortConsumerFactory.instance().deleteObject(self._consumer)
-        self._consumer = None
 
-        if self._serializer:
-            OpenRTM_aist.SerializerFactory.instance().deleteObject(self._serializer)
+        self._consumer = None
         self._serializer = None
 
         return self.PORT_OK

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -241,7 +241,7 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
         if datatype is None:
             if data is None:
                 self._rtcout.RTC_ERROR("invalid data type")
-                return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET, data
+                return OpenRTM_aist.UNKNOWN_ERROR, data
             datatype = data
 
         ret, cdr_data = self._consumer.get()
@@ -250,20 +250,20 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
 
             if self._serializer is None:
                 self._rtcout.RTC_ERROR("serializer creation failure.")
-                return OpenRTM_aist.BufferStatus.UNKNOWN_ERROR, data
+                return OpenRTM_aist.UNKNOWN_ERROR, data
             
             self._serializer.isLittleEndian(self._endian)
             ser_ret, data = self._serializer.deserialize(cdr_data, datatype)
 
             if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:
                 self._rtcout.RTC_ERROR("unknown endian from connector")
-                return OpenRTM_aist.BufferStatus.UNKNOWN_ERROR, data
+                return OpenRTM_aist.UNKNOWN_ERROR, data
             elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR:
                 self._rtcout.RTC_ERROR("unknown error")
-                return OpenRTM_aist.BufferStatus.UNKNOWN_ERROR, data
+                return OpenRTM_aist.UNKNOWN_ERROR, data
             elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOTFOUND:
                 self._rtcout.RTC_ERROR("unknown serializer from connector")
-                return OpenRTM_aist.BufferStatus.UNKNOWN_ERROR, data
+                return OpenRTM_aist.UNKNOWN_ERROR, data
 
         return ret, data
 

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -241,7 +241,7 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
         if datatype is None:
             if data is None:
                 self._rtcout.RTC_ERROR("invalid data type")
-                return OpenRTM_aist.UNKNOWN_ERROR, data
+                return self.UNKNOWN_ERROR, data
             datatype = data
 
         ret, cdr_data = self._consumer.get()
@@ -250,20 +250,20 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
 
             if self._serializer is None:
                 self._rtcout.RTC_ERROR("serializer creation failure.")
-                return OpenRTM_aist.UNKNOWN_ERROR, data
+                return self.UNKNOWN_ERROR, data
             
             self._serializer.isLittleEndian(self._endian)
             ser_ret, data = self._serializer.deserialize(cdr_data, datatype)
 
             if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:
                 self._rtcout.RTC_ERROR("unknown endian from connector")
-                return OpenRTM_aist.UNKNOWN_ERROR, data
+                return self.UNKNOWN_ERROR, data
             elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_ERROR:
                 self._rtcout.RTC_ERROR("unknown error")
-                return OpenRTM_aist.UNKNOWN_ERROR, data
+                return self.UNKNOWN_ERROR, data
             elif ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOTFOUND:
                 self._rtcout.RTC_ERROR("unknown serializer from connector")
-                return OpenRTM_aist.UNKNOWN_ERROR, data
+                return self.UNKNOWN_ERROR, data
 
         return ret, data
 

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -235,15 +235,20 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
         if not self._consumer:
             return self.PORT_ERROR, data
 
+        datatype = self._dataType
+        if datatype is None:
+            if data is None:
+                self._rtcout.RTC_ERROR("invalid data type")
+                return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET, data
+            datatype = data
+
         ret, cdr_data = self._consumer.get()
 
         if ret == self.PORT_OK:
-            if data is None:
-                self._rtcout.RTC_ERROR("argument is invalid")
                 return OpenRTM_aist.BufferStatus.PRECONDITION_NOT_MET, data
 
             self._serializer.isLittleEndian(self._endian)
-            ser_ret, data = self._serializer.deserialize(cdr_data, data)
+            ser_ret, data = self._serializer.deserialize(cdr_data, datatype)
 
             if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:
                 self._rtcout.RTC_ERROR("unknown endian from connector")

--- a/OpenRTM_aist/InPortPushConnector.py
+++ b/OpenRTM_aist/InPortPushConnector.py
@@ -286,7 +286,7 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
         if datatype is None:
             if data is None:
                 self._rtcout.RTC_ERROR("invalid data type")
-                return self.PRECONDITION_NOT_MET, data
+                return self.UNKNOWN_ERROR, data
             datatype = data
 
         ret, cdr = self.readBuff()
@@ -343,7 +343,6 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
         # delete consumer
         if self._provider:
             cfactory = OpenRTM_aist.InPortProviderFactory.instance()
-            cfactory.deleteObject(self._provider)
 
             self._provider.exit()
 
@@ -352,12 +351,9 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
         # delete buffer
         if self._buffer and self._deleteBuffer == True:
             bfactory = OpenRTM_aist.CdrBufferFactory.instance()
-            bfactory.deleteObject(self._buffer)
 
         self._buffer = None
 
-        if self._serializer:
-            OpenRTM_aist.SerializerFactory.instance().deleteObject(self._serializer)
         self._serializer = None
 
         return self.PORT_OK

--- a/OpenRTM_aist/InPortPushConnector.py
+++ b/OpenRTM_aist/InPortPushConnector.py
@@ -280,8 +280,12 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
     def read(self, data=None):
         self._rtcout.RTC_TRACE("read()")
 
-        if not self._dataType:
-            return self.PRECONDITION_NOT_MET, data
+        datatype = self._dataType
+        if datatype is None:
+            if data is None:
+                self._rtcout.RTC_ERROR("invalid data type")
+                return self.PRECONDITION_NOT_MET, data
+            datatype = data
 
         ret, cdr = self.readBuff()
 
@@ -290,7 +294,7 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
         else:
             cdr = self.onBufferRead(cdr)
             self._serializer.isLittleEndian(self._endian)
-            ser_ret, _data = self._serializer.deserialize(cdr, self._dataType)
+            ser_ret, _data = self._serializer.deserialize(cdr, datatype)
 
             if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK:
                 data = _data

--- a/OpenRTM_aist/InPortSHMConsumer.py
+++ b/OpenRTM_aist/InPortSHMConsumer.py
@@ -201,5 +201,4 @@ class InPortSHMConsumer(OpenRTM_aist.InPortCorbaCdrConsumer):
 def InPortSHMConsumerInit():
     factory = OpenRTM_aist.InPortConsumerFactory.instance()
     factory.addFactory("shared_memory",
-                       OpenRTM_aist.InPortSHMConsumer,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.InPortSHMConsumer)

--- a/OpenRTM_aist/InPortSHMProvider.py
+++ b/OpenRTM_aist/InPortSHMProvider.py
@@ -247,5 +247,4 @@ class InPortSHMProvider(OpenRTM_aist.InPortProvider,
 def InPortSHMProviderInit():
     factory = OpenRTM_aist.InPortProviderFactory.instance()
     factory.addFactory("shared_memory",
-                       OpenRTM_aist.InPortSHMProvider,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.InPortSHMProvider)

--- a/OpenRTM_aist/LocalServiceAdmin.py
+++ b/OpenRTM_aist/LocalServiceAdmin.py
@@ -131,7 +131,6 @@ class LocalServiceAdmin:
     def finalize(self):
         for svc_ in self._services:
             svc_.finalize()
-            self._factory.deleteObject(svc_)
         self._services = []
 
         return
@@ -279,7 +278,6 @@ class LocalServiceAdmin:
         for (i, svc_) in enumerate(self._services):
             if name == svc_.getProfile().name:
                 svc_.finalize()
-                self._factory.deleteObject(svc_)
                 del self._services[i]
                 self._rtcout.RTC_INFO(
                     "SDO service  has been deleted: %s", name)

--- a/OpenRTM_aist/LocalServiceBase.py
+++ b/OpenRTM_aist/LocalServiceBase.py
@@ -155,8 +155,6 @@ class LocalServiceProfile:
 #       = RTC::LocalServiceFactory::instance();
 #     factory.addFactory(::RTC::MyLocalSerivce::name,
 #                        ::coil::Creator< ::RTC::LocalServiceBase,
-#                        ::RTC::MyLocalService>,
-#                        ::coil::Destructor< ::RTC::LocalServiceBase,
 #                        ::RTC::MyLocalService>);
 #   }
 # };

--- a/OpenRTM_aist/LogstreamFile.py
+++ b/OpenRTM_aist/LogstreamFile.py
@@ -326,5 +326,4 @@ class LogstreamFile(OpenRTM_aist.LogstreamBase):
 
 def LogstreamFileInit():
     OpenRTM_aist.LogstreamFactory.instance().addFactory("file",
-                                                        OpenRTM_aist.LogstreamFile,
-                                                        OpenRTM_aist.Delete)
+                                                        OpenRTM_aist.LogstreamFile)

--- a/OpenRTM_aist/ModuleManager.py
+++ b/OpenRTM_aist/ModuleManager.py
@@ -474,6 +474,7 @@ class ModuleManager:
         # for new
         comp_spec_name = classname + "_spec"
 
+
         try:
             code = "UTF-8-SIG"
             import chardet

--- a/OpenRTM_aist/MultilayerCompositeEC.py
+++ b/OpenRTM_aist/MultilayerCompositeEC.py
@@ -394,8 +394,6 @@ class MultilayerCompositeEC(OpenRTM_aist.PeriodicExecutionContext):
             self._task.resume()
             self._task.finalize()
 
-            OpenRTM_aist.PeriodicTaskFactory.instance().deleteObject(self._task)
-
     ##
     # @if jp
     # @brief RTC実行スレッド作成
@@ -619,6 +617,5 @@ class MultilayerCompositeEC(OpenRTM_aist.PeriodicExecutionContext):
 # @endif
 def MultilayerCompositeECInit(manager):
     OpenRTM_aist.ExecutionContextFactory.instance().addFactory("MultilayerCompositeEC",
-                                                               OpenRTM_aist.MultilayerCompositeEC,
-                                                               OpenRTM_aist.ECDelete)
+                                                               OpenRTM_aist.MultilayerCompositeEC)
     return

--- a/OpenRTM_aist/NamingServiceNumberingPolicy.py
+++ b/OpenRTM_aist/NamingServiceNumberingPolicy.py
@@ -121,5 +121,4 @@ class NamingServiceNumberingPolicy(OpenRTM_aist.NumberingPolicy):
 
 def NamingServiceNumberingPolicyInit():
     OpenRTM_aist.NumberingPolicyFactory.instance().addFactory("ns_unique",
-                                                              OpenRTM_aist.NamingServiceNumberingPolicy,
-                                                              OpenRTM_aist.Delete)
+                                                              OpenRTM_aist.NamingServiceNumberingPolicy)

--- a/OpenRTM_aist/NodeNumberingPolicy.py
+++ b/OpenRTM_aist/NodeNumberingPolicy.py
@@ -123,5 +123,4 @@ class NodeNumberingPolicy(OpenRTM_aist.NumberingPolicy):
 
 def NodeNumberingPolicyInit():
     OpenRTM_aist.NumberingPolicyFactory.instance().addFactory("node_unique",
-                                                              OpenRTM_aist.NodeNumberingPolicy,
-                                                              OpenRTM_aist.Delete)
+                                                              OpenRTM_aist.NodeNumberingPolicy)

--- a/OpenRTM_aist/NumberingPolicy.py
+++ b/OpenRTM_aist/NumberingPolicy.py
@@ -206,8 +206,6 @@ class ProcessUniquePolicy(NumberingPolicy):
 
 def ProcessUniquePolicyInit():
     OpenRTM_aist.NumberingPolicyFactory.instance().addFactory("default",
-                                                              OpenRTM_aist.ProcessUniquePolicy,
-                                                              OpenRTM_aist.Delete)
+                                                              OpenRTM_aist.ProcessUniquePolicy)
     OpenRTM_aist.NumberingPolicyFactory.instance().addFactory("process_unique",
-                                                              OpenRTM_aist.ProcessUniquePolicy,
-                                                              OpenRTM_aist.Delete)
+                                                              OpenRTM_aist.ProcessUniquePolicy)

--- a/OpenRTM_aist/OpenHRPExecutionContext.py
+++ b/OpenRTM_aist/OpenHRPExecutionContext.py
@@ -306,10 +306,8 @@ class OpenHRPExecutionContext(OpenRTM_aist.ExecutionContextBase,
 
 def OpenHRPExecutionContextInit(manager):
     OpenRTM_aist.ExecutionContextFactory.instance().addFactory("OpenHRPExecutionContext",
-                                                               OpenRTM_aist.OpenHRPExecutionContext,
-                                                               OpenRTM_aist.ECDelete)
+                                                               OpenRTM_aist.OpenHRPExecutionContext)
     OpenRTM_aist.ExecutionContextFactory.instance().addFactory("SynchExtTriggerEC",
-                                                               OpenRTM_aist.OpenHRPExecutionContext,
-                                                               OpenRTM_aist.ECDelete)
+                                                               OpenRTM_aist.OpenHRPExecutionContext)
 
     return

--- a/OpenRTM_aist/OutPortBase.py
+++ b/OpenRTM_aist/OutPortBase.py
@@ -212,20 +212,6 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
 
     ##
     # @if jp
-    # @brief Provider を削除するための Functor
-    # @else
-    # @brief Functor to delete Providers
-    # @endif
-    #
-    class provider_cleanup:
-        def __init__(self):
-            self._factory = OpenRTM_aist.OutPortProviderFactory.instance()
-
-        def __call__(self, p):
-            self._factory.deleteObject(p)
-
-    ##
-    # @if jp
     # @brief Connector を削除するための Functor
     # @else
     # @brief Functor to delete Connectors
@@ -1296,7 +1282,6 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
             if not provider.publishInterface(cprof.properties):
                 self._rtcout.RTC_ERROR(
                     "publishing interface information error")
-                OpenRTM_aist.OutPortProviderFactory.instance().deleteObject(provider)
                 return None
 
             return provider
@@ -1338,7 +1323,6 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
 
             if not consumer.subscribeInterface(cprof.properties):
                 self._rtcout.RTC_ERROR("interface subscription failed.")
-                OpenRTM_aist.InPortConsumerFactory.instance().deleteObject(consumer)
                 return 0
 
             return consumer

--- a/OpenRTM_aist/OutPortCSPConsumer.py
+++ b/OpenRTM_aist/OutPortCSPConsumer.py
@@ -210,5 +210,4 @@ class OutPortCSPConsumer(OpenRTM_aist.OutPortCorbaCdrConsumer):
 def OutPortCSPConsumerInit():
     factory = OpenRTM_aist.OutPortConsumerFactory.instance()
     factory.addFactory("csp_channel",
-                       OpenRTM_aist.OutPortCSPConsumer,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.OutPortCSPConsumer)

--- a/OpenRTM_aist/OutPortCSPProvider.py
+++ b/OpenRTM_aist/OutPortCSPProvider.py
@@ -268,5 +268,4 @@ class OutPortCSPProvider(OpenRTM_aist.OutPortProvider, CSP__POA.OutPortCsp):
 def OutPortCSPProviderInit():
     factory = OpenRTM_aist.OutPortProviderFactory.instance()
     factory.addFactory("csp_channel",
-                       OpenRTM_aist.OutPortCSPProvider,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.OutPortCSPProvider)

--- a/OpenRTM_aist/OutPortCorbaCdrConsumer.py
+++ b/OpenRTM_aist/OutPortCorbaCdrConsumer.py
@@ -441,6 +441,5 @@ class OutPortCorbaCdrConsumer(
 def OutPortCorbaCdrConsumerInit():
     factory = OpenRTM_aist.OutPortConsumerFactory.instance()
     factory.addFactory("corba_cdr",
-                       OpenRTM_aist.OutPortCorbaCdrConsumer,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.OutPortCorbaCdrConsumer)
     return

--- a/OpenRTM_aist/OutPortCorbaCdrProvider.py
+++ b/OpenRTM_aist/OutPortCorbaCdrProvider.py
@@ -450,5 +450,4 @@ class OutPortCorbaCdrProvider(OpenRTM_aist.OutPortProvider,
 def OutPortCorbaCdrProviderInit():
     factory = OpenRTM_aist.OutPortProviderFactory.instance()
     factory.addFactory("corba_cdr",
-                       OpenRTM_aist.OutPortCorbaCdrProvider,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.OutPortCorbaCdrProvider)

--- a/OpenRTM_aist/OutPortDSConsumer.py
+++ b/OpenRTM_aist/OutPortDSConsumer.py
@@ -441,6 +441,5 @@ class OutPortDSConsumer(OpenRTM_aist.OutPortConsumer,
 def OutPortDSConsumerInit():
     factory = OpenRTM_aist.OutPortConsumerFactory.instance()
     factory.addFactory("data_service",
-                       OpenRTM_aist.OutPortDSConsumer,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.OutPortDSConsumer)
     return

--- a/OpenRTM_aist/OutPortDSProvider.py
+++ b/OpenRTM_aist/OutPortDSProvider.py
@@ -451,5 +451,4 @@ class OutPortDSProvider(OpenRTM_aist.OutPortProvider,
 def OutPortDSProviderInit():
     factory = OpenRTM_aist.OutPortProviderFactory.instance()
     factory.addFactory("data_service",
-                       OpenRTM_aist.OutPortDSProvider,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.OutPortDSProvider)

--- a/OpenRTM_aist/OutPortDirectConsumer.py
+++ b/OpenRTM_aist/OutPortDirectConsumer.py
@@ -259,6 +259,5 @@ class OutPortDirectConsumer(OpenRTM_aist.OutPortConsumer):
 def OutPortDirectConsumerInit():
     factory = OpenRTM_aist.OutPortConsumerFactory.instance()
     factory.addFactory("direct",
-                       OpenRTM_aist.OutPortDirectConsumer,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.OutPortDirectConsumer)
     return

--- a/OpenRTM_aist/OutPortDirectProvider.py
+++ b/OpenRTM_aist/OutPortDirectProvider.py
@@ -175,5 +175,4 @@ class OutPortDirectProvider(OpenRTM_aist.OutPortProvider):
 def OutPortDirectProviderInit():
     factory = OpenRTM_aist.OutPortProviderFactory.instance()
     factory.addFactory("direct",
-                       OpenRTM_aist.OutPortDirectProvider,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.OutPortDirectProvider)

--- a/OpenRTM_aist/OutPortDuplexConnector.py
+++ b/OpenRTM_aist/OutPortDuplexConnector.py
@@ -291,19 +291,16 @@ class OutPortDuplexConnector(OpenRTM_aist.OutPortConnector):
         self.onDisconnect()
         # delete provider
         if self._provider:
-            OpenRTM_aist.OutPortProviderFactory.instance().deleteObject(self._provider)
             self._provider.exit()
         self._provider = None
 
         if self._serializer:
             self._rtcout.RTC_DEBUG("delete serializer")
-            OpenRTM_aist.SerializerFactory.instance().deleteObject(self._serializer)
         self._serializer = None
 
         if self._consumer:
             self._rtcout.RTC_DEBUG("delete consumer")
             cfactory = OpenRTM_aist.InPortConsumerFactory.instance()
-            cfactory.deleteObject(self._consumer)
 
         self._consumer = None
 

--- a/OpenRTM_aist/OutPortPullConnector.py
+++ b/OpenRTM_aist/OutPortPullConnector.py
@@ -301,17 +301,12 @@ class OutPortPullConnector(OpenRTM_aist.OutPortConnector):
         self.onDisconnect()
         # delete provider
         if self._provider:
-            OpenRTM_aist.OutPortProviderFactory.instance().deleteObject(self._provider)
             self._provider.exit()
         self._provider = None
 
         # delete buffer
-        if self._buffer:
-            OpenRTM_aist.CdrBufferFactory.instance().deleteObject(self._buffer)
         self._buffer = None
 
-        if self._serializer:
-            OpenRTM_aist.SerializerFactory.instance().deleteObject(self._serializer)
         self._serializer = None
 
         return self.PORT_OK

--- a/OpenRTM_aist/OutPortPushConnector.py
+++ b/OpenRTM_aist/OutPortPushConnector.py
@@ -187,14 +187,12 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
     # @if jp
     # @brief デストラクタ
     #
-    # disconnect() が呼ばれ、consumer, publisher, buffer が解体・削除される。
+    #
     #
     # @else
     #
     # @brief Destructor
     #
-    # This operation calls disconnect(), which destructs and deletes
-    # the consumer, the publisher and the buffer.
     #
     # @endif
     #
@@ -310,8 +308,8 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
         # delete publisher
         if self._publisher:
             self._rtcout.RTC_DEBUG("delete publisher")
+            self._publisher.exit()
             pfactory = OpenRTM_aist.PublisherFactory.instance()
-            pfactory.deleteObject(self._publisher)
 
         self._publisher = None
 
@@ -319,7 +317,6 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
         if self._consumer:
             self._rtcout.RTC_DEBUG("delete consumer")
             cfactory = OpenRTM_aist.InPortConsumerFactory.instance()
-            cfactory.deleteObject(self._consumer)
 
         self._consumer = None
 
@@ -327,13 +324,11 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
         if self._buffer:
             self._rtcout.RTC_DEBUG("delete buffer")
             bfactory = OpenRTM_aist.CdrBufferFactory.instance()
-            bfactory.deleteObject(self._buffer)
 
         self._buffer = None
 
         if self._serializer:
             self._rtcout.RTC_DEBUG("delete serializer")
-            OpenRTM_aist.SerializerFactory.instance().deleteObject(self._serializer)
         self._serializer = None
 
         self._rtcout.RTC_TRACE("disconnect() done")

--- a/OpenRTM_aist/OutPortSHMConsumer.py
+++ b/OpenRTM_aist/OutPortSHMConsumer.py
@@ -192,6 +192,5 @@ class OutPortSHMConsumer(OpenRTM_aist.OutPortCorbaCdrConsumer):
 def OutPortSHMConsumerInit():
     factory = OpenRTM_aist.OutPortConsumerFactory.instance()
     factory.addFactory("shared_memory",
-                       OpenRTM_aist.OutPortSHMConsumer,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.OutPortSHMConsumer)
     return

--- a/OpenRTM_aist/OutPortSHMProvider.py
+++ b/OpenRTM_aist/OutPortSHMProvider.py
@@ -255,5 +255,4 @@ class OutPortSHMProvider(OpenRTM_aist.OutPortProvider,
 def OutPortSHMProviderInit():
     factory = OpenRTM_aist.OutPortProviderFactory.instance()
     factory.addFactory("shared_memory",
-                       OpenRTM_aist.OutPortSHMProvider,
-                       OpenRTM_aist.Delete)
+                       OpenRTM_aist.OutPortSHMProvider)

--- a/OpenRTM_aist/PeriodicExecutionContext.py
+++ b/OpenRTM_aist/PeriodicExecutionContext.py
@@ -826,6 +826,5 @@ class PeriodicExecutionContext(OpenRTM_aist.ExecutionContextBase,
 
 def PeriodicExecutionContextInit(manager):
     OpenRTM_aist.ExecutionContextFactory.instance().addFactory("PeriodicExecutionContext",
-                                                               OpenRTM_aist.PeriodicExecutionContext,
-                                                               OpenRTM_aist.ECDelete)
+                                                               OpenRTM_aist.PeriodicExecutionContext)
     return

--- a/OpenRTM_aist/PublisherFlush.py
+++ b/OpenRTM_aist/PublisherFlush.py
@@ -493,8 +493,6 @@ class PublisherFlush(OpenRTM_aist.PublisherBase):
 
 def PublisherFlushInit():
     OpenRTM_aist.PublisherFactory.instance().addFactory("flush",
-                                                        OpenRTM_aist.PublisherFlush,
-                                                        OpenRTM_aist.Delete)
+                                                        OpenRTM_aist.PublisherFlush)
     OpenRTM_aist.PublisherFactory.instance().addFactory("block",
-                                                        OpenRTM_aist.PublisherFlush,
-                                                        OpenRTM_aist.Delete)
+                                                        OpenRTM_aist.PublisherFlush)

--- a/OpenRTM_aist/PublisherNew.py
+++ b/OpenRTM_aist/PublisherNew.py
@@ -95,11 +95,22 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
     # @endif
     def __del__(self):
         self._rtcout.RTC_TRACE("~PublisherNew()")
+
+    ##
+    # @if jp
+    # @brief 終了処理
+    #
+    # @param self
+    #
+    # @else
+    # @brief
+    # @endif
+    def exit(self):
+        self._rtcout.RTC_TRACE("exit()")
         if self._task:
             self._task.resume()
             self._task.finalize()
 
-            OpenRTM_aist.PeriodicTaskFactory.instance().deleteObject(self._task)
             #del self._task
             self._rtcout.RTC_PARANOID("task deleted.")
 
@@ -108,6 +119,7 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
         # "buffer"   should be deleted in the Connector
         self._buffer = 0
         return
+
 
     ##
     # @if jp
@@ -1079,8 +1091,6 @@ class PublisherNew(OpenRTM_aist.PublisherBase):
 
 def PublisherNewInit():
     OpenRTM_aist.PublisherFactory.instance().addFactory("new",
-                                                        OpenRTM_aist.PublisherNew,
-                                                        OpenRTM_aist.Delete)
+                                                        OpenRTM_aist.PublisherNew)
     OpenRTM_aist.PublisherFactory.instance().addFactory("nonblock",
-                                                        OpenRTM_aist.PublisherNew,
-                                                        OpenRTM_aist.Delete)
+                                                        OpenRTM_aist.PublisherNew)

--- a/OpenRTM_aist/PublisherPeriodic.py
+++ b/OpenRTM_aist/PublisherPeriodic.py
@@ -99,13 +99,23 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
     # @endif
     def __del__(self):
         self._rtcout.RTC_TRACE("~PublisherPeriodic()")
+
+    ##
+    # @if jp
+    # @brief 終了処理
+    #
+    # @param self
+    #
+    # @else
+    # @brief 
+    # @endif
+    def exit(self):
+        self._rtcout.RTC_TRACE("exit()")
         if self._task:
             self._task.resume()
             self._task.finalize()
             self._rtcout.RTC_PARANOID("task finalized.")
 
-            OpenRTM_aist.PeriodicTaskFactory.instance().deleteObject(self._task)
-            del self._task
             self._rtcout.RTC_PARANOID("task deleted.")
 
         # "consumer" should be deleted in the Connector
@@ -1127,5 +1137,4 @@ class PublisherPeriodic(OpenRTM_aist.PublisherBase):
 
 def PublisherPeriodicInit():
     OpenRTM_aist.PublisherFactory.instance().addFactory("periodic",
-                                                        OpenRTM_aist.PublisherPeriodic,
-                                                        OpenRTM_aist.Delete)
+                                                        OpenRTM_aist.PublisherPeriodic)

--- a/OpenRTM_aist/RTObject.py
+++ b/OpenRTM_aist/RTObject.py
@@ -510,7 +510,8 @@ class RTObject_impl:
 
         # EC creation
         ec_args_ = []
-        if self.getContextOptions(ec_args_) != RTC.RTC_OK:
+        ret, ec_args_ = self.getContextOptions(ec_args_)
+        if ret != RTC.RTC_OK:
             self._rtcout.RTC_ERROR(
                 "Valid EC options are not available. Aborting")
             return RTC.BAD_PARAMETER
@@ -5073,12 +5074,12 @@ class RTObject_impl:
         # Component specific multiple EC option available
         if not self._properties.findNode("execution_contexts"):
             self._rtcout.RTC_DEBUG("No component specific EC specified.")
-            return RTC.RTC_ERROR
+            return RTC.RTC_ERROR, ec_args
 
         args_ = self._properties.getProperty("execution_contexts")
         ecs_tmp_ = [s.strip() for s in args_.split(",")]
         if not ecs_tmp_[0]:
-            return RTC.RTC_ERROR
+            return RTC.RTC_ERROR, ec_args
         self._rtcout.RTC_DEBUG("Component specific e EC option available,")
         self._rtcout.RTC_DEBUG("%s", args_)
 
@@ -5089,7 +5090,7 @@ class RTObject_impl:
                 self._rtcout.RTC_INFO(
                     "EC none. EC will not be bound to the RTC.")
                 ec_args = []
-                return RTC.RTC_OK
+                return RTC.RTC_OK, ec_args
 
             type_and_name_ = [s.strip() for s in ec_tmp.split("(")]
             if len(type_and_name_) > 2:
@@ -5133,7 +5134,7 @@ class RTObject_impl:
             self._rtcout.RTC_DEBUG("New EC properties stored:")
             self._rtcout.RTC_DEBUG(p_)
 
-        return RTC.RTC_OK
+        return RTC.RTC_OK, ec_args
 
     ##
     # @brief getting global EC options from rtc.conf
@@ -5148,13 +5149,13 @@ class RTObject_impl:
         prop_ = self._properties.findNode("exec_cxt.periodic")
         if not prop_:
             self._rtcout.RTC_WARN("No global EC options found.")
-            return RTC.RTC_ERROR
+            return RTC.RTC_ERROR, global_ec_props
 
         self._rtcout.RTC_DEBUG("Global EC options are specified.")
         self._rtcout.RTC_DEBUG(prop_)
         self.getInheritedECOptions(global_ec_props)
         global_ec_props.mergeProperties(prop_)
-        return RTC.RTC_OK
+        return RTC.RTC_OK, global_ec_props
 
     ##
     # @brief getting EC options
@@ -5165,20 +5166,20 @@ class RTObject_impl:
     def getContextOptions(self, ec_args):
         self._rtcout.RTC_DEBUG("getContextOptions()")
         global_props_ = OpenRTM_aist.Properties()
-        ret_global_ = self.getGlobalContextOptions(global_props_)
-        ret_private_ = self.getPrivateContextOptions(ec_args)
+        ret_global_, global_props_ = self.getGlobalContextOptions(global_props_)
+        ret_private_, ec_args = self.getPrivateContextOptions(ec_args)
 
         # private(X), global(X) -> error
         # private(O), global(O) -> private
         # private(X), global(O) -> global
         # private(O), global(X) -> private
         if ret_global_ != RTC.RTC_OK and ret_private_ != RTC.RTC_OK:
-            return RTC.RTC_ERROR
+            return RTC.RTC_ERROR, ec_args
 
         if ret_global_ == RTC.RTC_OK and ret_private_ != RTC.RTC_OK:
             ec_args.append(global_props_)
 
-        return RTC.RTC_OK
+        return RTC.RTC_OK, ec_args
 
     ##
     # @brief fiding existing EC from the factory
@@ -5186,15 +5187,15 @@ class RTObject_impl:
     # ReturnCode_t findExistingEC(coil::Properties& ec_arg,
     #                             RTC::ExecutionContextBase*& ec);
 
-    def findExistingEC(self, ec_arg, ec):
-        eclist_ = OpenRTM_aist.ExecutionContextFactory.instance().createdObjects()
-        for ec_ in eclist_:
-            if ec_.getProperties().getProperty("type") == ec_arg.getProperty("type") and \
-                    ec_.getProperties().getProperty("name") == ec_arg.getProperty("name"):
-                ec[0] = ec_
-                return RTC.RTC_OK
+    def findExistingEC(self, ec_arg):
+        if self._manager:
+            eclist_ = self._manager.createdExecutionContexts()
+            for ec in eclist_:
+                if ec.getProperties().getProperty("type") == ec_arg.getProperty("type") and \
+                        ec.getProperties().getProperty("name") == ec_arg.getProperty("name"):
+                    return RTC.RTC_OK, ec
 
-        return RTC.RTC_ERROR
+        return RTC.RTC_ERROR, None
 
     ##
     # @brief creating, initializing and binding context
@@ -5208,8 +5209,8 @@ class RTObject_impl:
         for ec_arg_ in ec_args:
             ec_type_ = ec_arg_.getProperty("type")
             ec_name_ = ec_arg_.getProperty("name")
-            ec_ = [None]
-            if ec_name_ and self.findExistingEC(ec_arg_, ec_) == RTC.RTC_OK:
+            ret, ec = self.findExistingEC(ec_arg_)
+            if ec_name_ and ret == RTC.RTC_OK:
                 # if EC's name exists, find existing EC in the factory.
                 self._rtcout.RTC_DEBUG("EC: type=%s, name=%s already exists.",
                                        (ec_type_, ec_name_))
@@ -5220,10 +5221,10 @@ class RTObject_impl:
                     self._rtcout.RTC_DEBUG("Available ECs: %s",
                                            OpenRTM_aist.flatten(avail_ec_))
                     continue
-                ec_[0] = OpenRTM_aist.ExecutionContextFactory.instance(
+                ec = OpenRTM_aist.ExecutionContextFactory.instance(
                 ).createObject(ec_type_)
 
-            if not ec_[0]:
+            if not ec:
                 # EC factory available but creation failed. Resource full?
                 self._rtcout.RTC_ERROR("EC (%s) creation failed.", ec_type_)
                 self._rtcout.RTC_DEBUG("Available EC list: %s",
@@ -5231,17 +5232,19 @@ class RTObject_impl:
                 ret_ = RTC.RTC_ERROR
                 continue
 
+            if self._manager:
+                self._manager.addExecutionContext(ec)
+
             self._rtcout.RTC_DEBUG("EC (%s) created.", ec_type_)
 
-            ec_[0].init(ec_arg_)
-            self._eclist.append(ec_[0])
-            ec_[0].bindComponent(self)
+            ec.init(ec_arg_)
+            self._eclist.append(ec)
+            ec.bindComponent(self)
 
         if len(self._eclist) == 0:
             default_prop = OpenRTM_aist.Properties()
             default_prop.setDefaults(OpenRTM_aist.default_config)
 
-            ec_ = [None]
             ec_type_ = default_prop.getProperty("exec_cxt.periodic.type")
             if not ec_type_ in avail_ec_:
                 self._rtcout.RTC_WARN("EC %s is not available.", ec_type_)
@@ -5279,17 +5282,21 @@ class RTObject_impl:
                     self._rtcout.RTC_PARANOID("Option %s exists.", opt_)
                     default_opts.setProperty(opt_, p_.getProperty(opt_))
 
-            ec_[0] = OpenRTM_aist.ExecutionContextFactory.instance(
+            ec = OpenRTM_aist.ExecutionContextFactory.instance(
             ).createObject(ec_type_)
-            # if not ec_[0]:
-            #  self._rtcout.RTC_ERROR("EC (%s) creation failed.", ec_type_)
-            #  self._rtcout.RTC_DEBUG("Available EC list: %s",
-            #                         OpenRTM_aist.flatten(avail_ec_))
-            #  return RTC.RTC_ERROR
+            
+            if not ec:
+                self._rtcout.RTC_ERROR("EC (%s) creation failed.", ec_type_)
+                self._rtcout.RTC_DEBUG("Available EC list: %s",
+                                    OpenRTM_aist.flatten(avail_ec_))
+                return RTC.RTC_ERROR
 
-            ec_[0].init(default_opts)
-            self._eclist.append(ec_[0])
-            ec_[0].bindComponent(self)
+            if self._manager:
+                self._manager.addExecutionContext(ec)
+
+            ec.init(default_opts)
+            self._eclist.append(ec)
+            ec.bindComponent(self)
 
         return ret_
 

--- a/OpenRTM_aist/SdoServiceAdmin.py
+++ b/OpenRTM_aist/SdoServiceAdmin.py
@@ -360,7 +360,6 @@ class SdoServiceAdmin:
             if strid == str(self._providers[idx].getProfile().id):
                 self._providers[idx].finalize()
                 factory = OpenRTM_aist.SdoServiceProviderFactory.instance()
-                factory.deleteObject(self._providers[idx])
                 del self._providers[idx]
                 self._rtcout.RTC_INFO(
                     "SDO service provider has been deleted: %s", id)
@@ -430,7 +429,6 @@ class SdoServiceAdmin:
                 "properties: %s",
                 OpenRTM_aist.NVUtil.toString(
                     sProfile.properties))
-            factory.deleteObject(consumer)
             self._rtcout.RTC_INFO(
                 "SDO consumer was deleted by initialization failure")
             return False
@@ -467,7 +465,6 @@ class SdoServiceAdmin:
                 cons.finalize()
                 del self._consumers[idx]
                 factory = OpenRTM_aist.SdoServiceConsumerFactory.instance()
-                factory.deleteObject(cons)
                 self._rtcout.RTC_INFO("SDO service has been deleted: %s", id)
                 return True
 

--- a/OpenRTM_aist/SdoServiceConsumerBase.py
+++ b/OpenRTM_aist/SdoServiceConsumerBase.py
@@ -25,8 +25,6 @@ import OpenRTM_aist
 #
 # factory.addFactory(toRepositoryId<IDL Type>(),
 #                   Creator< SdoServiceConsumerBase,
-#                            your_sdo_service_consumer_subclass>,
-#                   Destructor< SdoServiceConsumerBase,
 #                            your_sdo_service_consumer_subclass>);
 #
 # @else

--- a/OpenRTM_aist/SdoServiceProviderBase.py
+++ b/OpenRTM_aist/SdoServiceProviderBase.py
@@ -100,8 +100,7 @@ import SDOPackage__POA
 #   def MySdoServiceProviderInit(mgr=None):
 #     factory = OpenRTM_aist.SdoServiceProviderFactory.instance()
 #     factory.addFactory(OpenRTM.MySdoService._NP_RepositoryId,
-#                        MySdoServiceProvider,
-#                        OpenRTM_aist.Delete)
+#                        MySdoServiceProvider)
 #     return
 # </pre>
 #

--- a/OpenRTM_aist/SimulatorExecutionContext.py
+++ b/OpenRTM_aist/SimulatorExecutionContext.py
@@ -198,6 +198,5 @@ class SimulatorExecutionContext(OpenRTM_aist.OpenHRPExecutionContext):
 #
 def SimulatorExecutionContextInit(manager):
     OpenRTM_aist.ExecutionContextFactory.instance().addFactory("SimulatorExecutionContext",
-                                                               OpenRTM_aist.SimulatorExecutionContext,
-                                                               OpenRTM_aist.ECDelete)
+                                                               OpenRTM_aist.SimulatorExecutionContext)
     return

--- a/OpenRTM_aist/ext/extended_fsm/ExtendedFsmServiceProvider.py
+++ b/OpenRTM_aist/ext/extended_fsm/ExtendedFsmServiceProvider.py
@@ -296,6 +296,5 @@ class ExtendedFsmServiceProvider(
 def ExtendedFsmServiceProviderInit(mgr=None):
     factory = OpenRTM_aist.SdoServiceProviderFactory.instance()
     factory.addFactory(RTC.ExtendedFsmService._NP_RepositoryId,
-                       ExtendedFsmServiceProvider,
-                       OpenRTM_aist.Delete)
+                       ExtendedFsmServiceProvider)
     return

--- a/OpenRTM_aist/ext/fsm4rtc_observer/ComponentObserverConsumer.py
+++ b/OpenRTM_aist/ext/fsm4rtc_observer/ComponentObserverConsumer.py
@@ -1315,6 +1315,5 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
 def ComponentObserverConsumerInit(mgr=None):
     factory = OpenRTM_aist.SdoServiceConsumerFactory.instance()
     factory.addFactory(RTC.ComponentObserver._NP_RepositoryId,
-                       ComponentObserverConsumer,
-                       OpenRTM_aist.Delete)
+                       ComponentObserverConsumer)
     return

--- a/OpenRTM_aist/ext/local_service/nameservice_file/FileNameservice.py
+++ b/OpenRTM_aist/ext/local_service/nameservice_file/FileNameservice.py
@@ -469,6 +469,5 @@ def FileNameserviceInit(manager):
     global service_name
     factory_ = OpenRTM_aist.LocalServiceFactory.instance()
     factory_.addFactory(service_name,
-                        FileNameservice,
-                        OpenRTM_aist.Delete)
+                        FileNameservice)
     return

--- a/OpenRTM_aist/ext/logger/fluentbit_stream/FluentBit.py
+++ b/OpenRTM_aist/ext/logger/fluentbit_stream/FluentBit.py
@@ -402,5 +402,4 @@ class FluentBit(OpenRTM_aist.LogstreamBase):
 
 def FluentBitInit(mgr):
     OpenRTM_aist.LogstreamFactory.instance().addFactory("fluentd",
-                                                        FluentBit,
-                                                        OpenRTM_aist.Delete)
+                                                        FluentBit)

--- a/OpenRTM_aist/ext/sdo/observer/ComponentObserverConsumer.py
+++ b/OpenRTM_aist/ext/sdo/observer/ComponentObserverConsumer.py
@@ -1013,6 +1013,5 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
 def ComponentObserverConsumerInit(mgr=None):
     factory = OpenRTM_aist.SdoServiceConsumerFactory.instance()
     factory.addFactory(OpenRTM.ComponentObserver._NP_RepositoryId,
-                       ComponentObserverConsumer,
-                       OpenRTM_aist.Delete)
+                       ComponentObserverConsumer)
     return

--- a/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceInPort.py
+++ b/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceInPort.py
@@ -390,5 +390,4 @@ class SubListener(dds.Listener):
 def OpenSpliceInPortInit():
     factory = OpenRTM_aist.InPortProviderFactory.instance()
     factory.addFactory("opensplice",
-                       OpenSpliceInPort,
-                       OpenRTM_aist.Delete)
+                       OpenSpliceInPort)

--- a/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceOutPort.py
+++ b/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceOutPort.py
@@ -267,5 +267,4 @@ class OpenSpliceOutPort(OpenRTM_aist.InPortConsumer):
 def OpenSpliceOutPortInit():
     factory = OpenRTM_aist.InPortConsumerFactory.instance()
     factory.addFactory("opensplice",
-                       OpenSpliceOutPort,
-                       OpenRTM_aist.Delete)
+                       OpenSpliceOutPort)

--- a/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceSerializer.py
+++ b/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceSerializer.py
@@ -200,7 +200,6 @@ class OpenSpliceSerializer(OpenRTM_aist.ByteDataStreamBase):
         if info:
             datatype = info.datatype()
             idlFile = info.idlFile()
-            factory.deleteObject(info)
             try:
                 gen_info = ddsutil.get_dds_classes_from_idl(idlFile, datatype)
                 osdata = gen_info.topic_data_class(
@@ -266,8 +265,7 @@ def addDataType(datatype, idlfile):
     data_name = data_name.replace("/", "::")
     OpenSpliceMessageInfo.OpenSpliceMessageInfoFactory.instance().addFactory(name,
                                                                              OpenSpliceMessageInfo.opensplice_message_info(
-                                                                                 data_name, idlfile),
-                                                                             OpenRTM_aist.Delete)
+                                                                                 data_name, idlfile))
 
 
 ##
@@ -283,8 +281,7 @@ def addDataType(datatype, idlfile):
 #
 def OpenSpliceSerializerInit():
     OpenRTM_aist.SerializerFactory.instance().addFactory("opensplice",
-                                                         OpenSpliceSerializer,
-                                                         OpenRTM_aist.Delete)
+                                                         OpenSpliceSerializer)
 
     OpenRTM_dir = OpenRTM_aist.__path__[0]
 

--- a/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceTopicManager.py
+++ b/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceTopicManager.py
@@ -190,7 +190,6 @@ class OpenSpliceTopicManager(object):
         if datainfo:
             datatype = datainfo.datatype()
             idlfile = datainfo.idlFile()
-            factory.deleteObject(datainfo)
             self._info[datatype] = ddsutil.get_dds_classes_from_idl(idlfile,
                                                                     datatype)
             return self._info[datatype]

--- a/OpenRTM_aist/ext/transport/ROS2Transport/ROS2InPort.py
+++ b/OpenRTM_aist/ext/transport/ROS2Transport/ROS2InPort.py
@@ -153,12 +153,10 @@ class ROS2InPort(OpenRTM_aist.InPortProvider):
         self._rtcout.RTC_VERBOSE("message type: %s", self._messageType)
         self._rtcout.RTC_VERBOSE("topic name: %s", self._topic)
 
-        factory = ROS2MessageInfo.ROS2MessageInfoFactory.instance()
-        info = factory.createObject(self._messageType)
+        factory = ROS2MessageInfo.ROS2MessageInfoList.instance()
+        info = factory.getInfo(self._messageType)
 
         info_type = info.datatype()
-
-        factory.deleteObject(info)
 
         self._subscriber = self._topicmgr.createSubscriber(
             info_type, self._topic, self.ros2_callback)
@@ -355,5 +353,4 @@ class ROS2InPort(OpenRTM_aist.InPortProvider):
 def ROS2InPortInit():
     factory = OpenRTM_aist.InPortProviderFactory.instance()
     factory.addFactory("ros2",
-                       ROS2InPort,
-                       OpenRTM_aist.Delete)
+                       ROS2InPort)

--- a/OpenRTM_aist/ext/transport/ROS2Transport/ROS2MessageInfo.py
+++ b/OpenRTM_aist/ext/transport/ROS2Transport/ROS2MessageInfo.py
@@ -93,106 +93,88 @@ class ROS2MessageInfoBase(object):
 
 ##
 # @if jp
-# @brief メッセージの情報格納オブジェクト生成関数
+# @class ROS2MessageInfo
+# @brief メッセージの情報格納クラス
 #
-# @param data_class ROS2データ型
-# @return メッセージの情報格納オブジェクト
 #
 # @else
+# @class ROS2MessageInfo
 # @brief
 #
-# @param data_class
-# @return
 #
 # @endif
-#
-def ros2_message_info(datatype):
+class ROS2MessageInfo(ROS2MessageInfoBase):
+    """
+    """
     ##
     # @if jp
-    # @class ROS2MessageInfo
-    # @brief メッセージの情報格納クラス
+    # @brief コンストラクタ
     #
+    # コンストラクタ
+    #
+    # @param self
     #
     # @else
-    # @class ROS2MessageInfo
+    # @brief Constructor
+    #
+    # @param self
+    #
+    # @endif
+
+    def __init__(self, datatype):
+        super(ROS2MessageInfo, self).__init__()
+        self._datatype = datatype
+    ##
+    # @if jp
+    # @brief デストラクタ
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @brief self
+    #
+    # @endif
+
+    def __del__(self):
+        pass
+    ##
+    # @if jp
+    # @brief メッセージの型名を取得
+    #
+    # @param self
+    # @return 型名
+    #
+    # @else
     # @brief
     #
     #
+    # @param self
+    # @return
+    #
     # @endif
-    class ROS2MessageInfo(ROS2MessageInfoBase):
-        """
-        """
+    #
 
-        ##
-        # @if jp
-        # @brief コンストラクタ
-        #
-        # コンストラクタ
-        #
-        # @param self
-        #
-        # @else
-        # @brief Constructor
-        #
-        # @param self
-        #
-        # @endif
-        def __init__(self):
-            super(ROS2MessageInfo, self).__init__()
-
-        ##
-        # @if jp
-        # @brief デストラクタ
-        #
-        #
-        # @param self
-        #
-        # @else
-        #
-        # @brief self
-        #
-        # @endif
-
-        def __del__(self):
-            pass
-
-        ##
-        # @if jp
-        # @brief メッセージの型名を取得
-        #
-        # @param self
-        # @return 型名
-        #
-        # @else
-        # @brief
-        #
-        #
-        # @param self
-        # @return
-        #
-        # @endif
-        #
-        def datatype(self):
-            return datatype
-
-    return ROS2MessageInfo
+    def datatype(self):
+        return self._datatype
 
 
-ros2messageinfofactory = None
+ros2messageinfolist = None
 
 
 ##
 # @if jp
-# @class ROS2MessageInfoFactory
+# @class ROS2MessageInfoList
 # @brief ROS2メッセージ情報格納オブジェクト生成ファクトリ
 #
 # @else
-# @class ROS2MessageInfoFactory
+# @class ROS2MessageInfoList
 # @brief
 #
 #
 # @endif
-class ROS2MessageInfoFactory(OpenRTM_aist.Factory, ROS2MessageInfoBase):
+class ROS2MessageInfoList:
     ##
     # @if jp
     # @brief コンストラクタ
@@ -208,7 +190,7 @@ class ROS2MessageInfoFactory(OpenRTM_aist.Factory, ROS2MessageInfoBase):
     #
     # @endif
     def __init__(self):
-        OpenRTM_aist.Factory.__init__(self)
+        self._data = {}
 
     ##
     # @if jp
@@ -246,11 +228,74 @@ class ROS2MessageInfoFactory(OpenRTM_aist.Factory, ROS2MessageInfoBase):
     # @endif
     #
     def instance():
-        global ros2messageinfofactory
+        global ros2messageinfolist
 
-        if ros2messageinfofactory is None:
-            ros2messageinfofactory = ROS2MessageInfoFactory()
+        if ros2messageinfolist is None:
+            ros2messageinfolist = ROS2MessageInfoList()
 
-        return ros2messageinfofactory
+        return ros2messageinfolist
 
     instance = staticmethod(instance)
+
+    ##
+    # @if jp
+    # @brief ROS2MessageInfoの追加
+    #
+    # @param self
+    # @param id 名前
+    # @param info ROS2MessageInfo
+    #
+    # @else
+    # @brief
+    #
+    # @param self
+    # @param id
+    # @param info
+    #
+    # @endif
+    #
+    def addInfo(id, info):
+        self._data[id] = info
+
+    ##
+    # @if jp
+    # @brief ROS2MessageInfoの削除
+    #
+    # @param self
+    # @param id 名前
+    # @return 削除に成功した場合はTrue
+    #
+    # @else
+    # @brief
+    #
+    # @param self
+    # @param id
+    # @return
+    #
+    # @endif
+    #
+    def removeInfo(self, id):
+        if id in self._data:
+            del self._data[id]
+            return True
+        return False
+
+    ##
+    # @if jp
+    # @brief 指定名のROS2MessageInfoの取得
+    #
+    # @param id 名前
+    # @return ROS2MessageInfo
+    #
+    # @else
+    # @brief
+    #
+    # @param id
+    # @return
+    #
+    # @endif
+    #
+    def getInfo(self, id):
+        if id in self._data:
+            return self._data[id]
+        return None

--- a/OpenRTM_aist/ext/transport/ROS2Transport/ROS2OutPort.py
+++ b/OpenRTM_aist/ext/transport/ROS2Transport/ROS2OutPort.py
@@ -123,12 +123,10 @@ class ROS2OutPort(OpenRTM_aist.InPortConsumer):
         self._rtcout.RTC_VERBOSE("message type: %s", self._messageType)
         self._rtcout.RTC_VERBOSE("topic name: %s", self._topic)
 
-        factory = ROS2MessageInfo.ROS2MessageInfoFactory.instance()
-        info = factory.createObject(self._messageType)
+        factory = ROS2MessageInfo.ROS2MessageInfoList.instance()
+        info = factory.getInfo(self._messageType)
 
         info_type = info.datatype()
-
-        factory.deleteObject(info)
 
         self._publisher = self._topicmgr.createPublisher(
             info_type, self._topic)
@@ -270,5 +268,4 @@ class ROS2OutPort(OpenRTM_aist.InPortConsumer):
 def ROS2OutPortInit():
     factory = OpenRTM_aist.InPortConsumerFactory.instance()
     factory.addFactory("ros2",
-                       ROS2OutPort,
-                       OpenRTM_aist.Delete)
+                       ROS2OutPort)

--- a/OpenRTM_aist/ext/transport/ROS2Transport/ROS2Serializer.py
+++ b/OpenRTM_aist/ext/transport/ROS2Transport/ROS2Serializer.py
@@ -229,12 +229,10 @@ def ros2_basic_data(message_type):
 def ROS2BasicDataInit(message_type, name):
     OpenRTM_aist.SerializerFactory.instance().addFactory(name,
                                                          ros2_basic_data(
-                                                             message_type),
-                                                         OpenRTM_aist.Delete)
-    ROS2MessageInfo.ROS2MessageInfoFactory.instance().addFactory(name,
-                                                                 ROS2MessageInfo.ros2_message_info(
-                                                                     message_type),
-                                                                 OpenRTM_aist.Delete)
+                                                             message_type))
+    ROS2MessageInfo.ROS2MessageInfoList.instance().addInfo(name,
+                                                                 ROS2MessageInfo.ROS2MessageInfo(
+                                                                     message_type))
 
 
 ##
@@ -378,12 +376,10 @@ class ROS2Point3DData(OpenRTM_aist.ByteDataStreamBase):
 #
 def ROS2Point3DInit():
     OpenRTM_aist.SerializerFactory.instance().addFactory("ros2:geometry_msgs/PointStamped",
-                                                         ROS2Point3DData,
-                                                         OpenRTM_aist.Delete)
-    ROS2MessageInfo.ROS2MessageInfoFactory.instance().addFactory("ros2:geometry_msgs/PointStamped",
-                                                                 ROS2MessageInfo.ros2_message_info(
-                                                                     PointStamped),
-                                                                 OpenRTM_aist.Delete)
+                                                         ROS2Point3DData)
+    ROS2MessageInfo.ROS2MessageInfoList.instance().addInfo("ros2:geometry_msgs/PointStamped",
+                                                                 ROS2MessageInfo.ROS2MessageInfo(
+                                                                     PointStamped))
 
 
 ##
@@ -529,12 +525,10 @@ class ROS2QuaternionData(OpenRTM_aist.ByteDataStreamBase):
 #
 def ROS2QuaternionInit():
     OpenRTM_aist.SerializerFactory.instance().addFactory("ros2:geometry_msgs/QuaternionStamped",
-                                                         ROS2QuaternionData,
-                                                         OpenRTM_aist.Delete)
-    ROS2MessageInfo.ROS2MessageInfoFactory.instance().addFactory("ros2:geometry_msgs/QuaternionStamped",
-                                                                 ROS2MessageInfo.ros2_message_info(
-                                                                     QuaternionStamped),
-                                                                 OpenRTM_aist.Delete)
+                                                         ROS2QuaternionData)
+    ROS2MessageInfo.ROS2MessageInfoList.instance().addInfo("ros2:geometry_msgs/QuaternionStamped",
+                                                                 ROS2MessageInfo.ROS2MessageInfo(
+                                                                     QuaternionStamped))
 
 
 ##
@@ -678,12 +672,10 @@ class ROS2Vector3DData(OpenRTM_aist.ByteDataStreamBase):
 #
 def ROS2Vector3DInit():
     OpenRTM_aist.SerializerFactory.instance().addFactory("ros2:geometry_msgs/Vector3Stamped",
-                                                         ROS2Vector3DData,
-                                                         OpenRTM_aist.Delete)
-    ROS2MessageInfo.ROS2MessageInfoFactory.instance().addFactory("ros2:geometry_msgs/Vector3Stamped",
-                                                                 ROS2MessageInfo.ros2_message_info(
-                                                                     Vector3Stamped),
-                                                                 OpenRTM_aist.Delete)
+                                                         ROS2Vector3DData)
+    ROS2MessageInfo.ROS2MessageInfoList.instance().addInfo("ros2:geometry_msgs/Vector3Stamped",
+                                                                 ROS2MessageInfo.ROS2MessageInfo(
+                                                                     Vector3Stamped))
 
 
 ##
@@ -833,12 +825,10 @@ class ROS2CameraImageData(OpenRTM_aist.ByteDataStreamBase):
 #
 def ROS2CameraImageInit():
     OpenRTM_aist.SerializerFactory.instance().addFactory("ros2:sensor_msgs/Image",
-                                                         ROS2CameraImageData,
-                                                         OpenRTM_aist.Delete)
-    ROS2MessageInfo.ROS2MessageInfoFactory.instance().addFactory("ros2:sensor_msgs/Image",
-                                                                 ROS2MessageInfo.ros2_message_info(
-                                                                     Image),
-                                                                 OpenRTM_aist.Delete)
+                                                         ROS2CameraImageData)
+    ROS2MessageInfo.ROS2MessageInfoList.instance().addInfo("ros2:sensor_msgs/Image",
+                                                                 ROS2MessageInfo.ROS2MessageInfo(
+                                                                     Image))
 
 
 ##

--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSInPort.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSInPort.py
@@ -235,12 +235,10 @@ class ROSInPort(OpenRTM_aist.InPortProvider):
             self._callerid = str(OpenRTM_aist.uuid1())
         self._callerid = "/" + self._callerid
 
-        factory = ROSMessageInfo.ROSMessageInfoFactory.instance()
-        info = factory.createObject(self._messageType)
+        factory = ROSMessageInfo.ROSMessageInfoList.instance()
+        info = factory.getInfo(self._messageType)
         if info:
             info_type = info.datatype()
-
-            factory.deleteObject(info)
         else:
             self._rtcout.RTC_ERROR("can not found %s", self._messageType)
             return
@@ -337,13 +335,12 @@ class ROSInPort(OpenRTM_aist.InPortProvider):
                             self._rtcout.RTC_ERROR("ValueError")
                             return
 
-                factory = ROSMessageInfo.ROSMessageInfoFactory.instance()
-                info = factory.createObject(self._messageType)
+                factory = ROSMessageInfo.ROSMessageInfoList.instance()
+                info = factory.getInfo(self._messageType)
                 if(info):
                     info_type = info.datatype()
                     info_md5sum = info.md5sum()
                     info_message_definition = info.message_definition()
-                    factory.deleteObject(info)
                 else:
                     self._rtcout.RTC_ERROR(
                         "Can not found %s", self._messageType)
@@ -735,5 +732,4 @@ class SubListener:
 def ROSInPortInit():
     factory = OpenRTM_aist.InPortProviderFactory.instance()
     factory.addFactory("ros",
-                       ROSInPort,
-                       OpenRTM_aist.Delete)
+                       ROSInPort)

--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSMessageInfo.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSMessageInfo.py
@@ -130,143 +130,126 @@ class ROSMessageInfoBase(object):
 
 ##
 # @if jp
-# @brief メッセージの情報格納オブジェクト生成関数
+# @class ROSMessageInfo
+# @brief メッセージの情報格納クラス
 #
-# @param data_class ROSメッセージ型
-# @return メッセージの情報格納オブジェクト
 #
 # @else
+# @class ROSMessageInfo
 # @brief
 #
-# @param data_class
-# @return
 #
 # @endif
-#
-def ros_message_info(data_class):
+class ROSMessageInfo(ROSMessageInfoBase):
+    """
+    """
     ##
     # @if jp
-    # @class ROSMessageInfo
-    # @brief メッセージの情報格納クラス
+    # @brief コンストラクタ
     #
+    # コンストラクタ
+    #
+    # @param self
     #
     # @else
-    # @class ROSMessageInfo
+    # @brief Constructor
+    #
+    # @param self
+    #
+    # @endif
+
+    def __init__(self, data_class):
+        super(ROSMessageInfo, self).__init__()
+        self._data_class = data_class
+    ##
+    # @if jp
+    # @brief デストラクタ
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @brief self
+    #
+    # @endif
+
+    def __del__(self):
+        pass
+    ##
+    # @if jp
+    # @brief メッセージの型名を取得
+    #
+    # @param self
+    # @return 型名
+    #
+    # @else
     # @brief
     #
     #
+    # @param self
+    # @return
+    #
     # @endif
-    class ROSMessageInfo(ROSMessageInfoBase):
-        """
-        """
+    #
 
-        ##
-        # @if jp
-        # @brief コンストラクタ
-        #
-        # コンストラクタ
-        #
-        # @param self
-        #
-        # @else
-        # @brief Constructor
-        #
-        # @param self
-        #
-        # @endif
-        def __init__(self):
-            super(ROSMessageInfo, self).__init__()
+    def datatype(self):
+        return self._data_class._type
+    ##
+    # @if jp
+    # @brief メッセージのMD5チェックサムを取得
+    #
+    # @param self
+    # @return MD5チェックサム
+    #
+    # @else
+    # @brief
+    #
+    #
+    # @param self
+    # @return
+    #
+    # @endif
+    #
 
-        ##
-        # @if jp
-        # @brief デストラクタ
-        #
-        #
-        # @param self
-        #
-        # @else
-        #
-        # @brief self
-        #
-        # @endif
+    def md5sum(self):
+        return self._data_class._md5sum
+    ##
+    # @if jp
+    # @brief メッセージのMD5チェックサムを取得
+    #
+    # @param self
+    # @return MD5チェックサム
+    #
+    # @else
+    # @brief
+    #
+    #
+    # @param self
+    # @return
+    #
+    # @endif
+    #
 
-        def __del__(self):
-            pass
-
-        ##
-        # @if jp
-        # @brief メッセージの型名を取得
-        #
-        # @param self
-        # @return 型名
-        #
-        # @else
-        # @brief
-        #
-        #
-        # @param self
-        # @return
-        #
-        # @endif
-        #
-        def datatype(self):
-            return data_class._type
-
-        ##
-        # @if jp
-        # @brief メッセージのMD5チェックサムを取得
-        #
-        # @param self
-        # @return MD5チェックサム
-        #
-        # @else
-        # @brief
-        #
-        #
-        # @param self
-        # @return
-        #
-        # @endif
-        #
-        def md5sum(self):
-            return data_class._md5sum
-
-        ##
-        # @if jp
-        # @brief メッセージのMD5チェックサムを取得
-        #
-        # @param self
-        # @return MD5チェックサム
-        #
-        # @else
-        # @brief
-        #
-        #
-        # @param self
-        # @return
-        #
-        # @endif
-        #
-        def message_definition(self):
-            return data_class._full_text
-    return ROSMessageInfo
+    def message_definition(self):
+        return self._data_class._full_text
 
 
-rosmessageinfofactory = None
+rosmessageinfolist = None
 
 
 ##
 # @if jp
-# @class ROSMessageInfoFactory
+# @class ROSMessageInfoList
 # @brief ROSメッセージ情報格納オブジェクト生成ファクトリ
 #
 # @else
-# @class ROSMessageInfoFactory
+# @class ROSMessageInfoList
 # @brief
 #
 #
 # @endif
-class ROSMessageInfoFactory(OpenRTM_aist.Factory, ROSMessageInfoBase):
+class ROSMessageInfoList:
     ##
     # @if jp
     # @brief コンストラクタ
@@ -282,7 +265,7 @@ class ROSMessageInfoFactory(OpenRTM_aist.Factory, ROSMessageInfoBase):
     #
     # @endif
     def __init__(self):
-        OpenRTM_aist.Factory.__init__(self)
+        self._data = {}
 
     ##
     # @if jp
@@ -320,11 +303,74 @@ class ROSMessageInfoFactory(OpenRTM_aist.Factory, ROSMessageInfoBase):
     # @endif
     #
     def instance():
-        global rosmessageinfofactory
+        global rosmessageinfolist
 
-        if rosmessageinfofactory is None:
-            rosmessageinfofactory = ROSMessageInfoFactory()
+        if rosmessageinfolist is None:
+            rosmessageinfolist = ROSMessageInfoList()
 
-        return rosmessageinfofactory
+        return rosmessageinfolist
 
     instance = staticmethod(instance)
+
+    ##
+    # @if jp
+    # @brief ROSMessageInfoの追加
+    #
+    # @param self
+    # @param id 名前
+    # @param info ROSMessageInfo
+    #
+    # @else
+    # @brief
+    #
+    # @param self
+    # @param id
+    # @param info
+    #
+    # @endif
+    #
+    def addInfo(self, id, info):
+        self._data[id] = info
+
+    ##
+    # @if jp
+    # @brief ROSMessageInfoの削除
+    #
+    # @param self
+    # @param id 名前
+    # @return 削除に成功した場合はTrue
+    #
+    # @else
+    # @brief
+    #
+    # @param self
+    # @param id
+    # @return
+    #
+    # @endif
+    #
+    def removeInfo(self, id):
+        if id in self._data:
+            del self._data[id]
+            return True
+        return False
+
+    ##
+    # @if jp
+    # @brief 指定名のROSMessageInfoの取得
+    #
+    # @param id 名前
+    # @return ROSMessageInfo
+    #
+    # @else
+    # @brief
+    #
+    # @param id
+    # @return
+    #
+    # @endif
+    #
+    def getInfo(self, id):
+        if id in self._data:
+            return self._data[id]
+        return None

--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSOutPort.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSOutPort.py
@@ -233,14 +233,13 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
         self._rtcout.RTC_VERBOSE("MD5sum:%s", md5sum)
         self._rtcout.RTC_VERBOSE("Type:%s", type_name)
 
-        factory = ROSMessageInfo.ROSMessageInfoFactory.instance()
-        info = factory.createObject(self._messageType)
+        factory = ROSMessageInfo.ROSMessageInfoList.instance()
+        info = factory.getInfo(self._messageType)
 
         if info:
             info_type = info.datatype()
             info_md5sum = info.md5sum()
             info_message_definition = info.message_definition()
-            factory.deleteObject(info)
         else:
             self._rtcout.RTC_ERROR("can not found %s", self._messageType)
             return
@@ -508,5 +507,4 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
 def ROSOutPortInit():
     factory = OpenRTM_aist.InPortConsumerFactory.instance()
     factory.addFactory("ros",
-                       ROSOutPort,
-                       OpenRTM_aist.Delete)
+                       ROSOutPort)

--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSSerializer.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSSerializer.py
@@ -296,12 +296,10 @@ def ros_basic_data(message_type):
 def ROSBasicDataInit(message_type, name):
     OpenRTM_aist.SerializerFactory.instance().addFactory(name,
                                                          ros_basic_data(
-                                                             message_type),
-                                                         OpenRTM_aist.Delete)
-    ROSMessageInfo.ROSMessageInfoFactory.instance().addFactory(name,
-                                                               ROSMessageInfo.ros_message_info(
-                                                                   message_type),
-                                                               OpenRTM_aist.Delete)
+                                                             message_type))
+    ROSMessageInfo.ROSMessageInfoList.instance().addInfo(name,
+                                                               ROSMessageInfo.ROSMessageInfo(
+                                                                   message_type))
 
 
 ##
@@ -449,12 +447,10 @@ class ROSPoint3DData(OpenRTM_aist.ByteDataStreamBase):
 #
 def ROSPoint3DInit():
     OpenRTM_aist.SerializerFactory.instance().addFactory("ros:geometry_msgs/PointStamped",
-                                                         ROSPoint3DData,
-                                                         OpenRTM_aist.Delete)
-    ROSMessageInfo.ROSMessageInfoFactory.instance().addFactory("ros:geometry_msgs/PointStamped",
-                                                               ROSMessageInfo.ros_message_info(
-                                                                   PointStamped),
-                                                               OpenRTM_aist.Delete)
+                                                         ROSPoint3DData)
+    ROSMessageInfo.ROSMessageInfoList.instance().addInfo("ros:geometry_msgs/PointStamped",
+                                                               ROSMessageInfo.ROSMessageInfo(
+                                                                   PointStamped))
 
 
 ##
@@ -604,12 +600,10 @@ class ROSQuaternionData(OpenRTM_aist.ByteDataStreamBase):
 #
 def ROSQuaternionInit():
     OpenRTM_aist.SerializerFactory.instance().addFactory("ros:geometry_msgs/QuaternionStamped",
-                                                         ROSQuaternionData,
-                                                         OpenRTM_aist.Delete)
-    ROSMessageInfo.ROSMessageInfoFactory.instance().addFactory("ros:geometry_msgs/QuaternionStamped",
-                                                               ROSMessageInfo.ros_message_info(
-                                                                   QuaternionStamped),
-                                                               OpenRTM_aist.Delete)
+                                                         ROSQuaternionData)
+    ROSMessageInfo.ROSMessageInfoList.instance().addInfo("ros:geometry_msgs/QuaternionStamped",
+                                                               ROSMessageInfo.ROSMessageInfo(
+                                                                   QuaternionStamped))
 
 
 ##
@@ -757,12 +751,10 @@ class ROSVector3DData(OpenRTM_aist.ByteDataStreamBase):
 #
 def ROSVector3DInit():
     OpenRTM_aist.SerializerFactory.instance().addFactory("ros:geometry_msgs/Vector3Stamped",
-                                                         ROSVector3DData,
-                                                         OpenRTM_aist.Delete)
-    ROSMessageInfo.ROSMessageInfoFactory.instance().addFactory("ros:geometry_msgs/Vector3Stamped",
-                                                               ROSMessageInfo.ros_message_info(
-                                                                   Vector3Stamped),
-                                                               OpenRTM_aist.Delete)
+                                                         ROSVector3DData)
+    ROSMessageInfo.ROSMessageInfoList.instance().addInfo("ros:geometry_msgs/Vector3Stamped",
+                                                               ROSMessageInfo.ROSMessageInfo(
+                                                                   Vector3Stamped))
 
 
 ##
@@ -917,12 +909,10 @@ class ROSCameraImageData(OpenRTM_aist.ByteDataStreamBase):
 #
 def ROSCameraImageInit():
     OpenRTM_aist.SerializerFactory.instance().addFactory("ros:sensor_msgs/Image",
-                                                         ROSCameraImageData,
-                                                         OpenRTM_aist.Delete)
-    ROSMessageInfo.ROSMessageInfoFactory.instance().addFactory("ros:sensor_msgs/Image",
-                                                               ROSMessageInfo.ros_message_info(
-                                                                   Image),
-                                                               OpenRTM_aist.Delete)
+                                                         ROSCameraImageData)
+    ROSMessageInfo.ROSMessageInfoList.instance().addInfo("ros:sensor_msgs/Image",
+                                                               ROSMessageInfo.ROSMessageInfo(
+                                                                   Image))
 
 
 ##


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Factoryでは終了処理を個別に設定できたり、作成済みのオブジェクト一覧を取得する機能があるが、Destructorはdel文を呼び出すだけのものしか使われておらず、作成済みのオブジェクト一覧の取得は実行コンテキストの生成時にしか使用されていないため、ほとんどの場合でFactoryが生成したオブジェクトのリストを持つこと自体が不要である。
むしろ削除時にdeleteObject関数を呼ばなければならないので使い勝手が悪くなっている。

## Description of the Change

FactoryからdeleteObject関数、createdObjects関数、isProducerOf関数、objectToIdentifier関数、objectToCreator関数、objectToDestructor関数を削除。addFactory関数からdestructorの引数を削除。Factoryは生成のみを行い、作成したオブジェクトをリストに格納しないようにした。

生成した実行コンテキストのリストをManagerで管理するように変更した。
ManagerクラスにaddExecutionContext関数、removeExecutionContext関数、createdExecutionContexts関数を追加した。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
