### PR TITLE
ローダブルモジュールの取得が失敗するエラーの修正

### DIFF
--- a/OpenRTM_aist/Process.py
+++ b/OpenRTM_aist/Process.py
@@ -93,4 +93,4 @@ def fork():
 def popen(command):
     args = shlex.split(command, " ")
     sp = subprocess.Popen(args, stdout=subprocess.PIPE)
-    return sp.communicate()[0]
+    return sp.communicate()[0].decode("utf-8")

--- a/OpenRTM_aist/Process.py
+++ b/OpenRTM_aist/Process.py
@@ -87,7 +87,7 @@ def fork():
 # @brief fork process
 # @endif
 #
-# int fork()
+# string popen(string command)
 
 
 def popen(command):


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

`get_loadable_modules()`等でロード可能なモジュールを取得しようとすると以下のエラーメッセージが表示される。

```
popen faild
```

## Description of the Change

Python3からは`subprocess`の`communicate`関数の戻り値がstr型からbytes型に仕様変更されているため、str型に変換して返すように修正した。
この修正でPython2でエラーが出るようになったが、masterブランチではPython2はサポートしないため場合分けなどは行わない。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
