### PR TITLE
構文の間違いで発生する警告の修正(1.2)

### DIFF
--- a/OpenRTM_aist/ConfigAdmin.py
+++ b/OpenRTM_aist/ConfigAdmin.py
@@ -1712,7 +1712,7 @@ class ConfigAdmin:
       return
 
     def __call__(self, conf):
-      if conf is None or conf is 0:
+      if conf is None or conf == 0:
         return False
 
       return self._name == conf.name

--- a/OpenRTM_aist/ConnectorListener.py
+++ b/OpenRTM_aist/ConnectorListener.py
@@ -288,7 +288,7 @@ class ConnectorDataListenerT(ConnectorDataListener):
   #                         const cdrMemoryStream& cdrdata)
   def __call__(self, info, cdrdata, data):
     endian = info.properties.getProperty("serializer.cdr.endian","little")
-    if endian is not "little" and endian is not None:
+    if endian != "little" and endian is not None:
       endian = OpenRTM_aist.split(endian, ",") # Maybe endian is ["little","big"]
       endian = OpenRTM_aist.normalize(endian) # Maybe self._endian is "little" or "big"
 

--- a/OpenRTM_aist/InPortBase.py
+++ b/OpenRTM_aist/InPortBase.py
@@ -500,7 +500,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
 
 
     if OpenRTM_aist.NVUtil.find_index(connector_profile.properties,
-                                      "dataport.serializer.cdr.endian") is -1:
+                                      "dataport.serializer.cdr.endian") == -1:
       self._rtcout.RTC_TRACE("ConnectorProfile dataport.serializer.cdr.endian set.")
       connector_profile.properties.append(OpenRTM_aist.NVUtil.newNV("dataport.serializer.cdr.endian","little,big"))
 

--- a/OpenRTM_aist/OutPortBase.py
+++ b/OpenRTM_aist/OutPortBase.py
@@ -408,7 +408,7 @@ class OutPortBase(OpenRTM_aist.PortBase,OpenRTM_aist.DataPortStatus):
       
         
     if OpenRTM_aist.NVUtil.find_index(connector_profile.properties,
-                                      "dataport.serializer.cdr.endian") is -1:
+                                      "dataport.serializer.cdr.endian") == -1:
       self._rtcout.RTC_TRACE("ConnectorProfile dataport.serializer.cdr.endian set.")
       connector_profile.properties.append(OpenRTM_aist.NVUtil.newNV("dataport.serializer.cdr.endian","little,big"))
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

本来は`=!`や`==`で比較する箇所を`is not`や`is`で比較しているコードがあるため警告が発生する。

## Description of the Change

警告の発生した箇所を修正した。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
