### PR TITLE
サンプルコンポーネントのrun.pyが正常に動作するように修正

### DIFF
--- a/OpenRTM_aist/examples/ExtTrigger/Connector.py
+++ b/OpenRTM_aist/examples/ExtTrigger/Connector.py
@@ -10,6 +10,7 @@ from omniORB import CORBA
 import RTC
 import OpenRTM
 import OpenRTM_aist
+import time
 
 
 def main():
@@ -36,12 +37,17 @@ def main():
     ec1 = OpenRTM_aist.CorbaConsumer(
         interfaceType=OpenRTM.ExtTrigExecutionContextService)
 
-    # find ConsoleIn0 component
-    conin.setObject(naming.resolve("ConsoleIn0.rtc"))
+    for _ in range(100):
+        try:
+            # find ConsoleIn0 component
+            conin.setObject(naming.resolve("ConsoleIn0.rtc"))
+            # get ports
+            inobj = conin.getObject()._narrow(RTC.RTObject)
+            pin = inobj.get_ports()
+            break
+        except:
+            time.sleep(0.1)
 
-    # get ports
-    inobj = conin.getObject()._narrow(RTC.RTObject)
-    pin = inobj.get_ports()
     pin[0].disconnect_all()
 
     # activate ConsoleIn0
@@ -49,12 +55,17 @@ def main():
     eclisti[0].activate_component(inobj)
     ec0.setObject(eclisti[0])
 
-    # find ConsoleOut0 component
-    conout.setObject(naming.resolve("ConsoleOut0.rtc"))
+    for _ in range(100):
+        try:
+            # find ConsoleOut0 component
+            conout.setObject(naming.resolve("ConsoleOut0.rtc"))
+            # get ports
+            outobj = conout.getObject()._narrow(RTC.RTObject)
+            pout = outobj.get_ports()
+            break
+        except:
+            time.sleep(0.1)
 
-    # get ports
-    outobj = conout.getObject()._narrow(RTC.RTObject)
-    pout = outobj.get_ports()
     pout[0].disconnect_all()
 
     # activate ConsoleOut0

--- a/OpenRTM_aist/examples/ExtTrigger/run.py
+++ b/OpenRTM_aist/examples/ExtTrigger/run.py
@@ -28,7 +28,7 @@ plat = sys.platform
 
 if plat == "win32":
     subprocess.call(
-        "start \"\" \"%RTM_ROOT%\\bin\\rtm-naming.bat\"",
+        'cd \"%RTM_ROOT%\\bin\\\" & start \"\" rtm-naming.bat',
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE)
@@ -43,7 +43,6 @@ if plat == "win32":
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE)
-    time.sleep(3)
     subprocess.call("python Connector.py", shell=True)
 
 else:

--- a/OpenRTM_aist/examples/SimpleIO/Connector.py
+++ b/OpenRTM_aist/examples/SimpleIO/Connector.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 
@@ -10,6 +10,8 @@ from optparse import OptionParser, OptionError
 
 import RTC
 import OpenRTM_aist
+
+import time
 
 
 def usage():
@@ -42,19 +44,29 @@ def main():
     conout = OpenRTM_aist.CorbaConsumer()
 
     # find ConsoleIn0 component
-    conin.setObject(naming.resolve("ConsoleIn0.rtc"))
+    for _ in range(100):
+        try:
+            conin.setObject(naming.resolve("ConsoleIn0.rtc"))
+            # get ports
+            inobj = conin.getObject()._narrow(RTC.RTObject)
+            pin = inobj.get_ports()
+            break
+        except:
+            time.sleep(0.1)
 
-    # get ports
-    inobj = conin.getObject()._narrow(RTC.RTObject)
-    pin = inobj.get_ports()
     pin[0].disconnect_all()
 
     # find ConsoleOut0 component
-    conout.setObject(naming.resolve("ConsoleOut0.rtc"))
+    for _ in range(100):
+        try:
+            conout.setObject(naming.resolve("ConsoleOut0.rtc"))
+            # get ports
+            outobj = conout.getObject()._narrow(RTC.RTObject)
+            pout = outobj.get_ports()
+            break
+        except:
+            time.sleep(0.1)
 
-    # get ports
-    outobj = conout.getObject()._narrow(RTC.RTObject)
-    pout = outobj.get_ports()
     pout[0].disconnect_all()
 
     # subscription type
@@ -124,6 +136,7 @@ def main():
                                                                        skip_count))
 
     ret, conprof = pin[0].connect(conprof)
+    print(ret)
 
     # activate ConsoleIn0
     eclistin = inobj.get_owned_contexts()

--- a/OpenRTM_aist/examples/SimpleIO/run.py
+++ b/OpenRTM_aist/examples/SimpleIO/run.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 
@@ -29,63 +29,41 @@ plat = sys.platform
 
 def main():
     if plat == "win32":
-        subprocess.call(
-            'start \"\" \"%RTM_ROOT%\\bin\\rtm-naming.bat\"',
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+        subprocess.call('cd \"%RTM_ROOT%\\bin\\\" & start \"\" rtm-naming.bat',
+                        shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         time.sleep(5)
-        subprocess.call(
-            "start python ConsoleIn.py".split(" "),
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
-        subprocess.call(
-            "start python Consoleout.py".split(" "),
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
-        time.sleep(3)
+        subprocess.call("start python ConsoleIn.py".split(
+            " "), shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.call("start python Consoleout.py".split(
+            " "), shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         subprocess.call("python Connector.py".split(" "), shell=True)
 
     else:
-        p = subprocess.Popen(
-            "which xterm",
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+        p = subprocess.Popen("which xterm", shell=True,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         term, stderr = p.communicate()
         status = p.returncode
         term = term.replace("\n", "")
         term += " -e"
         if status != 0:
-            p = subprocess.Popen(
-                "which kterm",
-                shell=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
+            p = subprocess.Popen("which kterm", shell=True,
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             term, stderr = p.communicate()
             status = p.returncode
             term = term.replace("\n", "")
             term += " -e"
 
         if status != 0:
-            p = subprocess.Popen(
-                "which uxterm",
-                shell=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
+            p = subprocess.Popen("which uxterm", shell=True,
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             term, stderr = p.communicate()
             status = p.returncode
             term = term.replace("\n", "")
             term += " -e"
 
         if status != 0:
-            p = subprocess.Popen(
-                "which gnome-terminal",
-                shell=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
+            p = subprocess.Popen("which gnome-terminal", shell=True,
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             term, stderr = p.communicate()
             status = p.returncode
             term = term.replace("\n", "")
@@ -107,23 +85,14 @@ def main():
     os.system('python %s/rtm-naming.py &'%path)
     """
         cmd = 'rtm-naming&'
-        subprocess.call(
-            cmd,
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+        subprocess.call(cmd, shell=True, stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE)
         cmd = '%s python ConsoleIn.py&' % term
-        subprocess.call(
-            cmd,
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+        subprocess.call(cmd, shell=True, stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE)
         cmd = '%s python ConsoleOut.py&' % term
-        subprocess.call(
-            cmd,
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+        subprocess.call(cmd, shell=True, stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE)
         time.sleep(3)
         subprocess.call("python Connector.py", shell=True)
 

--- a/OpenRTM_aist/examples/SimpleService/Connector.py
+++ b/OpenRTM_aist/examples/SimpleService/Connector.py
@@ -9,6 +9,7 @@ from omniORB import CORBA
 
 import RTC
 import OpenRTM_aist
+import time
 
 
 def usage():
@@ -29,20 +30,30 @@ def main():
     consumer = OpenRTM_aist.CorbaConsumer()
     provider = OpenRTM_aist.CorbaConsumer()
 
-    # find MyServiceConsumer0 component
-    consumer.setObject(naming.resolve("MyServiceConsumer0.rtc"))
+    for _ in range(100):
+        try:
+            # find MyServiceConsumer0 component
+            consumer.setObject(naming.resolve("MyServiceConsumer0.rtc"))
+            # get ports
+            consobj = consumer.getObject()._narrow(RTC.RTObject)
+            pcons = consobj.get_ports()
+            break
+        except:
+            time.sleep(0.1)
 
-    # get ports
-    consobj = consumer.getObject()._narrow(RTC.RTObject)
-    pcons = consobj.get_ports()
     pcons[0].disconnect_all()
 
-    # find MyServiceProvider0 component
-    provider.setObject(naming.resolve("MyServiceProvider0.rtc"))
+    for _ in range(100):
+        try:
+            # find MyServiceProvider0 component
+            provider.setObject(naming.resolve("MyServiceProvider0.rtc"))
+            # get ports
+            provobj = provider.getObject()._narrow(RTC.RTObject)
+            prov = provobj.get_ports()
+            break
+        except:
+            time.sleep(0.1)
 
-    # get ports
-    provobj = provider.getObject()._narrow(RTC.RTObject)
-    prov = provobj.get_ports()
     prov[0].disconnect_all()
 
     # connect ports

--- a/OpenRTM_aist/examples/SimpleService/run.py
+++ b/OpenRTM_aist/examples/SimpleService/run.py
@@ -31,7 +31,7 @@ if plat == "win32":
     #os.system("rd /S /Q SimpleService__POA")
     #os.system("omniidl.exe -bpython MyService.idl")
     subprocess.call(
-        "start \"\" \"%RTM_ROOT%\\bin\\rtm-naming.bat\"",
+        'cd \"%RTM_ROOT%\\bin\\\" & start \"\" rtm-naming.bat',
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE)
@@ -46,7 +46,6 @@ if plat == "win32":
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE)
-    time.sleep(3)
     subprocess.call("python Connector.py", shell=True)
 
 else:

--- a/OpenRTM_aist/examples/Slider_and_Motor/Connector.py
+++ b/OpenRTM_aist/examples/Slider_and_Motor/Connector.py
@@ -8,6 +8,7 @@ from omniORB import CORBA
 
 import RTC
 import OpenRTM_aist
+import time
 
 
 def main():
@@ -25,19 +26,29 @@ def main():
     tkm = OpenRTM_aist.CorbaConsumer()
 
     # find TkMotorComp0 component
-    tkm.setObject(naming.resolve("TkMotorComp0.rtc"))
+    for _ in range(100):
+        try:
+            tkm.setObject(naming.resolve("TkMotorComp0.rtc"))
+            # get ports
+            inobj = tkm.getObject()._narrow(RTC.RTObject)
+            pin = inobj.get_ports()
+            break
+        except:
+            time.sleep(0.1)
 
-    # get ports
-    inobj = tkm.getObject()._narrow(RTC.RTObject)
-    pin = inobj.get_ports()
     pin[0].disconnect_all()
 
-    # find SliderComp0 component
-    sl.setObject(naming.resolve("SliderComp0.rtc"))
+    for _ in range(100):
+        try:
+            # find SliderComp0 component
+            sl.setObject(naming.resolve("SliderComp0.rtc"))
+            # get ports
+            outobj = sl.getObject()._narrow(RTC.RTObject)
+            pout = outobj.get_ports()
+            break
+        except:
+            time.sleep(0.1)
 
-    # get ports
-    outobj = sl.getObject()._narrow(RTC.RTObject)
-    pout = outobj.get_ports()
     pout[0].disconnect_all()
 
     # connect ports

--- a/OpenRTM_aist/examples/Slider_and_Motor/run.py
+++ b/OpenRTM_aist/examples/Slider_and_Motor/run.py
@@ -28,7 +28,7 @@ plat = sys.platform
 
 if plat == "win32":
     subprocess.call(
-        "start \"\" \"%RTM_ROOT%\\bin\\rtm-naming.bat\"",
+        'cd \"%RTM_ROOT%\\bin\\\" & start \"\" rtm-naming.bat',
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE)
@@ -43,7 +43,6 @@ if plat == "win32":
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE)
-    time.sleep(5)
     subprocess.call("python Connector.py", shell=True)
 
 else:


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

- サンプルコンポーネントのrun.pyを実行するとRTC起動前に接続処理を実行してエラーになる
- run.pyでのネームサーバーの起動処理でkill-rtm-naming.batが見つからないというエラーが発生する。これは`C:\Program Files\OpenRTM-aist\x.y.z\bin`にパスが通っていないため。


## Description of the Change

- RTCが見つかるまでポーリングするように修正
- 一旦`%RTM_ROOT%\bin`に移動してrtm-naming.batを実行するように修正


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
