### PR TITLE
シリアライザ生成ファクトリの仕様変更

### DIFF
--- a/OpenRTM_aist/ByteDataStreamBase.py
+++ b/OpenRTM_aist/ByteDataStreamBase.py
@@ -22,12 +22,14 @@ import OpenRTM_aist
 
 ##
 # @if jp
-# @class
+# @class ByteDataStreamBase
 #
+# @brief シリアライザの基底クラス
 #
 # @else
-# @brief
+# @class ByteDataStreamBase
 #
+# @brief
 #
 # @endif
 class ByteDataStreamBase:
@@ -126,24 +128,124 @@ class ByteDataStreamBase:
 
 
 serializerfactories = None
+globalserializerfactories = None
+
+##
+# @if jp
+# @class SerializerFactory
+#
+# @brief シリアライザを生成するファクトリ
+#
+# @else
+# @class SerializerFactory
+#
+# @brief
+#
+# @endif
 
 
 class SerializerFactory(OpenRTM_aist.Factory, ByteDataStreamBase):
+
+    ##
+    # @if jp
+    # @brief コンストラクタ
+    #
+    # コンストラクタ
+    #
+    # @param self
+    #
+    # @else
+    # @brief Constructor
+    #
+    # @param self
+    #
+    # @endif
     def __init__(self):
         OpenRTM_aist.Factory.__init__(self)
         pass
 
+    ##
+    # @if jp
+    # @brief デストラクタ
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @brief self
+    #
+    # @endif
     def __del__(self):
         pass
+
+##
+# @if jp
+# @class SerializerFactories
+#
+# @brief シリアライザ生成ファクトリの一覧を操作するクラス
+#
+# @else
+# @class SerializerFactories
+#
+# @brief
+#
+# @endif
 
 
 class SerializerFactories:
+    ##
+    # @if jp
+    # @brief コンストラクタ
+    #
+    # コンストラクタ
+    #
+    # @param self
+    #
+    # @else
+    # @brief Constructor
+    #
+    # @param self
+    #
+    # @endif
     def __init__(self):
         self._factories = {}
 
+    ##
+    # @if jp
+    # @brief デストラクタ
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @brief self
+    #
+    # @endif
     def __del__(self):
         pass
 
+    ##
+    # @if jp
+    # @brief シリアライザの登録(データ型ごと)
+    #
+    # @param self
+    # @param marshalingtype シリアライザの種類(文字列)
+    # @param serializer シリアライザを定義したクラス
+    # @param datatype 対象のデータ型のインスタンス、もしくはクラス
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @param self
+    # @param marshalingtype
+    # @param serializer
+    # @param datatype
+    #
+    # @endif
     def addSerializer(self, marshalingtype, serializer, datatype):
         mtype = OpenRTM_aist.toTypename(datatype)
         if not (mtype in self._factories):
@@ -151,55 +253,143 @@ class SerializerFactories:
         self._factories[mtype].addFactory(marshalingtype,
                                           serializer)
 
+    ##
+    # @if jp
+    # @brief シリアライザの登録(グローバル)
+    # 基本的にシリアライザはデータ型ごとに追加するが、
+    # CORBA CDR形式のシリアライザのように全てのデータ型で共通の
+    # 処理を行う場合はグローバルにシリアライザを登録できる。
+    # 特定のデータ型から特定のROSメッセージ型への変換が必要などという
+    # 場合はデータ型ごとの登録が必要である。
+    #
+    #
+    #
+    # @param self
+    # @param marshalingtype シリアライザの種類(文字列)
+    # @param serializer シリアライザを定義したクラス
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @param self
+    # @param marshalingtype
+    # @param serializer
+    #
+    # @endif
     def addSerializerGlobal(self, marshalingtype, serializer):
-        mtype = "ALL"
-        if not (mtype in self._factories):
-            self._factories[mtype] = SerializerFactory()
-        self._factories[mtype].addFactory(marshalingtype,
-                                          serializer)
+        globalserializerfactories.addFactory(marshalingtype,
+                                             serializer)
+    ##
+    # @if jp
+    # @brief シリアライザの登録解除(データ型ごと)
+    #
+    # @param self
+    # @param marshalingtype シリアライザの種類(文字列)
+    # @param datatype 対象のデータ型のインスタンス、もしくはクラス
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @param self
+    # @param marshalingtype
+    # @param datatype
+    #
+    # @endif
 
     def removeSerializer(self, marshalingtype, datatype):
         mtype = OpenRTM_aist.toTypename(datatype)
         if mtype in self._factories:
             self._factories[mtype].removeFactory(marshalingtype)
 
+    ##
+    # @if jp
+    # @brief シリアライザの登録解除(グローバル)
+    #
+    # @param self
+    # @param marshalingtype シリアライザの種類(文字列)
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @param self
+    # @param marshalingtype
+    #
+    # @endif
     def removeSerializerGlobal(self, marshalingtype):
-        mtype = "ALL"
-        if mtype in self._factories:
-            self._factories[mtype].removeFactory(marshalingtype)
+        globalserializerfactories.removeFactory(marshalingtype)
 
+    ##
+    # @if jp
+    # @brief シリアライザの生成
+    #
+    # @param self
+    # @param marshalingtype シリアライザの種類(文字列)
+    # @param datatype 対象のデータ型のインスタンス、もしくはクラス
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @param self
+    # @param marshalingtype
+    # @param datatype
+    #
+    # @endif
     def createSerializer(self, marshalingtype, datatype):
-        mtype = OpenRTM_aist.toTypename(datatype)
-        if mtype in self._factories:
-            obj = self._factories[mtype].createObject(marshalingtype)
-            if obj is not None:
-                return obj
-        mtype = "ALL"
-        if mtype in self._factories:
-            obj = self._factories[mtype].createObject(marshalingtype)
-            if obj is not None:
-                return obj
+        if datatype is not None:
+            mtype = OpenRTM_aist.toTypename(datatype)
+            if mtype in self._factories:
+                obj = self._factories[mtype].createObject(marshalingtype)
+                if obj is not None:
+                    return obj
+        obj = globalserializerfactories.createObject(marshalingtype)
+        if obj is not None:
+            return obj
         return None
 
+    ##
+    # @if jp
+    # @brief 使用可能なシリアライザ一覧の取得
+    #
+    # @param self
+    # @param datatype 対象のデータ型のインスタンス、もしくはクラス
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @param self
+    # @param datatype
+    #
+    # @endif
     def getSerializerList(self, datatype):
-        available_types = []
-        mtype = OpenRTM_aist.toTypename(datatype)
-        if mtype in self._factories:
-            factory = self._factories[mtype]
-            available_types.extend(factory.getIdentifiers())
+        if datatype is not None:
+            available_types = []
+            mtype = OpenRTM_aist.toTypename(datatype)
+            if mtype in self._factories:
+                factory = self._factories[mtype]
+                available_types.extend(factory.getIdentifiers())
 
-        mtype = "ALL"
-        if mtype in self._factories:
-            factory = self._factories[mtype]
-            available_types.extend(factory.getIdentifiers())
+        available_types.extend(globalserializerfactories.getIdentifiers())
 
         return available_types
 
     def instance():
         global serializerfactories
+        global globalserializerfactories
 
         if serializerfactories is None:
             serializerfactories = SerializerFactories()
+        if globalserializerfactories is None:
+            globalserializerfactories = SerializerFactory()
 
         return serializerfactories
 

--- a/OpenRTM_aist/ByteDataStreamBase.py
+++ b/OpenRTM_aist/ByteDataStreamBase.py
@@ -342,7 +342,7 @@ class SerializerFactories:
     # @param datatype
     #
     # @endif
-    def createSerializer(self, marshalingtype, datatype):
+    def createSerializer(self, marshalingtype, datatype=None):
         if datatype is not None:
             mtype = OpenRTM_aist.toTypename(datatype)
             if mtype in self._factories:

--- a/OpenRTM_aist/CORBA_CdrMemoryStream.py
+++ b/OpenRTM_aist/CORBA_CdrMemoryStream.py
@@ -25,12 +25,14 @@ from omniORB import any
 
 ##
 # @if jp
-# @class
+# @class CORBA_CdrMemoryStream
 #
+# @brief CORBAのCDR形式シリアライザ、デシリアライザを定義
 #
 # @else
-# @brief
+# @class CORBA_CdrMemoryStream
 #
+# @brief
 #
 # @endif
 
@@ -181,4 +183,5 @@ class CORBA_CdrMemoryStream(OpenRTM_aist.ByteDataStreamBase):
 
 
 def CORBA_CdrMemoryStreamInit():
-    OpenRTM_aist.SerializerFactories.instance().addSerializerGlobal("cdr", CORBA_CdrMemoryStream)
+    OpenRTM_aist.SerializerFactories.instance().addSerializerGlobal("cdr",
+                                                                    CORBA_CdrMemoryStream)

--- a/OpenRTM_aist/CORBA_CdrMemoryStream.py
+++ b/OpenRTM_aist/CORBA_CdrMemoryStream.py
@@ -181,5 +181,4 @@ class CORBA_CdrMemoryStream(OpenRTM_aist.ByteDataStreamBase):
 
 
 def CORBA_CdrMemoryStreamInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("corba",
-                                                         OpenRTM_aist.CORBA_CdrMemoryStream)
+    OpenRTM_aist.SerializerFactories.instance().addSerializerGlobal("cdr", CORBA_CdrMemoryStream)

--- a/OpenRTM_aist/ConnectorListener.py
+++ b/OpenRTM_aist/ConnectorListener.py
@@ -355,7 +355,7 @@ class ConnectorDataListenerT(ConnectorDataListener):
                 "in.marshaling_type", marshaling_type)
         marshaling_type = marshaling_type.strip()
 
-        serializer = OpenRTM_aist.SerializerFactory.instance().createObject(marshaling_type)
+        serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(marshaling_type, data)
 
         serializer.isLittleEndian(endian)
         ret, data = serializer.deserialize(cdrdata, data)
@@ -805,7 +805,7 @@ class ConnectorDataListenerHolder:
                 "in.marshaling_type", marshaling_type)
         marshaling_type = marshaling_type.strip()
 
-        serializer = OpenRTM_aist.SerializerFactory.instance().createObject(marshaling_type)
+        serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(marshaling_type, self._data)
 
         data = self._data
         if serializer is not None:

--- a/OpenRTM_aist/ConnectorListener.py
+++ b/OpenRTM_aist/ConnectorListener.py
@@ -356,10 +356,11 @@ class ConnectorDataListenerT(ConnectorDataListener):
         marshaling_type = marshaling_type.strip()
 
         serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(marshaling_type, data)
+        if serializer is not None:
+            serializer.isLittleEndian(endian)
+            ret, data = serializer.deserialize(cdrdata, data)
 
-        serializer.isLittleEndian(endian)
-        ret, data = serializer.deserialize(cdrdata, data)
-
+            return data
         return data
 
 

--- a/OpenRTM_aist/InPort.py
+++ b/OpenRTM_aist/InPort.py
@@ -94,6 +94,10 @@ class InPort(OpenRTM_aist.InPortBase):
         self._directNewData = False
         self._valueMutex = threading.RLock()
 
+        marshaling_types = OpenRTM_aist.SerializerFactories.instance().getSerializerList(value)
+        marshaling_types = OpenRTM_aist.flatten(marshaling_types).lstrip()
+        self.addProperty("dataport.marshaling_types", marshaling_types)
+
         self._listeners.setDataType(copy.deepcopy(value))
         self._listeners.setPortType(OpenRTM_aist.PortType.InPortType)
 

--- a/OpenRTM_aist/InPortBase.py
+++ b/OpenRTM_aist/InPortBase.py
@@ -105,26 +105,6 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
         self.addProperty("dataport.data_type", data_type)
         self._properties.setProperty("data_type", data_type)
 
-        factory = OpenRTM_aist.SerializerFactory.instance()
-        serializer_list = factory.getIdentifiers()
-        ds = data_type.split(":")
-        marshaling_types = []
-        if len(ds) == 3:
-            data_name = ds[1]
-            for s in serializer_list:
-                s = s.lstrip()
-                v = s.split(":")
-                if len(v) == 3:
-                    if v[2] == data_name:
-                        marshaling_types.append(s)
-                else:
-                    marshaling_types.append(s)
-
-        marshaling_types = OpenRTM_aist.flatten(marshaling_types)
-        marshaling_types = marshaling_types.lstrip()
-        self._rtcout.RTC_DEBUG("available marshaling_types: %s", marshaling_types)
-        self.addProperty("dataport.marshaling_types", marshaling_types)
-
         self.addProperty("dataport.subscription_type", "Any")
         self._value = None
         self._listeners = OpenRTM_aist.ConnectorListeners()

--- a/OpenRTM_aist/InPortDuplexConnector.py
+++ b/OpenRTM_aist/InPortDuplexConnector.py
@@ -85,8 +85,7 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
             "in.marshaling_type", self._marshaling_type)
         self._marshaling_type = self._marshaling_type.strip()
 
-        self._serializer = OpenRTM_aist.SerializerFactory.instance(
-        ).createObject(self._marshaling_type)
+        self._serializer = None
 
         return
 
@@ -471,6 +470,12 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
     def unsubscribeInterface(self, prop):
         if self._consumer:
             self._consumer.unsubscribeInterface(prop)
+
+
+    def setDataType(self, data):
+        OpenRTM_aist.InPortConnector.setDataType(self, data)
+        if data is not None:
+            self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)
 
 
 ##

--- a/OpenRTM_aist/InPortDuplexConnector.py
+++ b/OpenRTM_aist/InPortDuplexConnector.py
@@ -474,8 +474,7 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
 
     def setDataType(self, data):
         OpenRTM_aist.InPortConnector.setDataType(self, data)
-        if data is not None:
-            self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)
+        self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)
 
 
 ##

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -416,5 +416,4 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
 
     def setDataType(self, data):
         OpenRTM_aist.InPortConnector.setDataType(self, data)
-        if data is not None:
-            self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)
+        self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -147,8 +147,7 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
             "in.marshaling_type", self._marshaling_type)
         self._marshaling_type = self._marshaling_type.strip()
 
-        self._serializer = OpenRTM_aist.SerializerFactory.instance(
-        ).createObject(self._marshaling_type)
+        self._serializer = None
 
         return
 
@@ -413,3 +412,9 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
     def unsubscribeInterface(self, prop):
         if self._consumer:
             self._consumer.unsubscribeInterface(prop)
+
+
+    def setDataType(self, data):
+        OpenRTM_aist.InPortConnector.setDataType(self, data)
+        if data is not None:
+            self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)

--- a/OpenRTM_aist/InPortPushConnector.py
+++ b/OpenRTM_aist/InPortPushConnector.py
@@ -522,9 +522,8 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
 
     def setDataType(self, data):
         OpenRTM_aist.InPortConnector.setDataType(self, data)
-        if data is not None:
-            self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(
-                self._marshaling_type, data)
+        self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(
+            self._marshaling_type, data)
 
     class WorkerThreadCtrl:
         def __init__(self):

--- a/OpenRTM_aist/InPortPushConnector.py
+++ b/OpenRTM_aist/InPortPushConnector.py
@@ -154,8 +154,7 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
             "in.marshaling_type", self._marshaling_type)
         self._marshaling_type = self._marshaling_type.strip()
 
-        self._serializer = OpenRTM_aist.SerializerFactory.instance(
-        ).createObject(self._marshaling_type)
+        self._serializer = None
 
         return
 
@@ -520,6 +519,12 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
             self._listeners.notify(
                 OpenRTM_aist.ConnectorListenerType.ON_BUFFER_READ_TIMEOUT, self._profile)
         return
+
+    def setDataType(self, data):
+        OpenRTM_aist.InPortConnector.setDataType(self, data)
+        if data is not None:
+            self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(
+                self._marshaling_type, data)
 
     class WorkerThreadCtrl:
         def __init__(self):

--- a/OpenRTM_aist/OutPort.py
+++ b/OpenRTM_aist/OutPort.py
@@ -101,6 +101,11 @@ class OutPort(OpenRTM_aist.OutPortBase):
         #self._OnUnderflow    = None
         #self._OnConnect      = None
         #self._OnDisconnect   = None
+
+        marshaling_types = OpenRTM_aist.SerializerFactories.instance().getSerializerList(value)
+        marshaling_types = OpenRTM_aist.flatten(marshaling_types).lstrip()
+        self.addProperty("dataport.marshaling_types", marshaling_types)
+
         self._listeners.setDataType(copy.deepcopy(value))
         self._listeners.setPortType(OpenRTM_aist.PortType.OutPortType)
         self.addConnectorDataListener(

--- a/OpenRTM_aist/OutPortBase.py
+++ b/OpenRTM_aist/OutPortBase.py
@@ -262,6 +262,7 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
         self._rtcout.RTC_DEBUG("available subscription_type: %s", pubs)
         self.addProperty("dataport.subscription_type", pubs)
         self.addProperty("dataport.io_mode", pubs)
+        self._value = None
 
         self._properties = OpenRTM_aist.Properties()
         self._name = name
@@ -272,26 +273,6 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
         self._connector_mutex = threading.RLock()
 
         self._properties.setProperty("data_type", data_type)
-
-        factory = OpenRTM_aist.SerializerFactory.instance()
-        serializer_list = factory.getIdentifiers()
-        ds = data_type.split(":")
-        marshaling_types = []
-        if len(ds) == 3:
-            data_name = ds[1]
-            for s in serializer_list:
-                s = s.lstrip()
-                v = s.split(":")
-                if len(v) == 3:
-                    if v[2] == data_name:
-                        marshaling_types.append(s)
-                else:
-                    marshaling_types.append(s)
-
-        marshaling_types = OpenRTM_aist.flatten(marshaling_types)
-        marshaling_types = marshaling_types.lstrip()
-        self._rtcout.RTC_DEBUG("available marshaling_types: %s", marshaling_types)
-        self.addProperty("dataport.marshaling_types", marshaling_types)
 
         self._listeners = OpenRTM_aist.ConnectorListeners()
         return
@@ -994,6 +975,7 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
             if not connector:
                 self._rtcout.RTC_ERROR("PullConnector creation failed.")
                 return RTC.RTC_ERROR
+            connector.setDataType(self._value)
 
             # connector set
             provider.setConnector(connector)
@@ -1014,6 +996,7 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
             if not connector:
                 self._rtcout.RTC_ERROR("DuplexConnector creation failed.")
                 return RTC.RTC_ERROR
+            connector.setDataType(self._value)
 
             # connector set
             provider.setConnector(connector)
@@ -1079,6 +1062,7 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
             connector = self.createConnector(cprof, prop, consumer_=consumer)
             if not connector:
                 return RTC.RTC_ERROR
+            connector.setDataType(self._value)
 
             ret = connector.setConnectorInfo(profile)
 
@@ -1117,6 +1101,7 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
             if not connector:
                 return RTC.RTC_ERROR
 
+            connector.setDataType(self._value)
             connector.setConsumer(consumer)
             ret = connector.setConnectorInfo(profile)
 

--- a/OpenRTM_aist/OutPortConnector.py
+++ b/OpenRTM_aist/OutPortConnector.py
@@ -60,6 +60,7 @@ class OutPortConnector(OpenRTM_aist.ConnectorBase):
         self._profile = info
         self._endian = True
         self._directMode = False
+        self._dataType = None
         return
 
     ##
@@ -272,3 +273,9 @@ class OutPortConnector(OpenRTM_aist.ConnectorBase):
     # @endif
     def unsubscribeInterface(self, prop):
         pass
+
+    # template<class DataType>
+    # void setDataTyep(DataType data);
+
+    def setDataType(self, data):
+        self._dataType = data

--- a/OpenRTM_aist/OutPortDuplexConnector.py
+++ b/OpenRTM_aist/OutPortDuplexConnector.py
@@ -463,8 +463,7 @@ class OutPortDuplexConnector(OpenRTM_aist.OutPortConnector):
 
     def setDataType(self, data):
         OpenRTM_aist.OutPortConnector.setDataType(self, data)
-        if data is not None:
-            self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)
+        self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)
 
 
 ##

--- a/OpenRTM_aist/OutPortDuplexConnector.py
+++ b/OpenRTM_aist/OutPortDuplexConnector.py
@@ -91,8 +91,7 @@ class OutPortDuplexConnector(OpenRTM_aist.OutPortConnector):
             "out.marshaling_type", self._marshaling_type)
         self._marshaling_type = self._marshaling_type.strip()
 
-        self._serializer = OpenRTM_aist.SerializerFactory.instance(
-        ).createObject(self._marshaling_type)
+        self._serializer = None
 
         self.onConnect()
 
@@ -460,6 +459,12 @@ class OutPortDuplexConnector(OpenRTM_aist.OutPortConnector):
     def unsubscribeInterface(self, prop):
         if self._consumer:
             self._consumer.unsubscribeInterface(prop)
+
+
+    def setDataType(self, data):
+        OpenRTM_aist.OutPortConnector.setDataType(self, data)
+        if data is not None:
+            self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)
 
 
 ##

--- a/OpenRTM_aist/OutPortPullConnector.py
+++ b/OpenRTM_aist/OutPortPullConnector.py
@@ -158,8 +158,7 @@ class OutPortPullConnector(OpenRTM_aist.OutPortConnector):
             "out.marshaling_type", self._marshaling_type)
         self._marshaling_type = self._marshaling_type.strip()
 
-        self._serializer = OpenRTM_aist.SerializerFactory.instance(
-        ).createObject(self._marshaling_type)
+        self._serializer = None
 
         return
 
@@ -417,6 +416,11 @@ class OutPortPullConnector(OpenRTM_aist.OutPortConnector):
     # void onDisconnect()
     def setDirectMode(self):
         self._directMode = True
+
+    def setDataType(self, data):
+        OpenRTM_aist.OutPortConnector.setDataType(self, data)
+        if data is not None:
+            self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)
 
     class WorkerThreadCtrl:
         def __init__(self):

--- a/OpenRTM_aist/OutPortPullConnector.py
+++ b/OpenRTM_aist/OutPortPullConnector.py
@@ -419,8 +419,7 @@ class OutPortPullConnector(OpenRTM_aist.OutPortConnector):
 
     def setDataType(self, data):
         OpenRTM_aist.OutPortConnector.setDataType(self, data)
-        if data is not None:
-            self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)
+        self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)
 
     class WorkerThreadCtrl:
         def __init__(self):

--- a/OpenRTM_aist/OutPortPushConnector.py
+++ b/OpenRTM_aist/OutPortPushConnector.py
@@ -519,5 +519,4 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
 
     def setDataType(self, data):
         OpenRTM_aist.OutPortConnector.setDataType(self, data)
-        if data is not None:
-            self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)
+        self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)

--- a/OpenRTM_aist/OutPortPushConnector.py
+++ b/OpenRTM_aist/OutPortPushConnector.py
@@ -177,8 +177,7 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
             "out.marshaling_type", self._marshaling_type)
         self._marshaling_type = self._marshaling_type.strip()
 
-        self._serializer = OpenRTM_aist.SerializerFactory.instance(
-        ).createObject(self._marshaling_type)
+        self._serializer = None
 
         self.onConnect()
         return
@@ -517,3 +516,8 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
     def unsubscribeInterface(self, prop):
         if self._consumer:
             self._consumer.unsubscribeInterface(prop)
+
+    def setDataType(self, data):
+        OpenRTM_aist.OutPortConnector.setDataType(self, data)
+        if data is not None:
+            self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)

--- a/OpenRTM_aist/examples/Serializer/ShortToDoubleSerializer.py
+++ b/OpenRTM_aist/examples/Serializer/ShortToDoubleSerializer.py
@@ -22,5 +22,5 @@ class ShortToDoubleSerializer(OpenRTM_aist.CORBA_CdrMemoryStream):
 
 
 def ShortToDoubleSerializerInit(mgr):
-    OpenRTM_aist.SerializerFactory.instance().addFactory("corba:RTC/TimedShort:RTC/TimedDouble",  # addFactory関数の第1引数で登録名を設定。以下で独自シリアライザを利用するときはこの名前を使用する。
-                                                         ShortToDoubleSerializer)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer(
+        "cdr:RTC/TimedShort:RTC/TimedDouble", ShortToDoubleSerializer, RTC.TimedDouble)  # addSerializer関数の第1引数で登録名を設定。独自シリアライザを利用するときはこの名前を使用する。

--- a/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceSerializer.py
+++ b/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceSerializer.py
@@ -195,7 +195,8 @@ class OpenSpliceSerializer(OpenRTM_aist.ByteDataStreamBase):
     # @endif
 
     def serialize(self, data):
-        info = OpenSpliceMessageInfo.OpenSpliceMessageInfoList.instance().getInfo(data._NP_RepositoryId)
+        info = OpenSpliceMessageInfo.OpenSpliceMessageInfoList.instance().getInfo(
+            data._NP_RepositoryId)
         if info:
             datatype = info.datatype()
             idlFile = info.idlFile()
@@ -263,8 +264,8 @@ def addDataType(datatype, idlfile):
     data_name = name.split(":")[1]
     data_name = data_name.replace("/", "::")
     OpenSpliceMessageInfo.OpenSpliceMessageInfoList.instance().addInfo(name,
-                                                            OpenSpliceMessageInfo.OpenSpliceMessageInfo(
-                                                            data_name, idlfile))
+                                                                       OpenSpliceMessageInfo.OpenSpliceMessageInfo(
+                                                                           data_name, idlfile))
 
 
 ##
@@ -279,8 +280,8 @@ def addDataType(datatype, idlfile):
 # @endif
 #
 def OpenSpliceSerializerInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("opensplice",
-                                                         OpenSpliceSerializer)
+    OpenRTM_aist.SerializerFactories.instance().addSerializerGlobal("opensplice",
+                                                                    OpenSpliceSerializer)
 
     OpenRTM_dir = OpenRTM_aist.__path__[0]
 
@@ -340,6 +341,7 @@ def OpenSpliceSerializerInit():
     addDataType(RTC.TimedCovariance3D, extendeddatatypes)
     addDataType(RTC.TimedSpeedHeading3D, extendeddatatypes)
     addDataType(RTC.TimedOAP, extendeddatatypes)
+    addDataType(RTC.TimedQuaternion, extendeddatatypes)
     addDataType(RTC.ActArrayActuatorPos, interfacedataTypes)
     addDataType(RTC.ActArrayActuatorSpeed, interfacedataTypes)
     addDataType(RTC.ActArrayActuatorCurrent, interfacedataTypes)

--- a/OpenRTM_aist/ext/transport/ROS2Transport/ROS2Serializer.py
+++ b/OpenRTM_aist/ext/transport/ROS2Transport/ROS2Serializer.py
@@ -227,12 +227,22 @@ def ros2_basic_data(message_type):
 
 
 def ROS2BasicDataInit(message_type, name):
-    OpenRTM_aist.SerializerFactory.instance().addFactory(name,
+    datatypes = [RTC.TimedState, RTC.TimedShort, RTC.TimedLong,
+                 RTC.TimedUShort, RTC.TimedULong, RTC.TimedFloat,
+                 RTC.TimedDouble, RTC.TimedChar, RTC.TimedWChar,
+                 RTC.TimedBoolean, RTC.TimedOctet, RTC.TimedString,
+                 RTC.TimedWString, RTC.TimedShortSeq, RTC.TimedLongSeq,
+                 RTC.TimedUShortSeq, RTC.TimedULongSeq, RTC.TimedFloatSeq,
+                 RTC.TimedDoubleSeq, RTC.TimedCharSeq, RTC.TimedWCharSeq,
+                 RTC.TimedBooleanSeq, RTC.TimedOctetSeq, RTC.TimedStringSeq,
+                 RTC.TimedWStringSeq]
+    for datatype in datatypes:
+        OpenRTM_aist.SerializerFactories.instance().addSerializer(name,
                                                          ros2_basic_data(
-                                                             message_type))
+                                                             message_type), datatype)
     ROS2MessageInfo.ROS2MessageInfoList.instance().addInfo(name,
-                                                                 ROS2MessageInfo.ROS2MessageInfo(
-                                                                     message_type))
+                                                           ROS2MessageInfo.ROS2MessageInfo(
+                                                               message_type))
 
 
 ##
@@ -375,11 +385,11 @@ class ROS2Point3DData(OpenRTM_aist.ByteDataStreamBase):
 # @endif
 #
 def ROS2Point3DInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("ros2:geometry_msgs/PointStamped",
-                                                         ROS2Point3DData)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer("ros2:geometry_msgs/PointStamped",
+                                                              ROS2Point3DData, RTC.TimedPoint3D)
     ROS2MessageInfo.ROS2MessageInfoList.instance().addInfo("ros2:geometry_msgs/PointStamped",
-                                                                 ROS2MessageInfo.ROS2MessageInfo(
-                                                                     PointStamped))
+                                                           ROS2MessageInfo.ROS2MessageInfo(
+                                                               PointStamped))
 
 
 ##
@@ -524,11 +534,11 @@ class ROS2QuaternionData(OpenRTM_aist.ByteDataStreamBase):
 # @endif
 #
 def ROS2QuaternionInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("ros2:geometry_msgs/QuaternionStamped",
-                                                         ROS2QuaternionData)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer("ros2:geometry_msgs/QuaternionStamped",
+                                                              ROS2QuaternionData, RTC.TimedQuaternion)
     ROS2MessageInfo.ROS2MessageInfoList.instance().addInfo("ros2:geometry_msgs/QuaternionStamped",
-                                                                 ROS2MessageInfo.ROS2MessageInfo(
-                                                                     QuaternionStamped))
+                                                           ROS2MessageInfo.ROS2MessageInfo(
+                                                               QuaternionStamped))
 
 
 ##
@@ -671,11 +681,11 @@ class ROS2Vector3DData(OpenRTM_aist.ByteDataStreamBase):
 # @endif
 #
 def ROS2Vector3DInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("ros2:geometry_msgs/Vector3Stamped",
-                                                         ROS2Vector3DData)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer("ros2:geometry_msgs/Vector3Stamped",
+                                                              ROS2Vector3DData, RTC.TimedVector3D)
     ROS2MessageInfo.ROS2MessageInfoList.instance().addInfo("ros2:geometry_msgs/Vector3Stamped",
-                                                                 ROS2MessageInfo.ROS2MessageInfo(
-                                                                     Vector3Stamped))
+                                                           ROS2MessageInfo.ROS2MessageInfo(
+                                                               Vector3Stamped))
 
 
 ##
@@ -824,11 +834,11 @@ class ROS2CameraImageData(OpenRTM_aist.ByteDataStreamBase):
 # @endif
 #
 def ROS2CameraImageInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("ros2:sensor_msgs/Image",
-                                                         ROS2CameraImageData)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer("ros2:sensor_msgs/Image",
+                                                              ROS2CameraImageData, RTC.CameraImage)
     ROS2MessageInfo.ROS2MessageInfoList.instance().addInfo("ros2:sensor_msgs/Image",
-                                                                 ROS2MessageInfo.ROS2MessageInfo(
-                                                                     Image))
+                                                           ROS2MessageInfo.ROS2MessageInfo(
+                                                               Image))
 
 
 ##

--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSSerializer.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSSerializer.py
@@ -18,6 +18,7 @@
 #
 
 import OpenRTM_aist
+import RTC
 
 try:
     from cStringIO import StringIO
@@ -88,7 +89,7 @@ def ros_serialize(msg):
     buf.write(struct.pack('<I', size))
     buf.seek(end)
     bdata = buf.getvalue()
-    
+
     return bdata
 
 
@@ -294,12 +295,22 @@ def ros_basic_data(message_type):
 
 
 def ROSBasicDataInit(message_type, name):
-    OpenRTM_aist.SerializerFactory.instance().addFactory(name,
-                                                         ros_basic_data(
-                                                             message_type))
+    datatypes = [RTC.TimedState, RTC.TimedShort, RTC.TimedLong,
+                 RTC.TimedUShort, RTC.TimedULong, RTC.TimedFloat,
+                 RTC.TimedDouble, RTC.TimedChar, RTC.TimedWChar,
+                 RTC.TimedBoolean, RTC.TimedOctet, RTC.TimedString,
+                 RTC.TimedWString, RTC.TimedShortSeq, RTC.TimedLongSeq,
+                 RTC.TimedUShortSeq, RTC.TimedULongSeq, RTC.TimedFloatSeq,
+                 RTC.TimedDoubleSeq, RTC.TimedCharSeq, RTC.TimedWCharSeq,
+                 RTC.TimedBooleanSeq, RTC.TimedOctetSeq, RTC.TimedStringSeq,
+                 RTC.TimedWStringSeq]
+    for datatype in datatypes:
+        OpenRTM_aist.SerializerFactories.instance().addSerializer(name,
+                                                                  ros_basic_data(
+                                                                      message_type), datatype)
     ROSMessageInfo.ROSMessageInfoList.instance().addInfo(name,
-                                                               ROSMessageInfo.ROSMessageInfo(
-                                                                   message_type))
+                                                         ROSMessageInfo.ROSMessageInfo(
+                                                             message_type))
 
 
 ##
@@ -446,11 +457,11 @@ class ROSPoint3DData(OpenRTM_aist.ByteDataStreamBase):
 # @endif
 #
 def ROSPoint3DInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("ros:geometry_msgs/PointStamped",
-                                                         ROSPoint3DData)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer("ros:geometry_msgs/PointStamped",
+                                                              ROSPoint3DData, RTC.TimedPoint3D)
     ROSMessageInfo.ROSMessageInfoList.instance().addInfo("ros:geometry_msgs/PointStamped",
-                                                               ROSMessageInfo.ROSMessageInfo(
-                                                                   PointStamped))
+                                                         ROSMessageInfo.ROSMessageInfo(
+                                                             PointStamped))
 
 
 ##
@@ -599,11 +610,11 @@ class ROSQuaternionData(OpenRTM_aist.ByteDataStreamBase):
 # @endif
 #
 def ROSQuaternionInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("ros:geometry_msgs/QuaternionStamped",
-                                                         ROSQuaternionData)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer("ros:geometry_msgs/QuaternionStamped",
+                                                              ROSQuaternionData, RTC.TimedQuaternion)
     ROSMessageInfo.ROSMessageInfoList.instance().addInfo("ros:geometry_msgs/QuaternionStamped",
-                                                               ROSMessageInfo.ROSMessageInfo(
-                                                                   QuaternionStamped))
+                                                         ROSMessageInfo.ROSMessageInfo(
+                                                             QuaternionStamped))
 
 
 ##
@@ -750,11 +761,11 @@ class ROSVector3DData(OpenRTM_aist.ByteDataStreamBase):
 # @endif
 #
 def ROSVector3DInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("ros:geometry_msgs/Vector3Stamped",
-                                                         ROSVector3DData)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer("ros:geometry_msgs/Vector3Stamped",
+                                                              ROSVector3DData, RTC.TimedVector3D)
     ROSMessageInfo.ROSMessageInfoList.instance().addInfo("ros:geometry_msgs/Vector3Stamped",
-                                                               ROSMessageInfo.ROSMessageInfo(
-                                                                   Vector3Stamped))
+                                                         ROSMessageInfo.ROSMessageInfo(
+                                                             Vector3Stamped))
 
 
 ##
@@ -908,11 +919,11 @@ class ROSCameraImageData(OpenRTM_aist.ByteDataStreamBase):
 # @endif
 #
 def ROSCameraImageInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("ros:sensor_msgs/Image",
-                                                         ROSCameraImageData)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer("ros:sensor_msgs/Image",
+                                                              ROSCameraImageData, RTC.CameraImage)
     ROSMessageInfo.ROSMessageInfoList.instance().addInfo("ros:sensor_msgs/Image",
-                                                               ROSMessageInfo.ROSMessageInfo(
-                                                                   Image))
+                                                         ROSMessageInfo.ROSMessageInfo(
+                                                             Image))
 
 
 ##


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

現状の実装ではデータ型ごとに使用できるシリアライザが区別できず、例えばTimedFloat型のデータポートで`ros2:sensor_msgs/Image`型が選択できたりする。

## Description of the Change

C++と同様にシリアライザ生成ファクトリを操作する以下の関数を実装した。

- `addSerializer`：シリアライザの登録(データ型指定)
- `removeSerializer`：シリアライザの登録解除(データ型指定)
- `createSerializer`：シリアライザの生成
- `getSerializerList`：使用可能なシリアライザの一覧取得

ファクトリはデータ型ごとに用意するようにした。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
