### PR TITLE
表示スケールを1 dot/mから100 dot/m (1 dot/cm)に変更

### DIFF
--- a/OpenRTM_aist/examples/TkLRFViewer/TkLRFViewer.py
+++ b/OpenRTM_aist/examples/TkLRFViewer/TkLRFViewer.py
@@ -433,8 +433,8 @@ class LRFrange(ScaledObject):
     def range_to_pos(self, data):
         pos = []
         pre_d = 0
-	scale_adj=100.0  # change from 1 dot/m to 100 dot/m (dot/cm)
-	scale_threshold=0.01 # change threshold value from m unit to cm unit
+	scale_adj = 100.0  # change from 1 dot/m to 100 dot/m (dot/cm)
+	scale_threshold = 0.01 # change threshold value from m unit to cm unit
         tfilter = self.tfilter_check.get()
         sfilter = self.sfilter_check.get()
         thresh = self.threshold_check.get()

--- a/OpenRTM_aist/examples/TkLRFViewer/TkLRFViewer.py
+++ b/OpenRTM_aist/examples/TkLRFViewer/TkLRFViewer.py
@@ -433,7 +433,8 @@ class LRFrange(ScaledObject):
     def range_to_pos(self, data):
         pos = []
         pre_d = 0
-
+	scale_adj=100.0  # change from 1 dot/m to 100 dot/m (dot/cm)
+	scale_threshold=0.01 # change threshold value from m unit to cm unit
         tfilter = self.tfilter_check.get()
         sfilter = self.sfilter_check.get()
         thresh = self.threshold_check.get()
@@ -447,7 +448,7 @@ class LRFrange(ScaledObject):
         # Spacial Filter
         for (n, d) in enumerate(data):
             # Threshold
-            if thresh and d < self.threshold:
+            if thresh and d < self.threshold * scale_threshold:
                 d = 10000  # pre_d
 
             if sfilter:
@@ -460,8 +461,8 @@ class LRFrange(ScaledObject):
             #deg = (n + self.offset_step) * self.angle_per_step + self.beg_angle
             #th = deg * math.pi / 180
             th = (n + self.offset_step) * self.angle_per_step + self.beg_angle
-            x = d * math.cos(th)
-            y = d * math.sin(th)
+            x = d * math.cos(th) * scale_adj
+            y = d * math.sin(th) * scale_adj
             pos.append(self.translate(x, y, 0, 0, 0))
         self.pre_data = data
         return pos


### PR DESCRIPTION
[UrgRTCComp.zip](https://github.com/OpenRTM/OpenRTM-aist-Python/files/4254680/UrgRTCComp.zip)
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
issue #175 

## Description of the Change

デフォルトスケールで、表示スケールを1 dot/mから100 dot/m (dot/cm)に変更、また、Thresholdnの値の実際の単位が、これまでm単位だったのをcm単位の値として扱うように変更。

## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->
インタプリタ用のファイルなので、ビルドは特にせず、直接実行しているのみです。
実際にHokyoURG-04Xをつかい、Suga-sanの2014/JanリリースのRTCを用いて動作検証。RTCの入手元は：https://github.com/sugarsweetrobotics/UrgRTC
コンパイルした結果のバイナリは下記に添付
[UrgRTCComp.zip](https://github.com/OpenRTM/OpenRTM-aist-Python/files/4254684/UrgRTCComp.zip)

- [ ] Did you succeed the build?
- [ ] No warnings for the build?  
- [X] Have you passed the unit tests?  
