### PR TITLE
Python3用debパッケージを生成できるように整備(1.2)

### DIFF
--- a/OpenRTM_aist/utils/rtcd/rtcd_python3
+++ b/OpenRTM_aist/utils/rtcd/rtcd_python3
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: euc-jp -*-
+
+##
+# @file rtcd_python
+# @brief RT component server daemon
+# @date $Date: $
+# @author Noriaki Ando <n-ando@aist.go.jp> and Shinji Kurihara
+#
+# Copyright (C) 2010
+#     Intelligent Systems Research Institute,
+#     National Institute of
+#         Advanced Industrial Science and Technology (AIST), Japan
+#     All rights reserved.
+
+import sys
+import rtcd
+
+def main():
+  rtcd.main()
+  return
+
+if __name__ == "__main__":
+  main()

--- a/OpenRTM_aist/utils/rtcprof/rtcprof_python3
+++ b/OpenRTM_aist/utils/rtcprof/rtcprof_python3
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# -*- Python -*-
+# -*- coding: euc-jp -*-
+
+##
+# @file rtcprof_python
+# @brief RT-Component profile dump command
+# @date $Date: $
+# @author Noriaki Ando <n-ando@aist.go.jp> and Shinji Kurihara
+#
+# Copyright (C) 2010
+#     Intelligent Systems Research Institute,
+#     National Institute of
+#         Advanced Industrial Science and Technology (AIST), Japan
+#     All rights reserved.
+
+import sys
+import rtcprof
+
+def main():
+  rtcprof.main()
+  return
+
+if __name__ == "__main__":
+  main()

--- a/packages/deb/debian/changelog
+++ b/packages/deb/debian/changelog
@@ -1,3 +1,9 @@
+openrtm-aist-python (1.2.1-1) experimental; urgency=low
+
+  * 1.2.1-1 (1.2.1-RELEASE). OpenRTM-aist-1.2.1-RELEASE
+
+ -- Noriaki Ando <n-ando@aist.go.jp>  Wed, 19 Feb 2020 16:28:36 +0900
+
 openrtm-aist-python (1.2.1-0) experimental; urgency=low
 
   * 1.2.1-0 (1.2.1-RELEASE). OpenRTM-aist-1.2.1-RELEASE

--- a/packages/deb/debian/control
+++ b/packages/deb/debian/control
@@ -2,11 +2,11 @@ Source: openrtm-aist-python
 Section: main
 Priority: extra
 Maintainer: Noriaki Ando <n-ando@aist.go.jp>
-Build-Depends: debhelper, python, python-omniorb
+Build-Depends: debhelper, python3-all-dev, python3-omniorb
 Standards-Version: 3.8.4
 Homepage: http://www.openrtm.org
 
-Package: openrtm-aist-python
+Package: openrtm-aist-python3
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, omniorb-nameserver
 Description: OpenRTM-aist, RT-Middleware distributed by AIST
@@ -20,13 +20,13 @@ Description: OpenRTM-aist, RT-Middleware distributed by AIST
  National Institute of Advanced Industrial Science and Technology
  (AIST), Japan. Please see http://www.openrtm.org/ for more detail.
 
-Package: openrtm-aist-python-example
+Package: openrtm-aist-python3-example
 Architecture: any
-Depends: openrtm-aist-python
+Depends: openrtm-aist-python3
 Description: OpenRTM-aist-Python examples
  Example components and sources of OpenRTM-aist.
 
-Package: openrtm-aist-python-doc
+Package: openrtm-aist-python3-doc
 Architecture: all
 Description: Documentation for openrtm-aist-python
  Class reference manual of OpenRTM-aist.

--- a/packages/deb/debian/rules
+++ b/packages/deb/debian/rules
@@ -18,7 +18,7 @@ configure-stamp:
 
 
 build: build-stamp
-	python setup.py build
+	python3 setup.py build
 
 build-stamp: configure-stamp  
 	dh_testdir
@@ -28,7 +28,7 @@ clean:
 	dh_testdir
 	dh_testroot
 	rm -f build-stamp configure-stamp
-	python setup.py clean
+	python3 setup.py clean
 
 	dh_clean 
 
@@ -39,13 +39,13 @@ install: build
 	dh_installdirs
 
 	# installing core
-	python setup.py install_core --prefix=$(CURDIR)/debian/openrtm-aist-python/usr --install-layout=deb
+	python3 setup.py install_core --prefix=$(CURDIR)/debian/openrtm-aist-python3/usr --install-layout=deb
 	# installing examples
-	(mkdir $(CURDIR)/debian/openrtm-aist-python-example/usr/)
-	python setup.py install_example --install-dir=$(CURDIR)/debian/openrtm-aist-python-example/usr/
+	(mkdir $(CURDIR)/debian/openrtm-aist-python3-example/usr/)
+	python3 setup.py install_example --install-dir=$(CURDIR)/debian/openrtm-aist-python3-example/usr/
 	# installing examples
-	(mkdir $(CURDIR)/debian/openrtm-aist-python-doc/usr/)
-	python setup.py install_doc --install-dir=$(CURDIR)/debian/openrtm-aist-python-doc/usr/
+	(mkdir $(CURDIR)/debian/openrtm-aist-python3-doc/usr/)
+	python3 setup.py install_doc --install-dir=$(CURDIR)/debian/openrtm-aist-python3-doc/usr/
 	dh_install -s
 
 # Build architecture-independent files here.

--- a/packages/deb/dpkg_build.sh
+++ b/packages/deb/dpkg_build.sh
@@ -107,7 +107,7 @@ check_distribution()
 
 get_version_info()
 {
-    VERSION=`../../setup.py --version`
+    VERSION=`python3 ../../setup.py --version`
     SHORT_VERSION=`echo $VERSION | sed 's/\.[0-9]*$//'`
     BUILD_ROOT="buildroot"
     PKG_NAME="OpenRTM-aist-Python-${VERSION}"
@@ -116,8 +116,8 @@ get_version_info()
 create_source_package()
 {
   cd ../../
-  ./setup.py build
-  ./setup.py sdist
+  python3 setup.py build
+  python3 setup.py sdist
   cd -
 }
 
@@ -131,10 +131,11 @@ create_files()
 {
   eval `dpkg-architecture`
   ARCH=$DEB_HOST_ARCH
+  PKG_VERSION=`dpkg-parsechangelog | sed -n 's/^Version: //p'`
 cat << EOF >> debian/files
-openrtm-aist-python_1.1.0-1_$ARCH.deb main extra
-openrtm-aist-python-example_1.1.0-1_$ARCH.deb main extra
-openrtm-aist-python-doc_1.1.0-1_all.deb main extra
+openrtm-aist-python3_${PKG_VERSION}_${ARCH}.deb main extra
+openrtm-aist-python3-example_${PKG_VERSION}_${ARCH}.deb main extra
+openrtm-aist-python3-doc_${PKG_VERSION}_all.deb main extra
 EOF
 }
 

--- a/setup.py
+++ b/setup.py
@@ -232,8 +232,8 @@ baseidl_path  = os.path.normpath(current_dir + "/" + baseidl_dir)
 #
 # scripts settings
 #
-pkg_scripts_unix  = ['OpenRTM_aist/utils/rtcd/rtcd_python',
-                     'OpenRTM_aist/utils/rtcprof/rtcprof_python']
+pkg_scripts_unix  = ['OpenRTM_aist/utils/rtcd/rtcd_python3',
+                     'OpenRTM_aist/utils/rtcprof/rtcprof_python3']
 pkg_scripts_win32 = ['OpenRTM_aist/utils/rtcd/rtcd.py',
 #                     'OpenRTM_aist/utils/rtcd/rtcd_python.exe',
                      'OpenRTM_aist/utils/rtcd/rtcd_python.bat',
@@ -256,14 +256,14 @@ ext_match_regex_win32 = ".*\.(py|conf|bat|xml|idl)$"
 # examples
 #
 example_dir           = "OpenRTM_aist/examples"
-target_example_dir    = "share/openrtm-" + pkg_shortver + "/components/python"
+target_example_dir    = "share/openrtm-" + pkg_shortver + "/components/python3"
 example_match_regex   = ".*\.(py|conf|sh|xml|idl)$"
 example_path          = os.path.normpath(current_dir + "/" + example_dir)
 #
 # documents
 #
 document_dir          = "OpenRTM_aist/docs"
-target_doc_dir        = "share/openrtm-" + pkg_shortver + "/doc/python"
+target_doc_dir        = "share/openrtm-" + pkg_shortver + "/doc/python3"
 document_match_regex  = ".*\.(css|gif|png|html||hhc|hhk|hhp)$"
 document_path         = os.path.normpath(current_dir + "/" + document_dir)
 
@@ -934,6 +934,7 @@ class install_core_lib(_install_lib):
                                ('optimize', 'optimize'),
                                ('skip_build', 'skip_build'),
                                )
+    _install_lib.finalize_options(self)
 
 from distutils.command.install_scripts import install_scripts as _install_scripts
 # sub-command "install_core_script" which is called from install_core
@@ -945,6 +946,8 @@ class install_core_scripts(_install_scripts):
                                ('force', 'force'),
                                ('skip_build', 'skip_build'),
                                )
+    _install_scripts.finalize_options(self)
+
 from distutils.command.install_egg_info import install_egg_info as _install_egg_info
 # sub-command "install_core_egg_info" which is called from install_core
 class install_core_egg_info(_install_egg_info):


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #176 


## Description of the Change
- setup.pyを実行するコマンドをpython3と指定した
- debファイルのバージョン番号を 1.2.1-1 とした
- debパッケージビルド時に依存しているomniORBpyを、python3-omniorb と指定
- debパッケージのインストール先は、Python2.7用 をインストールされている環境とバッティングしないようにした
  - /usr/binにインストールするコマンド名は、rtcd_python3、rtcprof_python3
  - exampleとdocのインストール先はpython3ディレクトリ下
  /usr/share/openrtm-1.2/components/python3
  /usr/share/openrtm-1.2/doc/python3
  - OpenRTM-aist-Python本体のインストール先
  /usr/lib/python3/dist-packages/OpenRTM_aist

- ビルド時に python3.6/distutils/command/install_lib.py でエラーが発生したことへの対応
  - setuplpyのinstall_core_libとinstall_core_script関数内でfinalizeの呼び出しが抜けていたので追加

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->
- Ubuntu18.04のDocker環境へ生成したOpenRTM-aist-Pythonをインストールしての動作確認
  - サンプルRTC ConsoleIn.pyとConsoleOut.pyの接続動作 OK（rtshell利用）
  - pythonは3のみで、2.7はインストールされていない
  ```
  # python --version
  bash: python: command not found
  # python3 --version
  Python 3.6.9
  ```
- テスト用のパッケージリポジトリ（http://150.29.99.185 <--DHCP環境）からaptでインストールした環境での確認
- omniorb, omniorbpy, openrtm-aist-python3 は pkg_install_ubuntu.sh を利用してインストール
  - このスクリプトは Python に関してバージョン3 関連のみをインストールするように修正済
  - リリースに合わせて OpenRTM-aist のmasterブランチにマージする必要があるため、現時点で @n-kawauchi のリポジトリにアップしてあるものを利用している

- テスト環境構築用Dockerfileは下記を利用
```
FROM ubuntu:18.04
RUN apt update\
 && apt install -y --no-install-recommends \
 wget \
 gnupg \
 && wget --no-check-certificate https://raw.githubusercontent.com/n-kawauchi/OpenRTM-aist/ubuntu_install_script/scripts/pkg_install_ubuntu.sh -O pkg_install_ubuntu.sh \
 && sed -i -e 's/reposerver="openrtm.org/reposerver="150.29.99.185/g' pkg_install_ubuntu.sh \
 && sed -i -e 's/reposervers="openrtm.org/reposervers="150.29.99.185/g' pkg_install_ubuntu.sh \
 && sh pkg_install_ubuntu.sh -l c++ -l python -l rtshell -d --yes
```

- 生成したDockerコンテナのインストール状況
```
# dpkg -l | grep openrtm
ii  openrtm-aist:amd64                1.2.1-0
ii  openrtm-aist-dev:amd64            1.2.1-0
ii  openrtm-aist-doc                  1.2.1-0
ii  openrtm-aist-example:amd64        1.2.1-0
ii  openrtm-aist-idl:amd64            1.2.1-0
ii  openrtm-aist-python3              1.2.1-1  <--★
ii  openrtm-aist-python3-doc          1.2.1-1  <--★
ii  openrtm-aist-python3-example      1.2.1-1  <--★

# dpkg -l | grep omni   
ii  libomniorb4-2:amd64               4.2.3-0.1
ii  libomniorb4-dev:amd64             4.2.3-0.1
ii  libomnithread4:amd64              4.2.3-0.1
ii  libomnithread4-dev:amd64          4.2.3-0.1
ii  omniidl                           4.2.3-0.1
ii  omniidl-python3                   4.2.3-0.1
ii  omniorb-nameserver                4.2.3-0.1
ii  python3-omniorb                   4.2.3-0.1
ii  python3-omniorb-omg               4.2.3-0.1
```

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
