### PR TITLE
Python3環境でdebパッケージ生成時の不具合修正

### DIFF
--- a/OpenRTM_aist/docs/Doxyfile_jp.in
+++ b/OpenRTM_aist/docs/Doxyfile_jp.in
@@ -86,7 +86,7 @@ WARN_LOGFILE           =
 # configuration options related to the input files
 #---------------------------------------------------------------------------
 INPUT                  = ../
-INPUT_ENCODING         = euc-jp
+INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.c \
                          *.cc \
                          *.cxx \

--- a/packages/deb/debian/changelog
+++ b/packages/deb/debian/changelog
@@ -1,3 +1,21 @@
+openrtm-aist-python (2.0.0-0) experimental; urgency=low
+
+  * 2.0.0-0 (2.0.0-RELEASE). OpenRTM-aist-2.0.0-RELEASE
+
+ -- Noriaki Ando <n-ando@aist.go.jp>  Thu, 29 Jul 2021 12:39:34 +0900
+
+openrtm-aist-python (1.2.2-0) experimental; urgency=low
+
+  * 1.2.2-0 (1.2.2-RELEASE). OpenRTM-aist-1.2.2-RELEASE
+
+ -- Noriaki Ando <n-ando@aist.go.jp>  Mon, 23 Mar 2020 16:22:17 +0900
+
+openrtm-aist-python (1.2.1-0) experimental; urgency=low
+
+  * 1.2.1-0 (1.2.1-RELEASE). OpenRTM-aist-1.2.1-RELEASE
+
+ -- Noriaki Ando <n-ando@aist.go.jp>  Fri, 24 May 2019 11:05:32 +0900
+
 openrtm-aist-python (1.2.0-0) experimental; urgency=low
 
   * 1.2.0-0 (1.2.0-RELEASE). OpenRTM-aist-1.2.0-RELEASE

--- a/packages/deb/debian/control
+++ b/packages/deb/debian/control
@@ -2,13 +2,13 @@ Source: openrtm-aist-python
 Section: main
 Priority: extra
 Maintainer: Noriaki Ando <n-ando@aist.go.jp>
-Build-Depends: debhelper, python, python-omniorb
+Build-Depends: debhelper, python3-all-dev, python3-omniorb
 Standards-Version: 3.8.4
 Homepage: http://www.openrtm.org
 
-Package: openrtm-aist-python
+Package: openrtm-aist-python3
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, omniorb-nameserver
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3-omniorb, omniorb-nameserver
 Description: OpenRTM-aist, RT-Middleware distributed by AIST
  OpenRTM-aist is a reference implementation of RTC (Robotic Technology
  Component Version 1.1, formal/12-09-01) specification which is OMG
@@ -20,13 +20,13 @@ Description: OpenRTM-aist, RT-Middleware distributed by AIST
  National Institute of Advanced Industrial Science and Technology
  (AIST), Japan. Please see http://www.openrtm.org/ for more detail.
 
-Package: openrtm-aist-python-example
+Package: openrtm-aist-python3-example
 Architecture: any
-Depends: openrtm-aist-python
+Depends: openrtm-aist-python3
 Description: OpenRTM-aist-Python examples
  Example components and sources of OpenRTM-aist.
 
-Package: openrtm-aist-python-doc
+Package: openrtm-aist-python3-doc
 Architecture: all
 Description: Documentation for openrtm-aist-python
  Class reference manual of OpenRTM-aist.

--- a/packages/deb/debian/rules
+++ b/packages/deb/debian/rules
@@ -18,7 +18,7 @@ configure-stamp:
 
 
 build: build-stamp
-	python setup.py build
+	python3 setup.py build
 
 build-stamp: configure-stamp  
 	dh_testdir
@@ -28,7 +28,7 @@ clean:
 	dh_testdir
 	dh_testroot
 	rm -f build-stamp configure-stamp
-	python setup.py clean
+	python3 setup.py clean
 
 	dh_clean 
 
@@ -39,13 +39,13 @@ install: build
 	dh_installdirs
 
 	# installing core
-	python setup.py install_core --prefix=$(CURDIR)/debian/openrtm-aist-python/usr --install-layout=deb
+	python3 setup.py install_core --prefix=$(CURDIR)/debian/openrtm-aist-python3/usr --install-layout=deb
 	# installing examples
-	(mkdir $(CURDIR)/debian/openrtm-aist-python-example/usr/)
-	python setup.py install_example --install-dir=$(CURDIR)/debian/openrtm-aist-python-example/usr/
+	(mkdir $(CURDIR)/debian/openrtm-aist-python3-example/usr/)
+	python3 setup.py install_example --install-dir=$(CURDIR)/debian/openrtm-aist-python3-example/usr/
 	# installing examples
-	(mkdir $(CURDIR)/debian/openrtm-aist-python-doc/usr/)
-	python setup.py install_doc --install-dir=$(CURDIR)/debian/openrtm-aist-python-doc/usr/
+	(mkdir $(CURDIR)/debian/openrtm-aist-python3-doc/usr/)
+	python3 setup.py install_doc --install-dir=$(CURDIR)/debian/openrtm-aist-python3-doc/usr/
 	dh_install -s
 
 # Build architecture-independent files here.

--- a/packages/deb/dpkg_build.sh
+++ b/packages/deb/dpkg_build.sh
@@ -107,7 +107,7 @@ check_distribution()
 
 get_version_info()
 {
-    VERSION=`../../setup.py --version`
+    VERSION=`python3 ../../setup.py --version`
     SHORT_VERSION=`echo $VERSION | sed 's/\.[0-9]*$//'`
     BUILD_ROOT="buildroot"
     PKG_NAME="OpenRTM-aist-Python-${VERSION}"
@@ -116,8 +116,8 @@ get_version_info()
 create_source_package()
 {
   cd ../../
-  ./setup.py build
-  ./setup.py sdist
+  python3 setup.py build
+  python3 setup.py sdist
   cd -
 }
 
@@ -131,10 +131,11 @@ create_files()
 {
   eval `dpkg-architecture`
   ARCH=$DEB_HOST_ARCH
+  PKG_VERSION=`dpkg-parsechangelog | sed -n 's/^Version: //p'`
 cat << EOF >> debian/files
-openrtm-aist-python_1.1.0-1_$ARCH.deb main extra
-openrtm-aist-python-example_1.1.0-1_$ARCH.deb main extra
-openrtm-aist-python-doc_1.1.0-1_all.deb main extra
+openrtm-aist-python3_${PKG_VERSION}_${ARCH}.deb main extra
+openrtm-aist-python3-example_${PKG_VERSION}_${ARCH}.deb main extra
+openrtm-aist-python3-doc_${PKG_VERSION}_all.deb main extra
 EOF
 }
 

--- a/setup.py
+++ b/setup.py
@@ -208,7 +208,7 @@ openrtm_ext_packages = [
     "OpenRTM_aist.ext.sdo.observer",
     "OpenRTM_aist.ext.ssl",
     "OpenRTM_aist.ext.logger",
-    "OpenRTM_aist.ext.logger.fluentbit_stream",
+    "OpenRTM_aist.ext.logger.fluentlogger",
     "OpenRTM_aist.ext.transport",
     "OpenRTM_aist.ext.transport.ROSTransport",
     "OpenRTM_aist.ext.transport.ROS2Transport",
@@ -257,8 +257,8 @@ baseidl_path = os.path.normpath(current_dir + "/" + baseidl_dir)
 #
 # scripts settings
 #
-pkg_scripts_unix = ['OpenRTM_aist/utils/rtcd/rtcd_python',
-                    'OpenRTM_aist/utils/rtcprof/rtcprof_python']
+pkg_scripts_unix = ['OpenRTM_aist/utils/rtcd/rtcd_python3',
+                    'OpenRTM_aist/utils/rtcprof/rtcprof_python3']
 pkg_scripts_win32 = ['OpenRTM_aist/utils/rtcd/rtcd_python.py',
                      #                     'OpenRTM_aist/utils/rtcd/rtcd_python.exe',
                      'OpenRTM_aist/utils/rtcd/rtcd_python.bat',
@@ -286,14 +286,14 @@ ext_match_regex_win32 = r".*\.(py|conf|bat|xml|idl)$"
 # examples
 #
 example_dir = "OpenRTM_aist/examples"
-target_example_dir = "share/openrtm-" + pkg_shortver + "/components/python"
+target_example_dir = "share/openrtm-" + pkg_shortver + "/components/python3"
 example_match_regex = r".*\.(py|conf|sh|xml|idl)$"
 example_path = os.path.normpath(current_dir + "/" + example_dir)
 #
 # documents
 #
 document_dir = "OpenRTM_aist/docs"
-target_doc_dir = "share/openrtm-" + pkg_shortver + "/doc/python"
+target_doc_dir = "share/openrtm-" + pkg_shortver + "/doc/python3"
 document_match_regex = r".*\.(css|gif|png|html||hhc|hhk|hhp|js)$"
 document_path = os.path.normpath(current_dir + "/" + document_dir)
 
@@ -1014,6 +1014,7 @@ class install_core_lib(_install_lib):
                                    ('optimize', 'optimize'),
                                    ('skip_build', 'skip_build'),
                                    )
+        _install_lib.finalize_options(self)
 
 
 # sub-command "install_core_script" which is called from install_core
@@ -1027,6 +1028,7 @@ class install_core_scripts(_install_scripts):
                                    ('force', 'force'),
                                    ('skip_build', 'skip_build'),
                                    )
+        _install_scripts.finalize_options(self)
 
 
 # sub-command "install_core_egg_info" which is called from install_core


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
Close #245 
Link to #245 


## Description of the Change
- setup.py sdist でソースパッケージ生成に関する修正
  - FluentLoggerプラグイン名前変更に対応 (setup.py)
  - Doxygenドキュメントビルド時のエラー対応
    - Doxyfile_jp.inのINPUT_ENCODINGをeuc-jpからUTF-8へ変更
- Python3対応debパッケージ生成に関する修正
  - setup.pyの修正
    - unix向けスクリプト名の変更 -> rtcd_python3、rtcprof_python3
    - example、docのディレクトリ変更 -> /components/python3、/doc/python3
    - python3.x/distutilsでのエラー対応で、install_core_libとinstall_core_script関数内でのfinalize呼び出し追加
  - packages/deb の修正


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->
- debパッケージ作成を確認
```
openrtm-aist-python3-doc_2.0.0-0_all.deb  openrtm-aist-python3-example_2.0.0-0_amd64.deb  
openrtm-aist-python3_2.0.0-0_amd64.deb
```
- 上記debパッケージでインストールし、RTSE上でサンプルRTCのConsoleIn/ConsoleOutの接続動作OKを確認
- OpenRTM-aistはインストールしていないため、ネームサーバは下記で起動した
```
$ python3 /usr/lib/python3/dist-packages/OpenRTM_aist/utils/rtm-naming/rtm-naming.py
```
- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
