### PR TITLE
ROS2TransportのImage型、Int8MultiArray型の変換時の不具合修正

### DIFF
--- a/OpenRTM_aist/ByteDataStreamBase.py
+++ b/OpenRTM_aist/ByteDataStreamBase.py
@@ -22,12 +22,14 @@ import OpenRTM_aist
 
 ##
 # @if jp
-# @class
+# @class ByteDataStreamBase
 #
+# @brief シリアライザの基底クラス
 #
 # @else
-# @brief
+# @class ByteDataStreamBase
 #
+# @brief
 #
 # @endif
 class ByteDataStreamBase:
@@ -125,23 +127,270 @@ class ByteDataStreamBase:
         return ByteDataStreamBase.SERIALIZE_NOTFOUND, data_type
 
 
-serializerfactory = None
+serializerfactories = None
+globalserializerfactories = None
+
+##
+# @if jp
+# @class SerializerFactory
+#
+# @brief シリアライザを生成するファクトリ
+#
+# @else
+# @class SerializerFactory
+#
+# @brief
+#
+# @endif
 
 
 class SerializerFactory(OpenRTM_aist.Factory, ByteDataStreamBase):
+
+    ##
+    # @if jp
+    # @brief コンストラクタ
+    #
+    # コンストラクタ
+    #
+    # @param self
+    #
+    # @else
+    # @brief Constructor
+    #
+    # @param self
+    #
+    # @endif
     def __init__(self):
         OpenRTM_aist.Factory.__init__(self)
         pass
 
+    ##
+    # @if jp
+    # @brief デストラクタ
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @brief self
+    #
+    # @endif
     def __del__(self):
         pass
 
+##
+# @if jp
+# @class SerializerFactories
+#
+# @brief シリアライザ生成ファクトリの一覧を操作するクラス
+#
+# @else
+# @class SerializerFactories
+#
+# @brief
+#
+# @endif
+
+
+class SerializerFactories:
+    ##
+    # @if jp
+    # @brief コンストラクタ
+    #
+    # コンストラクタ
+    #
+    # @param self
+    #
+    # @else
+    # @brief Constructor
+    #
+    # @param self
+    #
+    # @endif
+    def __init__(self):
+        self._factories = {}
+
+    ##
+    # @if jp
+    # @brief デストラクタ
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @brief self
+    #
+    # @endif
+    def __del__(self):
+        pass
+
+    ##
+    # @if jp
+    # @brief シリアライザの登録(データ型ごと)
+    #
+    # @param self
+    # @param marshalingtype シリアライザの種類(文字列)
+    # @param serializer シリアライザを定義したクラス
+    # @param datatype 対象のデータ型のインスタンス、もしくはクラス
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @param self
+    # @param marshalingtype
+    # @param serializer
+    # @param datatype
+    #
+    # @endif
+    def addSerializer(self, marshalingtype, serializer, datatype):
+        mtype = OpenRTM_aist.toTypename(datatype)
+        if not (mtype in self._factories):
+            self._factories[mtype] = SerializerFactory()
+        self._factories[mtype].addFactory(marshalingtype,
+                                          serializer)
+
+    ##
+    # @if jp
+    # @brief シリアライザの登録(グローバル)
+    # 基本的にシリアライザはデータ型ごとに追加するが、
+    # CORBA CDR形式のシリアライザのように全てのデータ型で共通の
+    # 処理を行う場合はグローバルにシリアライザを登録できる。
+    # 特定のデータ型から特定のROSメッセージ型への変換が必要などという
+    # 場合はデータ型ごとの登録が必要である。
+    #
+    #
+    #
+    # @param self
+    # @param marshalingtype シリアライザの種類(文字列)
+    # @param serializer シリアライザを定義したクラス
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @param self
+    # @param marshalingtype
+    # @param serializer
+    #
+    # @endif
+    def addSerializerGlobal(self, marshalingtype, serializer):
+        globalserializerfactories.addFactory(marshalingtype,
+                                             serializer)
+    ##
+    # @if jp
+    # @brief シリアライザの登録解除(データ型ごと)
+    #
+    # @param self
+    # @param marshalingtype シリアライザの種類(文字列)
+    # @param datatype 対象のデータ型のインスタンス、もしくはクラス
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @param self
+    # @param marshalingtype
+    # @param datatype
+    #
+    # @endif
+
+    def removeSerializer(self, marshalingtype, datatype):
+        mtype = OpenRTM_aist.toTypename(datatype)
+        if mtype in self._factories:
+            self._factories[mtype].removeFactory(marshalingtype)
+
+    ##
+    # @if jp
+    # @brief シリアライザの登録解除(グローバル)
+    #
+    # @param self
+    # @param marshalingtype シリアライザの種類(文字列)
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @param self
+    # @param marshalingtype
+    #
+    # @endif
+    def removeSerializerGlobal(self, marshalingtype):
+        globalserializerfactories.removeFactory(marshalingtype)
+
+    ##
+    # @if jp
+    # @brief シリアライザの生成
+    #
+    # @param self
+    # @param marshalingtype シリアライザの種類(文字列)
+    # @param datatype 対象のデータ型のインスタンス、もしくはクラス
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @param self
+    # @param marshalingtype
+    # @param datatype
+    #
+    # @endif
+    def createSerializer(self, marshalingtype, datatype=None):
+        if datatype is not None:
+            mtype = OpenRTM_aist.toTypename(datatype)
+            if mtype in self._factories:
+                obj = self._factories[mtype].createObject(marshalingtype)
+                if obj is not None:
+                    return obj
+        obj = globalserializerfactories.createObject(marshalingtype)
+        if obj is not None:
+            return obj
+        return None
+
+    ##
+    # @if jp
+    # @brief 使用可能なシリアライザ一覧の取得
+    #
+    # @param self
+    # @param datatype 対象のデータ型のインスタンス、もしくはクラス
+    #
+    #
+    # @param self
+    #
+    # @else
+    #
+    # @param self
+    # @param datatype
+    #
+    # @endif
+    def getSerializerList(self, datatype):
+        if datatype is not None:
+            available_types = []
+            mtype = OpenRTM_aist.toTypename(datatype)
+            if mtype in self._factories:
+                factory = self._factories[mtype]
+                available_types.extend(factory.getIdentifiers())
+
+        available_types.extend(globalserializerfactories.getIdentifiers())
+
+        return available_types
+
     def instance():
-        global serializerfactory
+        global serializerfactories
+        global globalserializerfactories
 
-        if serializerfactory is None:
-            serializerfactory = SerializerFactory()
+        if serializerfactories is None:
+            serializerfactories = SerializerFactories()
+        if globalserializerfactories is None:
+            globalserializerfactories = SerializerFactory()
 
-        return serializerfactory
+        return serializerfactories
 
     instance = staticmethod(instance)

--- a/OpenRTM_aist/CORBA_CdrMemoryStream.py
+++ b/OpenRTM_aist/CORBA_CdrMemoryStream.py
@@ -25,12 +25,14 @@ from omniORB import any
 
 ##
 # @if jp
-# @class
+# @class CORBA_CdrMemoryStream
 #
+# @brief CORBAのCDR形式シリアライザ、デシリアライザを定義
 #
 # @else
-# @brief
+# @class CORBA_CdrMemoryStream
 #
+# @brief
 #
 # @endif
 
@@ -181,5 +183,6 @@ class CORBA_CdrMemoryStream(OpenRTM_aist.ByteDataStreamBase):
 
 
 def CORBA_CdrMemoryStreamInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("cdr",
-                                                         OpenRTM_aist.CORBA_CdrMemoryStream)
+    OpenRTM_aist.SerializerFactories.instance().addSerializerGlobal("cdr",
+                                                                    CORBA_CdrMemoryStream)
+

--- a/OpenRTM_aist/ConnectorListener.py
+++ b/OpenRTM_aist/ConnectorListener.py
@@ -355,11 +355,12 @@ class ConnectorDataListenerT(ConnectorDataListener):
                 "inport.marshaling_type", marshaling_type)
         marshaling_type = marshaling_type.strip()
 
-        serializer = OpenRTM_aist.SerializerFactory.instance().createObject(marshaling_type)
+        serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(marshaling_type, data)
+        if serializer is not None:
+            serializer.isLittleEndian(endian)
+            ret, data = serializer.deserialize(cdrdata, data)
 
-        serializer.isLittleEndian(endian)
-        ret, data = serializer.deserialize(cdrdata, data)
-
+            return data
         return data
 
 
@@ -805,7 +806,7 @@ class ConnectorDataListenerHolder:
                 "inport.marshaling_type", marshaling_type)
         marshaling_type = marshaling_type.strip()
 
-        serializer = OpenRTM_aist.SerializerFactory.instance().createObject(marshaling_type)
+        serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(marshaling_type, self._data)
 
         data = self._data
         if serializer is not None:

--- a/OpenRTM_aist/InPort.py
+++ b/OpenRTM_aist/InPort.py
@@ -94,6 +94,10 @@ class InPort(OpenRTM_aist.InPortBase):
         self._directNewData = False
         self._valueMutex = threading.RLock()
 
+        marshaling_types = OpenRTM_aist.SerializerFactories.instance().getSerializerList(value)
+        marshaling_types = OpenRTM_aist.flatten(marshaling_types).lstrip()
+        self.addProperty("dataport.marshaling_types", marshaling_types)
+
         self._listeners.setDataType(copy.deepcopy(value))
         self._listeners.setPortType(OpenRTM_aist.PortType.InPortType)
 

--- a/OpenRTM_aist/InPortBase.py
+++ b/OpenRTM_aist/InPortBase.py
@@ -105,26 +105,6 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
         self.addProperty("dataport.data_type", data_type)
         self._properties.setProperty("data_type", data_type)
 
-        factory = OpenRTM_aist.SerializerFactory.instance()
-        serializer_list = factory.getIdentifiers()
-        ds = data_type.split(":")
-        marshaling_types = []
-        if len(ds) == 3:
-            data_name = ds[1]
-            for s in serializer_list:
-                s = s.lstrip()
-                v = s.split(":")
-                if len(v) == 3:
-                    if v[2] == data_name:
-                        marshaling_types.append(s)
-                else:
-                    marshaling_types.append(s)
-
-        marshaling_types = OpenRTM_aist.flatten(marshaling_types)
-        marshaling_types = marshaling_types.lstrip()
-        self._rtcout.RTC_DEBUG("available marshaling_types: %s", marshaling_types)
-        self.addProperty("dataport.marshaling_types", marshaling_types)
-
         self.addProperty("dataport.subscription_type", "Any")
         self._value = None
         self._listeners = OpenRTM_aist.ConnectorListeners()

--- a/OpenRTM_aist/InPortDuplexConnector.py
+++ b/OpenRTM_aist/InPortDuplexConnector.py
@@ -83,8 +83,7 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
             "marshaling_type", "cdr")
         self._marshaling_type = self._marshaling_type.strip()
 
-        self._serializer = OpenRTM_aist.SerializerFactory.instance(
-        ).createObject(self._marshaling_type)
+        self._serializer = None
 
         return
 
@@ -469,6 +468,11 @@ class InPortDuplexConnector(OpenRTM_aist.InPortConnector):
     def unsubscribeInterface(self, prop):
         if self._consumer:
             self._consumer.unsubscribeInterface(prop)
+
+
+    def setDataType(self, data):
+        OpenRTM_aist.InPortConnector.setDataType(self, data)
+        self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)
 
 
 ##

--- a/OpenRTM_aist/InPortPullConnector.py
+++ b/OpenRTM_aist/InPortPullConnector.py
@@ -145,8 +145,7 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
             "marshaling_type", "cdr")
         self._marshaling_type = self._marshaling_type.strip()
 
-        self._serializer = OpenRTM_aist.SerializerFactory.instance(
-        ).createObject(self._marshaling_type)
+        self._serializer = None
 
         return
 
@@ -411,3 +410,8 @@ class InPortPullConnector(OpenRTM_aist.InPortConnector):
     def unsubscribeInterface(self, prop):
         if self._consumer:
             self._consumer.unsubscribeInterface(prop)
+
+
+    def setDataType(self, data):
+        OpenRTM_aist.InPortConnector.setDataType(self, data)
+        self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)

--- a/OpenRTM_aist/InPortPushConnector.py
+++ b/OpenRTM_aist/InPortPushConnector.py
@@ -152,8 +152,7 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
             "marshaling_type", "cdr")
         self._marshaling_type = self._marshaling_type.strip()
 
-        self._serializer = OpenRTM_aist.SerializerFactory.instance(
-        ).createObject(self._marshaling_type)
+        self._serializer = None
 
         return
 
@@ -518,6 +517,11 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
             self._listeners.notify(
                 OpenRTM_aist.ConnectorListenerType.ON_BUFFER_READ_TIMEOUT, self._profile)
         return
+
+    def setDataType(self, data):
+        OpenRTM_aist.InPortConnector.setDataType(self, data)
+        self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(
+            self._marshaling_type, data)
 
     class WorkerThreadCtrl:
         def __init__(self):

--- a/OpenRTM_aist/OutPort.py
+++ b/OpenRTM_aist/OutPort.py
@@ -101,6 +101,11 @@ class OutPort(OpenRTM_aist.OutPortBase):
         #self._OnUnderflow    = None
         #self._OnConnect      = None
         #self._OnDisconnect   = None
+
+        marshaling_types = OpenRTM_aist.SerializerFactories.instance().getSerializerList(value)
+        marshaling_types = OpenRTM_aist.flatten(marshaling_types).lstrip()
+        self.addProperty("dataport.marshaling_types", marshaling_types)
+
         self._listeners.setDataType(copy.deepcopy(value))
         self._listeners.setPortType(OpenRTM_aist.PortType.OutPortType)
         self.addConnectorDataListener(

--- a/OpenRTM_aist/OutPortBase.py
+++ b/OpenRTM_aist/OutPortBase.py
@@ -262,6 +262,7 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
         self._rtcout.RTC_DEBUG("available subscription_type: %s", pubs)
         self.addProperty("dataport.subscription_type", pubs)
         self.addProperty("dataport.io_mode", pubs)
+        self._value = None
 
         self._properties = OpenRTM_aist.Properties()
         self._name = name
@@ -272,26 +273,6 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
         self._connector_mutex = threading.RLock()
 
         self._properties.setProperty("data_type", data_type)
-
-        factory = OpenRTM_aist.SerializerFactory.instance()
-        serializer_list = factory.getIdentifiers()
-        ds = data_type.split(":")
-        marshaling_types = []
-        if len(ds) == 3:
-            data_name = ds[1]
-            for s in serializer_list:
-                s = s.lstrip()
-                v = s.split(":")
-                if len(v) == 3:
-                    if v[2] == data_name:
-                        marshaling_types.append(s)
-                else:
-                    marshaling_types.append(s)
-
-        marshaling_types = OpenRTM_aist.flatten(marshaling_types)
-        marshaling_types = marshaling_types.lstrip()
-        self._rtcout.RTC_DEBUG("available marshaling_types: %s", marshaling_types)
-        self.addProperty("dataport.marshaling_types", marshaling_types)
 
         self._listeners = OpenRTM_aist.ConnectorListeners()
         return
@@ -994,6 +975,7 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
             if not connector:
                 self._rtcout.RTC_ERROR("PullConnector creation failed.")
                 return RTC.RTC_ERROR
+            connector.setDataType(self._value)
 
             # connector set
             provider.setConnector(connector)
@@ -1014,6 +996,7 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
             if not connector:
                 self._rtcout.RTC_ERROR("DuplexConnector creation failed.")
                 return RTC.RTC_ERROR
+            connector.setDataType(self._value)
 
             # connector set
             provider.setConnector(connector)
@@ -1079,6 +1062,7 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
             connector = self.createConnector(cprof, prop, consumer_=consumer)
             if not connector:
                 return RTC.RTC_ERROR
+            connector.setDataType(self._value)
 
             ret = connector.setConnectorInfo(profile)
 
@@ -1117,6 +1101,7 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
             if not connector:
                 return RTC.RTC_ERROR
 
+            connector.setDataType(self._value)
             connector.setConsumer(consumer)
             ret = connector.setConnectorInfo(profile)
 

--- a/OpenRTM_aist/OutPortConnector.py
+++ b/OpenRTM_aist/OutPortConnector.py
@@ -60,6 +60,7 @@ class OutPortConnector(OpenRTM_aist.ConnectorBase):
         self._profile = info
         self._endian = True
         self._directMode = False
+        self._dataType = None
         return
 
     ##
@@ -272,3 +273,9 @@ class OutPortConnector(OpenRTM_aist.ConnectorBase):
     # @endif
     def unsubscribeInterface(self, prop):
         pass
+
+    # template<class DataType>
+    # void setDataTyep(DataType data);
+
+    def setDataType(self, data):
+        self._dataType = data

--- a/OpenRTM_aist/OutPortDuplexConnector.py
+++ b/OpenRTM_aist/OutPortDuplexConnector.py
@@ -89,8 +89,7 @@ class OutPortDuplexConnector(OpenRTM_aist.OutPortConnector):
             "marshaling_type", "cdr")
         self._marshaling_type = self._marshaling_type.strip()
 
-        self._serializer = OpenRTM_aist.SerializerFactory.instance(
-        ).createObject(self._marshaling_type)
+        self._serializer = None
 
         self.onConnect()
 
@@ -458,6 +457,11 @@ class OutPortDuplexConnector(OpenRTM_aist.OutPortConnector):
     def unsubscribeInterface(self, prop):
         if self._consumer:
             self._consumer.unsubscribeInterface(prop)
+
+
+    def setDataType(self, data):
+        OpenRTM_aist.OutPortConnector.setDataType(self, data)
+        self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)
 
 
 ##

--- a/OpenRTM_aist/OutPortPullConnector.py
+++ b/OpenRTM_aist/OutPortPullConnector.py
@@ -156,8 +156,7 @@ class OutPortPullConnector(OpenRTM_aist.OutPortConnector):
             "marshaling_type", "cdr")
         self._marshaling_type = self._marshaling_type.strip()
 
-        self._serializer = OpenRTM_aist.SerializerFactory.instance(
-        ).createObject(self._marshaling_type)
+        self._serializer = None
 
         return
 
@@ -415,6 +414,10 @@ class OutPortPullConnector(OpenRTM_aist.OutPortConnector):
     # void onDisconnect()
     def setDirectMode(self):
         self._directMode = True
+
+    def setDataType(self, data):
+        OpenRTM_aist.OutPortConnector.setDataType(self, data)
+        self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)
 
     class WorkerThreadCtrl:
         def __init__(self):

--- a/OpenRTM_aist/OutPortPushConnector.py
+++ b/OpenRTM_aist/OutPortPushConnector.py
@@ -175,8 +175,7 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
             "marshaling_type", "cdr")
         self._marshaling_type = self._marshaling_type.strip()
 
-        self._serializer = OpenRTM_aist.SerializerFactory.instance(
-        ).createObject(self._marshaling_type)
+        self._serializer = None
 
         self.onConnect()
         return
@@ -515,3 +514,7 @@ class OutPortPushConnector(OpenRTM_aist.OutPortConnector):
     def unsubscribeInterface(self, prop):
         if self._consumer:
             self._consumer.unsubscribeInterface(prop)
+
+    def setDataType(self, data):
+        OpenRTM_aist.OutPortConnector.setDataType(self, data)
+        self._serializer = OpenRTM_aist.SerializerFactories.instance().createSerializer(self._marshaling_type, data)

--- a/OpenRTM_aist/examples/Serializer/ShortToDoubleSerializer.py
+++ b/OpenRTM_aist/examples/Serializer/ShortToDoubleSerializer.py
@@ -22,5 +22,5 @@ class ShortToDoubleSerializer(OpenRTM_aist.CORBA_CdrMemoryStream):
 
 
 def ShortToDoubleSerializerInit(mgr):
-    OpenRTM_aist.SerializerFactory.instance().addFactory("cdr:RTC/TimedShort:RTC/TimedDouble",  # addFactory関数の第1引数で登録名を設定。以下で独自シリアライザを利用するときはこの名前を使用する。
-                                                         ShortToDoubleSerializer)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer(
+        "cdr:RTC/TimedShort:RTC/TimedDouble", ShortToDoubleSerializer, RTC.TimedDouble)  # addSerializer関数の第1引数で登録名を設定。独自シリアライザを利用するときはこの名前を使用する。

--- a/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceSerializer.py
+++ b/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceSerializer.py
@@ -195,7 +195,8 @@ class OpenSpliceSerializer(OpenRTM_aist.ByteDataStreamBase):
     # @endif
 
     def serialize(self, data):
-        info = OpenSpliceMessageInfo.OpenSpliceMessageInfoList.instance().getInfo(data._NP_RepositoryId)
+        info = OpenSpliceMessageInfo.OpenSpliceMessageInfoList.instance().getInfo(
+            data._NP_RepositoryId)
         if info:
             datatype = info.datatype()
             idlFile = info.idlFile()
@@ -263,8 +264,8 @@ def addDataType(datatype, idlfile):
     data_name = name.split(":")[1]
     data_name = data_name.replace("/", "::")
     OpenSpliceMessageInfo.OpenSpliceMessageInfoList.instance().addInfo(name,
-                                                            OpenSpliceMessageInfo.OpenSpliceMessageInfo(
-                                                            data_name, idlfile))
+                                                                       OpenSpliceMessageInfo.OpenSpliceMessageInfo(
+                                                                           data_name, idlfile))
 
 
 ##
@@ -279,8 +280,8 @@ def addDataType(datatype, idlfile):
 # @endif
 #
 def OpenSpliceSerializerInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("opensplice",
-                                                         OpenSpliceSerializer)
+    OpenRTM_aist.SerializerFactories.instance().addSerializerGlobal("opensplice",
+                                                                    OpenSpliceSerializer)
 
     OpenRTM_dir = OpenRTM_aist.__path__[0]
 
@@ -340,6 +341,7 @@ def OpenSpliceSerializerInit():
     addDataType(RTC.TimedCovariance3D, extendeddatatypes)
     addDataType(RTC.TimedSpeedHeading3D, extendeddatatypes)
     addDataType(RTC.TimedOAP, extendeddatatypes)
+    addDataType(RTC.TimedQuaternion, extendeddatatypes)
     addDataType(RTC.ActArrayActuatorPos, interfacedataTypes)
     addDataType(RTC.ActArrayActuatorSpeed, interfacedataTypes)
     addDataType(RTC.ActArrayActuatorCurrent, interfacedataTypes)

--- a/OpenRTM_aist/ext/transport/ROS2Transport/ROS2InPort.py
+++ b/OpenRTM_aist/ext/transport/ROS2Transport/ROS2InPort.py
@@ -147,7 +147,8 @@ class ROS2InPort(OpenRTM_aist.InPortProvider):
         args = []
         self._topicmgr = ROS2TopicManager.instance(args)
 
-        self._messageType = prop.getProperty("marshaling_type", "ROS2Float32")
+        self._messageType = prop.getProperty(
+            "marshaling_type", "ros2:std_msgs/Float32")
         self._topic = prop.getProperty("ros2.topic", "chatter")
 
         self._rtcout.RTC_VERBOSE("message type: %s", self._messageType)

--- a/OpenRTM_aist/ext/transport/ROS2Transport/ROS2OutPort.py
+++ b/OpenRTM_aist/ext/transport/ROS2Transport/ROS2OutPort.py
@@ -117,7 +117,8 @@ class ROS2OutPort(OpenRTM_aist.InPortConsumer):
         args = []
         self._topicmgr = ROS2TopicManager.instance(args)
 
-        self._messageType = prop.getProperty("marshaling_type", "ROSFloat32")
+        self._messageType = prop.getProperty(
+            "marshaling_type", "ros2:std_msgs/Float32")
         self._topic = prop.getProperty("ros2.topic", "chatter")
 
         self._rtcout.RTC_VERBOSE("message type: %s", self._messageType)

--- a/OpenRTM_aist/ext/transport/ROS2Transport/ROS2Serializer.py
+++ b/OpenRTM_aist/ext/transport/ROS2Transport/ROS2Serializer.py
@@ -21,6 +21,7 @@ import OpenRTM_aist
 import omniORB
 
 import struct
+import array
 import ROS2MessageInfo
 import RTC
 import rclpy
@@ -196,9 +197,15 @@ def ros2_basic_data(message_type):
         def deserialize(self, bdata, data_type):
             try:
                 if isinstance(data_type.data, bytes):
-                    data_type.data = bytes(bdata.data)
+                    if isinstance(bdata.data, array.array):
+                        data_type.data = bdata.data.tobytes()
+                    else:
+                        data_type.data = bytes(bdata.data)
                 elif isinstance(data_type.data, str):
-                    data_type.data = str(bdata.data)
+                    if isinstance(bdata.data, array.array):
+                        data_type.data = bdata.data.tostring()
+                    else:
+                        data_type.data = str(bdata.data)
                 elif isinstance(data_type.data, list):
                     data_type.data = list(bdata.data)
                 elif isinstance(data_type.data, tuple):
@@ -822,7 +829,7 @@ class ROS2CameraImageData(OpenRTM_aist.ByteDataStreamBase):
             data_type.height = bdata.height
             data_type.width = bdata.width
             data_type.format = bdata.encoding
-            data_type.pixels = bdata.data
+            data_type.pixels = bdata.data.tobytes()
             return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK, data_type
         except BaseException:
             return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN, data_type

--- a/OpenRTM_aist/ext/transport/ROS2Transport/ROS2Serializer.py
+++ b/OpenRTM_aist/ext/transport/ROS2Transport/ROS2Serializer.py
@@ -154,18 +154,20 @@ def ros2_basic_data(message_type):
         def serialize(self, data):
             msg = message_type()
             field_type = msg.get_fields_and_field_types()["data"]
-            if field_type == "int8" or field_type == "int16" or field_type == "int32" or field_type == "int64":
+            if field_type == "int" or field_type == "int8" or field_type == "int16" or field_type == "int32" or field_type == "int64":
                 msg.data = int(data.data)
-            elif field_type == "uint8" or field_type == "uint16" or field_type == "uint32" or field_type == "uint64":
+            elif field_type == "uint" or field_type == "uint8" or field_type == "uint16" or field_type == "uint32" or field_type == "uint64":
                 msg.data = int(data.data)
-            elif field_type == "float32" or field_type == "float64":
+            elif field_type == "float" or field_type == "double" or field_type == "float32" or field_type == "float64":
                 msg.data = float(data.data)
-            elif field_type == "int8[]" or field_type == "int16[]" or field_type == "int32[]" or field_type == "int64[]":
+            elif field_type == "sequence<int8>" or field_type == "sequence<int16>" or field_type == "sequence<int32>" or field_type == "sequence<int64>" or field_type == "int8[]" or field_type == "int16[]" or field_type == "int32[]" or field_type == "int64[]":
                 msg.data = list(map(int, data.data))
-            elif field_type == "uint8[]" or field_type == "uint16[]" or field_type == "uint32[]" or field_type == "uint64[]":
+            elif field_type == "sequence<uint8>" or field_type == "sequence<uint16>" or field_type == "sequence<uint32>" or field_type == "sequence<uint64>" or field_type == "uint8[]" or field_type == "uint16[]" or field_type == "uint32[]" or field_type == "uint64[]":
                 msg.data = list(map(int, data.data))
-            elif field_type == "float32[]" or field_type == "float64[]":
+            elif field_type == "sequence<float>" or field_type == "sequence<double>" or field_type == "float32[]" or field_type == "float64[]":
                 msg.data = list(map(float, data.data))
+            elif field_type == "string":
+                msg.data = str(data.data)
             else:
                 msg.data = data.data
 
@@ -201,6 +203,10 @@ def ros2_basic_data(message_type):
                     data_type.data = list(bdata.data)
                 elif isinstance(data_type.data, tuple):
                     data_type.data = tuple(bdata.data)
+                elif isinstance(data_type.data, int):
+                    data_type.data = int(bdata.data)
+                elif isinstance(data_type.data, float):
+                    data_type.data = float(bdata.data)
                 else:
                     data_type.data = bdata.data
                 return OpenRTM_aist.ByteDataStreamBase.SERIALIZE_OK, data_type

--- a/OpenRTM_aist/ext/transport/ROS2Transport/ROS2Serializer.py
+++ b/OpenRTM_aist/ext/transport/ROS2Transport/ROS2Serializer.py
@@ -227,12 +227,22 @@ def ros2_basic_data(message_type):
 
 
 def ROS2BasicDataInit(message_type, name):
-    OpenRTM_aist.SerializerFactory.instance().addFactory(name,
+    datatypes = [RTC.TimedState, RTC.TimedShort, RTC.TimedLong,
+                 RTC.TimedUShort, RTC.TimedULong, RTC.TimedFloat,
+                 RTC.TimedDouble, RTC.TimedChar, RTC.TimedWChar,
+                 RTC.TimedBoolean, RTC.TimedOctet, RTC.TimedString,
+                 RTC.TimedWString, RTC.TimedShortSeq, RTC.TimedLongSeq,
+                 RTC.TimedUShortSeq, RTC.TimedULongSeq, RTC.TimedFloatSeq,
+                 RTC.TimedDoubleSeq, RTC.TimedCharSeq, RTC.TimedWCharSeq,
+                 RTC.TimedBooleanSeq, RTC.TimedOctetSeq, RTC.TimedStringSeq,
+                 RTC.TimedWStringSeq]
+    for datatype in datatypes:
+        OpenRTM_aist.SerializerFactories.instance().addSerializer(name,
                                                          ros2_basic_data(
-                                                             message_type))
+                                                             message_type), datatype)
     ROS2MessageInfo.ROS2MessageInfoList.instance().addInfo(name,
-                                                                 ROS2MessageInfo.ROS2MessageInfo(
-                                                                     message_type))
+                                                           ROS2MessageInfo.ROS2MessageInfo(
+                                                               message_type))
 
 
 ##
@@ -375,11 +385,11 @@ class ROS2Point3DData(OpenRTM_aist.ByteDataStreamBase):
 # @endif
 #
 def ROS2Point3DInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("ros2:geometry_msgs/PointStamped",
-                                                         ROS2Point3DData)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer("ros2:geometry_msgs/PointStamped",
+                                                              ROS2Point3DData, RTC.TimedPoint3D)
     ROS2MessageInfo.ROS2MessageInfoList.instance().addInfo("ros2:geometry_msgs/PointStamped",
-                                                                 ROS2MessageInfo.ROS2MessageInfo(
-                                                                     PointStamped))
+                                                           ROS2MessageInfo.ROS2MessageInfo(
+                                                               PointStamped))
 
 
 ##
@@ -524,11 +534,11 @@ class ROS2QuaternionData(OpenRTM_aist.ByteDataStreamBase):
 # @endif
 #
 def ROS2QuaternionInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("ros2:geometry_msgs/QuaternionStamped",
-                                                         ROS2QuaternionData)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer("ros2:geometry_msgs/QuaternionStamped",
+                                                              ROS2QuaternionData, RTC.TimedQuaternion)
     ROS2MessageInfo.ROS2MessageInfoList.instance().addInfo("ros2:geometry_msgs/QuaternionStamped",
-                                                                 ROS2MessageInfo.ROS2MessageInfo(
-                                                                     QuaternionStamped))
+                                                           ROS2MessageInfo.ROS2MessageInfo(
+                                                               QuaternionStamped))
 
 
 ##
@@ -671,11 +681,11 @@ class ROS2Vector3DData(OpenRTM_aist.ByteDataStreamBase):
 # @endif
 #
 def ROS2Vector3DInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("ros2:geometry_msgs/Vector3Stamped",
-                                                         ROS2Vector3DData)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer("ros2:geometry_msgs/Vector3Stamped",
+                                                              ROS2Vector3DData, RTC.TimedVector3D)
     ROS2MessageInfo.ROS2MessageInfoList.instance().addInfo("ros2:geometry_msgs/Vector3Stamped",
-                                                                 ROS2MessageInfo.ROS2MessageInfo(
-                                                                     Vector3Stamped))
+                                                           ROS2MessageInfo.ROS2MessageInfo(
+                                                               Vector3Stamped))
 
 
 ##
@@ -824,11 +834,11 @@ class ROS2CameraImageData(OpenRTM_aist.ByteDataStreamBase):
 # @endif
 #
 def ROS2CameraImageInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("ros2:sensor_msgs/Image",
-                                                         ROS2CameraImageData)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer("ros2:sensor_msgs/Image",
+                                                              ROS2CameraImageData, RTC.CameraImage)
     ROS2MessageInfo.ROS2MessageInfoList.instance().addInfo("ros2:sensor_msgs/Image",
-                                                                 ROS2MessageInfo.ROS2MessageInfo(
-                                                                     Image))
+                                                           ROS2MessageInfo.ROS2MessageInfo(
+                                                               Image))
 
 
 ##

--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSInPort.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSInPort.py
@@ -91,7 +91,7 @@ class ROSInPort(OpenRTM_aist.InPortProvider):
 
         self._topic = "chatter"
         self._callerid = ""
-        self._messageType = "ROSFloat32"
+        self._messageType = "ros:std_msgs/Float32"
         self._roscorehost = "localhost"
         self._roscoreport = "11311"
 
@@ -218,7 +218,8 @@ class ROSInPort(OpenRTM_aist.InPortProvider):
             self._rtcout.RTC_VERBOSE("Subscriber already exists.")
             return
 
-        self._messageType = prop.getProperty("marshaling_type", "ROSFloat32")
+        self._messageType = prop.getProperty(
+            "marshaling_type", "ros:std_msgs/Float32")
         self._topic = prop.getProperty("ros.topic", "chatter")
         self._topic = "/" + self._topic
         self._roscorehost = prop.getProperty("ros.roscore.host", "localhost")

--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSOutPort.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSOutPort.py
@@ -224,7 +224,7 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
             self._rtcout.RTC_DEBUG("read ROS handshake exception")
             return
         except BaseException:
-            print(traceback.format_exc())
+            self._rtcout.RTC_ERROR(OpenRTM_aist.Logger.print_exception())
 
         topic_name = header['topic']
         md5sum = header['md5sum']
@@ -284,7 +284,7 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
         try:
             write_ros_handshake_header(client_sock, fields)
         except rosgraph.network.ROSHandshakeException:
-            self._rtcout.RTC_DEBUG("write ROS handshake exception")
+            self._rtcout.RTC_ERROR("write ROS handshake exception")
             return
         if poller:
             poller.unregister(fileno)

--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSOutPort.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSOutPort.py
@@ -71,7 +71,7 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
         self._rtcout = OpenRTM_aist.Manager.instance().getLogbuf("ROSOutPort")
         self._properties = None
         self._callerid = ""
-        self._messageType = "ROSFloat32"
+        self._messageType = "ros:std_msgs/Float32"
         self._topic = "chatter"
         self._roscorehost = "localhost"
         self._roscoreport = "11311"
@@ -138,7 +138,8 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
 
         self._properties = prop
 
-        self._messageType = prop.getProperty("marshaling_type", "ROSFloat32")
+        self._messageType = prop.getProperty(
+            "marshaling_type", "ros:std_msgs/Float32")
         self._topic = prop.getProperty("ros.topic", "chatter")
         self._topic = "/" + self._topic
         self._roscorehost = prop.getProperty("ros.roscore.host", "localhost")

--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSSerializer.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSSerializer.py
@@ -18,6 +18,7 @@
 #
 
 import OpenRTM_aist
+import RTC
 
 try:
     from cStringIO import StringIO
@@ -88,7 +89,7 @@ def ros_serialize(msg):
     buf.write(struct.pack('<I', size))
     buf.seek(end)
     bdata = buf.getvalue()
-    
+
     return bdata
 
 
@@ -294,12 +295,22 @@ def ros_basic_data(message_type):
 
 
 def ROSBasicDataInit(message_type, name):
-    OpenRTM_aist.SerializerFactory.instance().addFactory(name,
-                                                         ros_basic_data(
-                                                             message_type))
+    datatypes = [RTC.TimedState, RTC.TimedShort, RTC.TimedLong,
+                 RTC.TimedUShort, RTC.TimedULong, RTC.TimedFloat,
+                 RTC.TimedDouble, RTC.TimedChar, RTC.TimedWChar,
+                 RTC.TimedBoolean, RTC.TimedOctet, RTC.TimedString,
+                 RTC.TimedWString, RTC.TimedShortSeq, RTC.TimedLongSeq,
+                 RTC.TimedUShortSeq, RTC.TimedULongSeq, RTC.TimedFloatSeq,
+                 RTC.TimedDoubleSeq, RTC.TimedCharSeq, RTC.TimedWCharSeq,
+                 RTC.TimedBooleanSeq, RTC.TimedOctetSeq, RTC.TimedStringSeq,
+                 RTC.TimedWStringSeq]
+    for datatype in datatypes:
+        OpenRTM_aist.SerializerFactories.instance().addSerializer(name,
+                                                                  ros_basic_data(
+                                                                      message_type), datatype)
     ROSMessageInfo.ROSMessageInfoList.instance().addInfo(name,
-                                                               ROSMessageInfo.ROSMessageInfo(
-                                                                   message_type))
+                                                         ROSMessageInfo.ROSMessageInfo(
+                                                             message_type))
 
 
 ##
@@ -446,11 +457,11 @@ class ROSPoint3DData(OpenRTM_aist.ByteDataStreamBase):
 # @endif
 #
 def ROSPoint3DInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("ros:geometry_msgs/PointStamped",
-                                                         ROSPoint3DData)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer("ros:geometry_msgs/PointStamped",
+                                                              ROSPoint3DData, RTC.TimedPoint3D)
     ROSMessageInfo.ROSMessageInfoList.instance().addInfo("ros:geometry_msgs/PointStamped",
-                                                               ROSMessageInfo.ROSMessageInfo(
-                                                                   PointStamped))
+                                                         ROSMessageInfo.ROSMessageInfo(
+                                                             PointStamped))
 
 
 ##
@@ -599,11 +610,11 @@ class ROSQuaternionData(OpenRTM_aist.ByteDataStreamBase):
 # @endif
 #
 def ROSQuaternionInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("ros:geometry_msgs/QuaternionStamped",
-                                                         ROSQuaternionData)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer("ros:geometry_msgs/QuaternionStamped",
+                                                              ROSQuaternionData, RTC.TimedQuaternion)
     ROSMessageInfo.ROSMessageInfoList.instance().addInfo("ros:geometry_msgs/QuaternionStamped",
-                                                               ROSMessageInfo.ROSMessageInfo(
-                                                                   QuaternionStamped))
+                                                         ROSMessageInfo.ROSMessageInfo(
+                                                             QuaternionStamped))
 
 
 ##
@@ -750,11 +761,11 @@ class ROSVector3DData(OpenRTM_aist.ByteDataStreamBase):
 # @endif
 #
 def ROSVector3DInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("ros:geometry_msgs/Vector3Stamped",
-                                                         ROSVector3DData)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer("ros:geometry_msgs/Vector3Stamped",
+                                                              ROSVector3DData, RTC.TimedVector3D)
     ROSMessageInfo.ROSMessageInfoList.instance().addInfo("ros:geometry_msgs/Vector3Stamped",
-                                                               ROSMessageInfo.ROSMessageInfo(
-                                                                   Vector3Stamped))
+                                                         ROSMessageInfo.ROSMessageInfo(
+                                                             Vector3Stamped))
 
 
 ##
@@ -908,11 +919,11 @@ class ROSCameraImageData(OpenRTM_aist.ByteDataStreamBase):
 # @endif
 #
 def ROSCameraImageInit():
-    OpenRTM_aist.SerializerFactory.instance().addFactory("ros:sensor_msgs/Image",
-                                                         ROSCameraImageData)
+    OpenRTM_aist.SerializerFactories.instance().addSerializer("ros:sensor_msgs/Image",
+                                                              ROSCameraImageData, RTC.CameraImage)
     ROSMessageInfo.ROSMessageInfoList.instance().addInfo("ros:sensor_msgs/Image",
-                                                               ROSMessageInfo.ROSMessageInfo(
-                                                                   Image))
+                                                         ROSMessageInfo.ROSMessageInfo(
+                                                             Image))
 
 
 ##

--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSTopicManager.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSTopicManager.py
@@ -325,8 +325,12 @@ class ROSTopicManager(rosgraph.xmlrpc.XmlRpcHandler):
     # @endif
     def shutdown(self):
         self._shutdownflag = True
-        self._server_sock.shutdown(socket.SHUT_RDWR)
-        self._server_sock.close()
+        try:
+            self._server_sock.shutdown(socket.SHUT_RDWR)
+            self._server_sock.close()
+        except BaseException:
+            pass
+
         self._thread.join()
         self._node.shutdown(True)
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

## Description of the Change

`RTC::CameraImage`->`sensor_msgs/Image`への変換時に画像データを格納した変数をそのままコピーしていたが、`sensor_msgs/Image`型では画像データをarray型で持っており`RTC::CameraImage`型にコピーするためにはbyte型への変換が必要だったため修正した。

また`std_msgs/Int8MultiArray`->`RTC::TimedOctetSeq`もbyte型への変換が必要だったため修正した。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
