### PR TITLE
ROS2TransportがROS2 dashingで実行時にエラーになる問題の修正

### DIFF
--- a/OpenRTM_aist/ext/transport/ROS2Transport/ROS2TopicManager.py
+++ b/OpenRTM_aist/ext/transport/ROS2Transport/ROS2TopicManager.py
@@ -22,12 +22,7 @@ import ROS2MessageInfo
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSProfile
-from rclpy.qos import HistoryPolicy
-from rclpy.qos import Duration
-from rclpy.qos import ReliabilityPolicy
-from rclpy.qos import DurabilityPolicy
-from rclpy.qos import LivelinessPolicy
-from rclpy.qos import HistoryPolicy
+
 import threading
 
 
@@ -274,6 +269,32 @@ class ROS2TopicManager(object):
     #
     # @endif
     def get_qosprofile(prop):
+
+        if hasattr(rclpy.qos, "HistoryPolicy"):
+            HistoryPolicy = rclpy.qos.HistoryPolicy
+        else:
+            HistoryPolicy = rclpy.qos.QoSHistoryPolicy
+
+        if hasattr(rclpy.qos, "Duration"):
+            Duration = rclpy.qos.Duration
+        else:
+            Duration = rclpy.qos.QoSDuration
+
+        if hasattr(rclpy.qos, "ReliabilityPolicy"):
+            ReliabilityPolicy = rclpy.qos.ReliabilityPolicy
+        else:
+            ReliabilityPolicy = rclpy.qos.QoSReliabilityPolicy
+
+        if hasattr(rclpy.qos, "DurabilityPolicy"):
+            DurabilityPolicy = rclpy.qos.DurabilityPolicy
+        else:
+            DurabilityPolicy = rclpy.qos.QoSDurabilityPolicy
+
+        if hasattr(rclpy.qos, "LivelinessPolicy"):
+            LivelinessPolicy = rclpy.qos.LivelinessPolicy
+        else:
+            LivelinessPolicy = rclpy.qos.QoSLivelinessPolicy
+
         history = HistoryPolicy.KEEP_LAST
         history_type = prop.getProperty("history", "KEEP_LAST")
         


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#248 の修正でROS2 foxyに対応したが、ROS2 dashingでエラーが発生し接続できなくなった。


## Description of the Change

ROS2 dashingとfoxyで以下のクラス名が変わっているため、どちらにも対応できるようにした。

|dashing|foxy|
|---|---|
|rclpy.qos.QoSHistoryPolicy|rclpy.qos.HistoryPolicy|
|rclpy.qos.QoSDuration|rclpy.qos.Duration|
|rclpy.qos.QoSReliabilityPolicy|rclpy.qos.ReliabilityPolicy|
|rclpy.qos.QoSDurabilityPolicy|rclpy.qos.DurabilityPolicy|
|rclpy.qos.QoSLivelinessPolicy|rclpy.qos.LivelinessPolicy|


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
