### PR TITLE
Copyright message in log-header updated. (1.2)

### DIFF
--- a/OpenRTM_aist/Manager.py
+++ b/OpenRTM_aist/Manager.py
@@ -1682,9 +1682,11 @@ class Manager:
                                                 "enable", "disable", False))
 
     self._rtcout.RTC_INFO("%s", self._config.getProperty("openrtm.version"))
-    self._rtcout.RTC_INFO("Copyright (C) 2003-2010")
-    self._rtcout.RTC_INFO("  Noriaki Ando")
-    self._rtcout.RTC_INFO("  Intelligent Systems Research Institute, AIST")
+    self._rtcout.RTC_INFO("Copyright (C) 2003-2020, Noriaki Ando and OpenRTM development team,")
+    self._rtcout.RTC_INFO("  Intelligent Systems Research Institute, AIST,")
+    self._rtcout.RTC_INFO("Copyright (C) 2020, Noriaki Ando and OpenRTM development team,")
+    self._rtcout.RTC_INFO("  Industrial Cyber-Physical Research Center, AIST,")
+    self._rtcout.RTC_INFO("  All right reserved.")
     self._rtcout.RTC_INFO("Manager starting.")
     self._rtcout.RTC_INFO("Starting local logging.")
 

--- a/OpenRTM_aist/version.py
+++ b/OpenRTM_aist/version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: euc-jp -*-
 
-openrtm_name    = "OpenRTM-aist-1.2.1"
-openrtm_version = "1.2.1"
+openrtm_name    = "OpenRTM-aist-1.2.2"
+openrtm_version = "1.2.2"
 corba_name      = "omniORB"


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug



## Description of the Change

- OpenRTM-aist と同じ内容になるように更新した  OpenRTM/OpenRTM-aist#877
- 動作確認したところ、ログファイルに出力されるバージョン番号が1.2.1だったので、version.pyも修正した


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- OpenRTM-aist-Python 1.2.2をインストールしている環境で、修正ファイルのみ差し替えてログファイル内容を確認した
```
2020-06-26 10:44:27,323 file.manager INFO 1.2.2
2020-06-26 10:44:27,323 file.manager INFO Copyright (C) 2003-2020, Noriaki Ando and OpenRTM development team,
2020-06-26 10:44:27,323 file.manager INFO   Intelligent Systems Research Institute, AIST,
2020-06-26 10:44:27,323 file.manager INFO Copyright (C) 2020, Noriaki Ando and OpenRTM development team,
2020-06-26 10:44:27,323 file.manager INFO   Industrial Cyber-Physical Research Center, AIST,
2020-06-26 10:44:27,323 file.manager INFO   All right reserved.
```

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
