### PR TITLE
FluentLoggerに文字列ではなくProperties型を入力してエラーになる問題の修正

### DIFF
--- a/OpenRTM_aist/SystemLogger.py
+++ b/OpenRTM_aist/SystemLogger.py
@@ -329,7 +329,7 @@ class LogStream:
                     print("RTC_LOG : argument error")
                     return
             for log in self._loggerObj:
-                log.log(messages, LV, self._logger_name)
+                log.log(str(messages), LV, self._logger_name)
 
             self.release()
 
@@ -366,7 +366,7 @@ class LogStream:
                     return
 
             for log in self._loggerObj:
-                log.log(messages, Logger.FATAL, self._logger_name)
+                log.log(str(messages), Logger.FATAL, self._logger_name)
 
             self.release()
 
@@ -403,7 +403,7 @@ class LogStream:
                     return
 
             for log in self._loggerObj:
-                log.log(messages, Logger.ERROR, self._logger_name)
+                log.log(str(messages), Logger.ERROR, self._logger_name)
 
             self.release()
 
@@ -444,7 +444,7 @@ class LogStream:
                     return
 
             for log in self._loggerObj:
-                log.log(messages, Logger.WARN, self._logger_name)
+                log.log(str(messages), Logger.WARN, self._logger_name)
 
             self.release()
 
@@ -485,7 +485,7 @@ class LogStream:
                     return
 
             for log in self._loggerObj:
-                log.log(messages, Logger.INFO, self._logger_name)
+                log.log(str(messages), Logger.INFO, self._logger_name)
 
             self.release()
 
@@ -526,7 +526,7 @@ class LogStream:
                     return
 
             for log in self._loggerObj:
-                log.log(messages, Logger.DEBUG, self._logger_name)
+                log.log(str(messages), Logger.DEBUG, self._logger_name)
 
             self.release()
 
@@ -568,7 +568,7 @@ class LogStream:
                     return
 
             for log in self._loggerObj:
-                log.log(messages, Logger.TRACE, self._logger_name)
+                log.log(str(messages), Logger.TRACE, self._logger_name)
 
             self.release()
 
@@ -610,7 +610,7 @@ class LogStream:
                     return
 
             for log in self._loggerObj:
-                log.log(messages, Logger.VERBOSE, self._logger_name)
+                log.log(str(messages), Logger.VERBOSE, self._logger_name)
 
             self.release()
 
@@ -652,7 +652,7 @@ class LogStream:
                     return
 
             for log in self._loggerObj:
-                log.log(messages, Logger.PARANOID, self._logger_name)
+                log.log(str(messages), Logger.PARANOID, self._logger_name)
 
             self.release()
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
FluentLoggerで以下のエラーが発生することがある。

```
2020-02-04 19:10:02.000000000 +0900 test.simpleio: {"level":"CRITICAL","message":"Can't output to log","traceback":"Traceback (most recent call last):\n  File \"C:\\Python37\\lib\\site-packages\\fluent_logger-0.9.3-py3.7.egg\\fluent\\sender.py\", line 90, in emit_with_time\n    bytes_ = self._make_packet(label, timestamp, data)\n  File \"C:\\Python37\\lib\\site-packages\\fluent_logger-0.9.3-py3.7.egg\\fluent\\sender.py\", line 133, in _make_packet\n    return msgpack.packb(packet, **self.msgpack_kwargs)\n  File \"C:\\Python37\\lib\\site-packages\\msgpack-0.6.1-py3.7-win-amd64.egg\\msgpack\\__init__.py\", line 46, in packb\n    return Packer(**kwargs).pack(o)\n  File \"msgpack\\_packer.pyx\", line 282, in msgpack._cmsgpack.Packer.pack\n  File \"msgpack\\_packer.pyx\", line 288, in msgpack._cmsgpack.Packer.pack\n  File \"msgpack\\_packer.pyx\", line 285, in msgpack._cmsgpack.Packer.pack\n  File \"msgpack\\_packer.pyx\", line 261, in msgpack._cmsgpack.Packer._pack\n  File \"msgpack\\_packer.pyx\", line 232, in msgpack._cmsgpack.Packer._pack\n  File \"msgpack\\_packer.pyx\", line 279, in msgpack._cmsgpack.Packer._pack\nTypeError: can not serialize 'Properties' object\n"}
```


## Description of the Change

FluentLoggerに文字列ではなくProperties型を入力したことが原因のため、Logstreamへ必ず文字列を入力するように修正した。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
