### PR TITLE
ROSTransportの終了処理を修正

### DIFF
--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSTopicManager.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSTopicManager.py
@@ -326,11 +326,10 @@ class ROSTopicManager(rosgraph.xmlrpc.XmlRpcHandler):
     def shutdown(self):
         self._shutdownflag = True
         try:
-            self._server_sock.shutdown(socket.SHUT_RDWR)
-            self._server_sock.close()
+            self._server_sock.shutdown(socket.SHUT_WR)
         except BaseException:
             pass
-
+        self._server_sock.close()
         self._thread.join()
         self._node.shutdown(True)
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

以下のsocket終了処理がWindowsとLinuxで動作が異なる。

https://github.com/OpenRTM/OpenRTM-aist-Python/blob/dfadd5c3fc0488bf69d1aab86a31a5173ab9c917/OpenRTM_aist/ext/transport/ROSTransport/ROSTopicManager.py#L329-L330

Windowsの場合はshutdown関数で以下の例外が発生する。
ただし、shutdown関数が無くてもclose関数のみで正常終了する。

```
OSError: [WinError 10057] ソケットが接続されていないか、sendto 呼び出しを使ってデータグラム ソケットで送信するときにアドレスが指定されていないため、データの送受信を要求することは禁じられています。
```

Linuxの場合は例外は発生しないが、shutdown関数がない場合はaccept関数でブロックされたままになる。

## Description of the Change

pythonのsocketにはソケットが接続されていないかどうか確認する関数はないため、shutdown関数のみtry～exceptで例外処理を行うように変更した。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
