### PR TITLE
rtcprof実行時に発生するエラーの修正

### DIFF
--- a/OpenRTM_aist/utils/rtcprof/rtcprof.py
+++ b/OpenRTM_aist/utils/rtcprof/rtcprof.py
@@ -1,5 +1,6 @@
 ﻿#!/usr/bin/env python
 # -*- Python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # @file rtcprof.py
@@ -62,9 +63,17 @@ def main():
     # for new
     comp_spec_name = classname + "_spec"
 
-    with open(str(fullname)) as f:
-        if f.read().find(comp_spec_name) == -1:
-            return
+    try:
+        code = "UTF-8-SIG"
+        import chardet
+        import codecs
+        with open(str(fullname), mode='rb') as f:
+            code = chardet.detect(f.read())["encoding"]
+        with codecs.open(str(fullname), "r", encoding=code) as f:
+            if f.read().find(comp_spec_name) == -1:
+                return
+    except BaseException:
+        pass
     try:
         imp_file = __import__(basename.split(".")[0])
     except BaseException:


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

再現はできていないが、rtcprof.py実行時に以下のエラーが発生するらしい。

```
C:\Python37>rtcd_python.exe -d -f rtc.conf
Traceback (most recent call last):
  File "C:\Python37\rtcprof.py", line 112, in <module>
    main()
  File "C:\Python37\rtcprof.py", line 65, in main
    if f.read().find(comp_spec_name) == -1:
UnicodeDecodeError: 'cp932' codec can't decode byte 0x90 in position 2: illegal multibyte sequence
```


## Description of the Change

おそらく読み込むファイルの文字コード次第で発生するエラーだと考えられるため、文字コードを判別してから読み込むように修正した。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
