### PR TITLE
Clock rewind hung bug #208 fixed (master)

### DIFF
--- a/OpenRTM_aist/PeriodicExecutionContext.py
+++ b/OpenRTM_aist/PeriodicExecutionContext.py
@@ -152,45 +152,42 @@ class PeriodicExecutionContext(OpenRTM_aist.ExecutionContextBase,
             if ret == False:
                 self._rtcout.RTC_ERROR("CPU affinity mask setting failed")
 
-        while self.threadRunning():
-            OpenRTM_aist.ExecutionContextBase.invokeWorkerPreDo(self)
-            # Thread will stopped when all RTCs are INACTIVE.
-            # Therefore WorkerPreDo(updating state) have to be invoked
-            # before stopping thread.
-            guard = OpenRTM_aist.ScopedLock(self._workerthread._mutex)
-            while not self._workerthread._running:
-                self._workerthread._cond.wait()
-            del guard
+    while self.threadRunning():
+      OpenRTM_aist.ExecutionContextBase.invokeWorkerPreDo(self)
+      # Thread will stopped when all RTCs are INACTIVE.
+      # Therefore WorkerPreDo(updating state) have to be invoked
+      # before stopping thread.
+      guard = OpenRTM_aist.ScopedLock(self._workerthread._mutex)
+      while not self._workerthread._running:
+        self._workerthread._cond.wait()
+      del guard
 
-            t0_ = OpenRTM_aist.Time()
-            OpenRTM_aist.ExecutionContextBase.invokeWorkerDo(self)
-            OpenRTM_aist.ExecutionContextBase.invokeWorkerPostDo(self)
-            t1_ = OpenRTM_aist.Time()
+      t0_ = OpenRTM_aist.Time()
+      OpenRTM_aist.ExecutionContextBase.invokeWorkerDo(self)
+      OpenRTM_aist.ExecutionContextBase.invokeWorkerPostDo(self)
+      t1_ = OpenRTM_aist.Time()
 
-            period_ = self.getPeriod()
+      period_ = self.getPeriod()
+      exectime_ = (t1_ - t0_).getTime()
+      sleeptime_ = period_ - exectime_
 
-            if count_ > 1000:
-                exctm_ = (t1_ - t0_).getTime().toDouble()
-                slptm_ = period_.toDouble() - exctm_
-                self._rtcout.RTC_PARANOID(
-                    "Period:    %f [s]", period_.toDouble())
-                self._rtcout.RTC_PARANOID("Execution: %f [s]", exctm_)
-                self._rtcout.RTC_PARANOID("Sleep:     %f [s]", slptm_)
+      if count_ > 10:
+        self._rtcout.RTC_PARANOID("Period:    %f [s]", period_.toDouble())
+        self._rtcout.RTC_PARANOID("Execution: %f [s]", exectime_.toDouble())
+        self._rtcout.RTC_PARANOID("Sleep:     %f [s]", sleeptime_.toDouble())
 
-            t2_ = OpenRTM_aist.Time()
+      t2_ = OpenRTM_aist.Time()
 
-            if not self._nowait and period_.toDouble() > ((t1_ - t0_).getTime().toDouble()):
-                if count_ > 1000:
-                    self._rtcout.RTC_PARANOID("sleeping...")
-                slptm_ = period_.toDouble() - (t1_ - t0_).getTime().toDouble()
-                time.sleep(slptm_)
+      if not self._nowait and exectime_.toDouble() > 0.0 and sleeptime_.toDouble() > 0.0:
+        if count_ > 10:
+          self._rtcout.RTC_PARANOID("sleeping...")
+        time.sleep(sleeptime_.toDouble())
 
-            if count_ > 1000:
-                t3_ = OpenRTM_aist.Time()
-                self._rtcout.RTC_PARANOID(
-                    "Slept:     %f [s]", (t3_ - t2_).getTime().toDouble())
-                count_ = 0
-            count_ += 1
+      if count_ > 10:
+        t3_ = OpenRTM_aist.Time()
+        self._rtcout.RTC_PARANOID("Slept:     %f [s]", (t3_ - t2_).getTime().toDouble())
+        count_ = 0
+      count_ += 1
 
         self._rtcout.RTC_DEBUG("Thread terminated.")
         return 0

--- a/OpenRTM_aist/PeriodicExecutionContext.py
+++ b/OpenRTM_aist/PeriodicExecutionContext.py
@@ -151,43 +151,43 @@ class PeriodicExecutionContext(OpenRTM_aist.ExecutionContextBase,
             ret = OpenRTM_aist.setThreadAffinity(self._cpu)
             if ret == False:
                 self._rtcout.RTC_ERROR("CPU affinity mask setting failed")
+                
+        while self.threadRunning():
+            OpenRTM_aist.ExecutionContextBase.invokeWorkerPreDo(self)
+            # Thread will stopped when all RTCs are INACTIVE.
+            # Therefore WorkerPreDo(updating state) have to be invoked
+            # before stopping thread.
+            guard = OpenRTM_aist.ScopedLock(self._workerthread._mutex)
+            while not self._workerthread._running:
+                self._workerthread._cond.wait()
+            del guard
 
-    while self.threadRunning():
-      OpenRTM_aist.ExecutionContextBase.invokeWorkerPreDo(self)
-      # Thread will stopped when all RTCs are INACTIVE.
-      # Therefore WorkerPreDo(updating state) have to be invoked
-      # before stopping thread.
-      guard = OpenRTM_aist.ScopedLock(self._workerthread._mutex)
-      while not self._workerthread._running:
-        self._workerthread._cond.wait()
-      del guard
+            t0_ = OpenRTM_aist.Time()
+            OpenRTM_aist.ExecutionContextBase.invokeWorkerDo(self)
+            OpenRTM_aist.ExecutionContextBase.invokeWorkerPostDo(self)
+            t1_ = OpenRTM_aist.Time()
 
-      t0_ = OpenRTM_aist.Time()
-      OpenRTM_aist.ExecutionContextBase.invokeWorkerDo(self)
-      OpenRTM_aist.ExecutionContextBase.invokeWorkerPostDo(self)
-      t1_ = OpenRTM_aist.Time()
+            period_ = self.getPeriod()
+            exectime_ = (t1_ - t0_).getTime()
+            sleeptime_ = period_ - exectime_
 
-      period_ = self.getPeriod()
-      exectime_ = (t1_ - t0_).getTime()
-      sleeptime_ = period_ - exectime_
+            if count_ > 1000:
+                self._rtcout.RTC_PARANOID("Period:    %f [s]", period_.toDouble())
+                self._rtcout.RTC_PARANOID("Execution: %f [s]", exectime_.toDouble())
+                self._rtcout.RTC_PARANOID("Sleep:     %f [s]", sleeptime_.toDouble())
 
-      if count_ > 10:
-        self._rtcout.RTC_PARANOID("Period:    %f [s]", period_.toDouble())
-        self._rtcout.RTC_PARANOID("Execution: %f [s]", exectime_.toDouble())
-        self._rtcout.RTC_PARANOID("Sleep:     %f [s]", sleeptime_.toDouble())
+            t2_ = OpenRTM_aist.Time()
 
-      t2_ = OpenRTM_aist.Time()
+            if not self._nowait and exectime_.toDouble() > 0.0 and sleeptime_.toDouble() > 0.0:
+                if count_ > 1000:
+                    self._rtcout.RTC_PARANOID("sleeping...")
+                time.sleep(sleeptime_.toDouble())
 
-      if not self._nowait and exectime_.toDouble() > 0.0 and sleeptime_.toDouble() > 0.0:
-        if count_ > 10:
-          self._rtcout.RTC_PARANOID("sleeping...")
-        time.sleep(sleeptime_.toDouble())
-
-      if count_ > 10:
-        t3_ = OpenRTM_aist.Time()
-        self._rtcout.RTC_PARANOID("Slept:     %f [s]", (t3_ - t2_).getTime().toDouble())
-        count_ = 0
-      count_ += 1
+            if count_ > 1000:
+                t3_ = OpenRTM_aist.Time()
+                self._rtcout.RTC_PARANOID("Slept:     %f [s]", (t3_ - t2_).getTime().toDouble())
+                count_ = 0
+            count_ += 1
 
         self._rtcout.RTC_DEBUG("Thread terminated.")
         return 0

--- a/OpenRTM_aist/PeriodicExecutionContext.py
+++ b/OpenRTM_aist/PeriodicExecutionContext.py
@@ -178,7 +178,7 @@ class PeriodicExecutionContext(OpenRTM_aist.ExecutionContextBase,
 
             t2_ = OpenRTM_aist.Time()
 
-            if not self._nowait and exectime_.toDouble() > 0.0 and sleeptime_.toDouble() > 0.0:
+            if not self._nowait and exectime_.toDouble() >= 0.0 and sleeptime_.toDouble() > 0.0:
                 if count_ > 1000:
                     self._rtcout.RTC_PARANOID("sleeping...")
                 time.sleep(sleeptime_.toDouble())


### PR DESCRIPTION
Clock rewind causes hung and fixed it.

#208

## Identify the Bug
The default execution context has a bug that causes RTC to hang when rewinding the system clock.

## Description of the Change
If the system clock rewind detected during RTC's logic execution, skip the sleep in EC. 

## Verification 

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
