### PR TITLE
defaultのコンフィギュレーションセットはRTC生成時に追加するようにする

### DIFF
--- a/OpenRTM_aist/ConfigAdmin.py
+++ b/OpenRTM_aist/ConfigAdmin.py
@@ -387,6 +387,7 @@ class ConfigAdmin:
         self._newConfig = []
         self._listeners = OpenRTM_aist.ConfigurationListeners()
         self._changedParam = []
+        self._configsets.createNode(self._activeId)
 
     ##
     # @if jp


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

rtshellで以下の問題が発生する。

- https://github.com/gbiggs/rtshell/issues/24


コンフィギュレーションパラメータ、コンフィギュレーションセットが設定されていないRTC(ConsoleIn等)については、コンフィギュレーションセットは1つもない状態になる。
RTSystemEditor等でコンフィギュレーションパラメータを取得する際にgetActiveConfigurationSetを呼び出しており、getActiveConfigurationSetを呼ぶとdefaultコンフィギュレーションセットが追加される。

## Description of the Change

getActiveConfigurationSetが呼ばれた段階でdefaultコンフィギュレーションセットが追加されるという動作は分かりづらいだけなので、ConfigAdmin初期化時に追加するように変更した。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
