### PR TITLE
変数名の間違い、モジュールのimport漏れ、関数の多重定義、比較演算子の警告、エラー修正

### DIFF
--- a/OpenRTM_aist/CORBA_IORUtil.py
+++ b/OpenRTM_aist/CORBA_IORUtil.py
@@ -8,9 +8,12 @@
 #  @author Noriaki Ando
 #
 
+import sys
 from omniORB import CORBA
 from omniORB import *
 from omniORB import any
+from omniORB import cdrMarshal
+from omniORB import cdrUnmarshal
 from IORProfile_idl import *
 from IORProfile_idl import _0__GlobalIDL
 endian = True

--- a/OpenRTM_aist/CSPInPort.py
+++ b/OpenRTM_aist/CSPInPort.py
@@ -349,7 +349,7 @@ class CSPInPort(OpenRTM_aist.InPortBase):
         if not self._syncmode:
             guard_ctrl = OpenRTM_aist.ScopedLock(self._ctrl._cond)
         if not self._thebuffer.empty():
-            _, value = self._thebuffer.read(value)
+            _, value = self._thebuffer.read()
             if guard_ctrl is not None:
                 del guard_ctrl
             self.notify()

--- a/OpenRTM_aist/ConfigAdmin.py
+++ b/OpenRTM_aist/ConfigAdmin.py
@@ -1701,7 +1701,7 @@ class ConfigAdmin:
             return
 
         def __call__(self, conf):
-            if conf is None:
+            if conf is None or conf == 0:
                 return False
 
             return self._name == conf.name

--- a/OpenRTM_aist/ConnectorListener.py
+++ b/OpenRTM_aist/ConnectorListener.py
@@ -784,7 +784,7 @@ class ConnectorDataListenerHolder:
 
         endian = info.properties.getProperty(
             "serializer.cdr.endian", "little")
-        if endian is not "little" and endian is not None:
+        if endian != "little" and endian is not None:
             # Maybe endian is ["little","big"]
             endian = OpenRTM_aist.split(endian, ",")
             # Maybe self._endian is "little" or "big"

--- a/OpenRTM_aist/EventPort_pyfsm.py
+++ b/OpenRTM_aist/EventPort_pyfsm.py
@@ -78,7 +78,7 @@ class EventBinder1(OpenRTM_aist.ConnectorDataListener):
         return OpenRTM_aist.ConnectorListenerStatus.NO_CHANGE, cdrdata
 
     def run(self, data):
-        self._fsm.dispatch(pyfsm.Event(self._handler, data_))
+        self._fsm.dispatch(pyfsm.Event(self._handler, data))
 
 
 class EventConnListener(OpenRTM_aist.ConnectorListener):

--- a/OpenRTM_aist/ExecutionContextWorker.py
+++ b/OpenRTM_aist/ExecutionContextWorker.py
@@ -534,12 +534,11 @@ class ExecutionContextWorker:
                     id_, comp))
             del guard
         except BaseException:
-            del guard
             self._rtcout.RTC_ERROR("addComponent() failed.")
             return RTC.RTC_ERROR
 
         self._rtcout.RTC_DEBUG("addComponent() succeeded.")
-        if self._running == False:
+        if self._running is False:
             self.updateComponentList()
         return RTC.RTC_OK
 
@@ -635,7 +634,7 @@ class ExecutionContextWorker:
         guard = OpenRTM_aist.ScopedLock(self._removedMutex)
         self._removedComps.append(rtobj_)
         del guard
-        if self._running == False:
+        if self._running is False:
             self.updateComponentList()
         return RTC.RTC_OK
 

--- a/OpenRTM_aist/ExtTrigExecutionContext.py
+++ b/OpenRTM_aist/ExtTrigExecutionContext.py
@@ -410,13 +410,13 @@ class ExtTrigExecutionContext(OpenRTM_aist.ExecutionContextBase,
 
     def onAddedComponent(self, rtobj):
         guard = OpenRTM_aist.ScopedLock(self._workerthread._mutex)
-        if self._workerthread._ticked == False:
+        if self._workerthread._ticked is False:
             self._worker.updateComponentList()
         return RTC.RTC_OK
 
     def onRemovedComponent(self, rtobj):
         guard = OpenRTM_aist.ScopedLock(self._workerthread._mutex)
-        if self._workerthread._ticked == False:
+        if self._workerthread._ticked is False:
             self._worker.updateComponentList()
         return RTC.RTC_OK
 

--- a/OpenRTM_aist/FiniteStateMachineComponent.py
+++ b/OpenRTM_aist/FiniteStateMachineComponent.py
@@ -14,8 +14,8 @@
 #         Advanced Industrial Science and Technology (AIST), Japan
 #     All rights reserved.
 
-
 import OpenRTM_aist
+import RTC
 import OpenRTM
 import OpenRTM__POA
 

--- a/OpenRTM_aist/FiniteStateMachineComponentBase.py
+++ b/OpenRTM_aist/FiniteStateMachineComponentBase.py
@@ -282,38 +282,6 @@ class FiniteStateMachineComponentBase(OpenRTM_aist.RTObject_impl):
     # @endif
     # virtual ExecutionContext_ptr get_context(UniqueId exec_handle)
 
-    def get_owned_contexts(self):
-        return OpenRTM_aist.RTObject_impl.get_owned_contexts(self)
-
-    ##
-    # @if jp
-    # @brief [CORBA interface] ExecutionContextを取得する
-    #
-    # 指定したハンドルの ExecutionContext を取得する。
-    # ハンドルから ExecutionContext へのマッピングは、特定の RTC インスタンスに
-    # 固有である。ハンドルはこの RTC を attach_context した際に取得できる。
-    #
-    # @param self
-    # @param ec_id 取得対象 ExecutionContext ハンドル
-    #
-    # @return ExecutionContext
-    #
-    # @else
-    # @brief [CORBA interface] Get ExecutionContext.
-    #
-    # Obtain a reference to the execution context represented by the given
-    # handle.
-    # The mapping from handle to context is specific to a particular RTC
-    # instance. The given handle must have been obtained by a previous call to
-    # attach_context on this RTC.
-    #
-    # @param ec_id ExecutionContext handle
-    #
-    # @return ExecutionContext
-    #
-    # @endif
-    # virtual ExecutionContext_ptr get_context(UniqueId exec_handle)
-
     def get_context(self, ec_id):
         return OpenRTM_aist.RTObject_impl.get_context(self, ec_id)
 

--- a/OpenRTM_aist/GlobalFactory.py
+++ b/OpenRTM_aist/GlobalFactory.py
@@ -34,7 +34,7 @@ class Factory:
     # bool hasFactory(const Identifier& id)
 
     def hasFactory(self, id):
-        if not id in self._creators:
+        if id not in self._creators:
             return False
         return True
 
@@ -64,7 +64,7 @@ class Factory:
     # ReturnCode removeFactory(const Identifier& id)
 
     def removeFactory(self, id):
-        if not id in self._creators:
+        if id not in self._creators:
             return self.NOT_FOUND
 
         del self._creators[id]
@@ -73,7 +73,7 @@ class Factory:
     # AbstractClass* createObject(const Identifier& id)
 
     def createObject(self, id):
-        if not id in self._creators:
+        if id not in self._creators:
             print("Factory.createObject return None id: ", id)
             return None
         obj_ = self._creators[id]()

--- a/OpenRTM_aist/InPort.py
+++ b/OpenRTM_aist/InPort.py
@@ -152,7 +152,7 @@ class InPort(OpenRTM_aist.InPortBase):
         self._rtcout.RTC_TRACE("isNew()")
 
         guard = OpenRTM_aist.ScopedLock(self._valueMutex)
-        if self._directNewData == True:
+        if self._directNewData is True:
             self._rtcout.RTC_TRACE(
                 "isNew() returns true because of direct write.")
             return True
@@ -226,7 +226,7 @@ class InPort(OpenRTM_aist.InPortBase):
 
     def isEmpty(self, names=None):
         self._rtcout.RTC_TRACE("isEmpty()")
-        if self._directNewData == True:
+        if self._directNewData is True:
             return False
         if not self._connectors:
             self._rtcout.RTC_DEBUG("no connectors")
@@ -347,7 +347,7 @@ class InPort(OpenRTM_aist.InPortBase):
             self._rtcout.RTC_TRACE("OnRead called")
 
         guard = OpenRTM_aist.ScopedLock(self._valueMutex)
-        if self._directNewData == True:
+        if self._directNewData is True:
 
             self._rtcout.RTC_TRACE("Direct data transfer")
             if self._OnReadConvert is not None:

--- a/OpenRTM_aist/InPortBase.py
+++ b/OpenRTM_aist/InPortBase.py
@@ -898,7 +898,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
         # marge ConnectorProfile for buffer property.
         prop.mergeProperties(conn_prop.getNode("dataport.inport"))
 
-        if not self.isExistingMarshalingType(prop):
+        if self._value is not None and not self.isExistingMarshalingType(prop):
             return RTC.RTC_ERROR
 
         #
@@ -1008,7 +1008,7 @@ class InPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
         # marge ConnectorProfile for buffer property.
         prop.mergeProperties(conn_prop.getNode("dataport.inport"))
 
-        if not self.isExistingMarshalingType(prop):
+        if self._value is not None and not self.isExistingMarshalingType(prop):
             return RTC.RTC_ERROR
 
         #

--- a/OpenRTM_aist/InPortPushConnector.py
+++ b/OpenRTM_aist/InPortPushConnector.py
@@ -346,7 +346,7 @@ class InPortPushConnector(OpenRTM_aist.InPortConnector):
         self._provider = None
 
         # delete buffer
-        if self._buffer and self._deleteBuffer == True:
+        if self._buffer and self._deleteBuffer is True:
             bfactory = OpenRTM_aist.CdrBufferFactory.instance()
 
         self._buffer = None

--- a/OpenRTM_aist/Manager.py
+++ b/OpenRTM_aist/Manager.py
@@ -1160,7 +1160,7 @@ class Manager:
 
         avail_ec_ = OpenRTM_aist.ExecutionContextFactory.instance().getIdentifiers()
 
-        if not ec_id in avail_ec_:
+        if ec_id not in avail_ec_:
             self._rtcout.RTC_ERROR("Factory not found: %s", ec_id)
             return None
 
@@ -2098,7 +2098,7 @@ class Manager:
 
             ret = OpenRTM_aist.setProcessAffinity(cpu_num)
 
-            if ret == False:
+            if ret is False:
                 self._rtcout.RTC_ERROR("CPU affinity mask setting failed")
 
     ##

--- a/OpenRTM_aist/OutPortBase.py
+++ b/OpenRTM_aist/OutPortBase.py
@@ -951,7 +951,7 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
     """
         prop.mergeProperties(conn_prop.getNode("dataport.outport"))
 
-        if not self.isExistingMarshalingType(prop):
+        if self._value is not None and not self.isExistingMarshalingType(prop):
             return RTC.RTC_ERROR
 
         #
@@ -1039,7 +1039,7 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
     """
         prop.mergeProperties(conn_prop.getNode("dataport.outport"))
 
-        if not self.isExistingMarshalingType(prop):
+        if self._value is not None and not self.isExistingMarshalingType(prop):
             return RTC.RTC_ERROR
 
         #

--- a/OpenRTM_aist/OutPortDuplexConnector.py
+++ b/OpenRTM_aist/OutPortDuplexConnector.py
@@ -430,7 +430,7 @@ class OutPortDuplexConnector(OpenRTM_aist.OutPortConnector):
     def serializeData(self, data):
         if self._serializer is None:
             self._rtcout.RTC_ERROR("serializer creation failure.")
-            return self.UNKNOWN_ERROR, cdr_data
+            return self.UNKNOWN_ERROR, ""
         self._serializer.isLittleEndian(self._endian)
         ser_ret, cdr_data = self._serializer.serialize(data)
         if ser_ret == OpenRTM_aist.ByteDataStreamBase.SERIALIZE_NOT_SUPPORT_ENDIAN:

--- a/OpenRTM_aist/PeriodicECSharedComposite.py
+++ b/OpenRTM_aist/PeriodicECSharedComposite.py
@@ -471,7 +471,7 @@ class PeriodicECOrganization(OpenRTM_aist.Organization_impl):
                 "port_name: %s is in %s?",
                 (port_name,
                  OpenRTM_aist.flatten(portlist)))
-            if not port_name in portlist:
+            if port_name not in portlist:
                 self._rtcout.RTC_DEBUG(
                     "Not found: %s is in %s?", (port_name, OpenRTM_aist.flatten(portlist)))
                 continue
@@ -509,7 +509,7 @@ class PeriodicECOrganization(OpenRTM_aist.Organization_impl):
                 "port_name: %s is in %s?",
                 (port_name,
                  OpenRTM_aist.flatten(portlist)))
-            if not port_name in portlist:
+            if port_name not in portlist:
                 self._rtcout.RTC_DEBUG(
                     "Not found: %s is in %s?", (port_name, OpenRTM_aist.flatten(portlist)))
                 continue
@@ -968,13 +968,8 @@ class PeriodicECSharedComposite(OpenRTM_aist.DataFlowComponentBase):
         sdos = self._org.get_members()
 
         for sdo in sdos:
-            orglist = rtc.get_owned_organizations()
-            for org in orglist:
-                child_sdos = org.get_members()
-                for child_sdo in child_sdos:
-                    child = child_sdo._narrow(RTC.RTObject)
-
-                    self.resetChildComp(child)
+            rtc = sdo._narrow(RTC.RTObject)
+            self.resetChildComp(rtc)
 
         return RTC.RTC_OK
 

--- a/OpenRTM_aist/PeriodicExecutionContext.py
+++ b/OpenRTM_aist/PeriodicExecutionContext.py
@@ -149,7 +149,7 @@ class PeriodicExecutionContext(OpenRTM_aist.ExecutionContextBase,
 
         if self._cpu:
             ret = OpenRTM_aist.setThreadAffinity(self._cpu)
-            if ret == False:
+            if ret is False:
                 self._rtcout.RTC_ERROR("CPU affinity mask setting failed")
                 
         while self.threadRunning():
@@ -631,13 +631,13 @@ class PeriodicExecutionContext(OpenRTM_aist.ExecutionContextBase,
 
     def onAddedComponent(self, rtobj):
         guard = OpenRTM_aist.ScopedLock(self._workerthread._mutex)
-        if self._workerthread._running == False:
+        if self._workerthread._running is False:
             self._worker.updateComponentList()
         return RTC.RTC_OK
 
     def onRemovedComponent(self, rtobj):
         guard = OpenRTM_aist.ScopedLock(self._workerthread._mutex)
-        if self._workerthread._running == False:
+        if self._workerthread._running is False:
             self._worker.updateComponentList()
         return RTC.RTC_OK
 
@@ -652,7 +652,7 @@ class PeriodicExecutionContext(OpenRTM_aist.ExecutionContextBase,
         # If worker thread is stopped, restart worker thread.
         if self.isRunning():
             guard = OpenRTM_aist.ScopedLock(self._workerthread._mutex)
-            if self._workerthread._running == False:
+            if self._workerthread._running is False:
                 self._workerthread._running = True
                 self._workerthread._cond.acquire()
                 self._workerthread._cond.notify()
@@ -677,7 +677,7 @@ class PeriodicExecutionContext(OpenRTM_aist.ExecutionContextBase,
         # If worker thread is stopped, restart worker thread.
         if self.isRunning():
             guard = OpenRTM_aist.ScopedLock(self._workerthread._mutex)
-            if self._workerthread._running == False:
+            if self._workerthread._running is False:
                 self._workerthread._running = True
                 self._workerthread._cond.acquire()
                 self._workerthread._cond.notify()
@@ -696,7 +696,7 @@ class PeriodicExecutionContext(OpenRTM_aist.ExecutionContextBase,
                                    self.getStateString(comp.getStates().next)))
         if self.isAllNextState(RTC.INACTIVE_STATE):
             guard = OpenRTM_aist.ScopedLock(self._workerthread._mutex)
-            if self._workerthread._running == True:
+            if self._workerthread._running is True:
                 self._workerthread._running = False
                 self._rtcout.RTC_TRACE(
                     "All RTCs are INACTIVE. Stopping worker thread.")
@@ -714,7 +714,7 @@ class PeriodicExecutionContext(OpenRTM_aist.ExecutionContextBase,
                                    self.getStateString(comp.getStates().next)))
         if self.isAllNextState(RTC.INACTIVE_STATE):
             guard = OpenRTM_aist.ScopedLock(self._workerthread._mutex)
-            if self._workerthread._running == True:
+            if self._workerthread._running is True:
                 self._workerthread._running = False
                 self._rtcout.RTC_TRACE(
                     "All RTCs are INACTIVE. Stopping worker thread.")
@@ -732,7 +732,7 @@ class PeriodicExecutionContext(OpenRTM_aist.ExecutionContextBase,
                                    self.getStateString(comp.getStates().next)))
         if self.isAllNextState(RTC.INACTIVE_STATE):
             guard = OpenRTM_aist.ScopedLock(self._workerthread._mutex)
-            if self._workerthread._running == True:
+            if self._workerthread._running is True:
                 self._workerthread._running = False
                 self._rtcout.RTC_TRACE(
                     "All RTCs are INACTIVE. Stopping worker thread.")
@@ -750,7 +750,7 @@ class PeriodicExecutionContext(OpenRTM_aist.ExecutionContextBase,
                                    self.getStateString(comp.getStates().next)))
         if self.isAllNextState(RTC.INACTIVE_STATE):
             guard = OpenRTM_aist.ScopedLock(self._workerthread._mutex)
-            if self._workerthread._running == True:
+            if self._workerthread._running is True:
                 self._workerthread._running = False
                 self._rtcout.RTC_TRACE(
                     "All RTCs are INACTIVE. Stopping worker thread.")

--- a/OpenRTM_aist/RTObject.py
+++ b/OpenRTM_aist/RTObject.py
@@ -4337,38 +4337,6 @@ class RTObject_impl:
 
     ##
     # @if jp
-    #
-    # @brief ConfigurationSetNameListener を削除する
-    #
-    # addConfigurationSetNameListener で追加されたリスナオブジェクトを
-    # 削除する。
-    #
-    # @param type ConfigurationSetNameListenerType型の値。
-    #             ON_UPDATE_CONFIG_PARAM がある。
-    # @param listener 与えたリスナオブジェクトへのポインタ
-    #
-    # @else
-    #
-    # @brief Removing ConfigurationSetNameListener
-    #
-    # This function removes a listener object which is added by
-    # addConfigurationSetNameListener() function.
-    #
-    # @param type ConfigurationSetNameListenerType value
-    #             ON_UPDATE_CONFIG_PARAM is only allowed.
-    # @param listener a pointer to ConfigurationSetNameListener
-    #             listener object.
-    #
-    # @endif
-    # void
-    # removeConfigurationSetNameListener(ConfigurationSetNameListenerType type,
-    # ConfigurationSetNameListener* listener);
-    def removeConfigurationSetNameListener(self, type, listener):
-        self._configsets.removeConfigurationSetNameListener(type, listener)
-        return
-
-    ##
-    # @if jp
     # @brief PreFsmActionListener リスナを追加する
     #
     # FsmAction 実装関数の呼び出し直前のイベントに関連する各種リ
@@ -5215,7 +5183,7 @@ class RTObject_impl:
                                        (ec_type_, ec_name_))
             else:
                 # If EC's name is empty or no existing EC, create new EC.
-                if not ec_type_ in avail_ec_:
+                if ec_type_ not in avail_ec_:
                     self._rtcout.RTC_WARN("EC %s is not available.", ec_type_)
                     self._rtcout.RTC_DEBUG("Available ECs: %s",
                                            OpenRTM_aist.flatten(avail_ec_))
@@ -5245,7 +5213,7 @@ class RTObject_impl:
             default_prop.setDefaults(OpenRTM_aist.default_config)
 
             ec_type_ = default_prop.getProperty("exec_cxt.periodic.type")
-            if not ec_type_ in avail_ec_:
+            if ec_type_ not in avail_ec_:
                 self._rtcout.RTC_WARN("EC %s is not available.", ec_type_)
                 self._rtcout.RTC_DEBUG("Available ECs: %s",
                                        OpenRTM_aist.flatten(avail_ec_))

--- a/OpenRTM_aist/RTObjectBase.py
+++ b/OpenRTM_aist/RTObjectBase.py
@@ -5126,9 +5126,9 @@ class RTObjectBase:
         if self._manager:
             eclist_ = self._manager.createdExecutionContexts()
             for e_ in eclist_:
-                if ec.getProperties().getProperty("type") == ec_arg.getProperty("type") and \
-                        ec.getProperties().getProperty("name") == ec_arg.getProperty("name"):
-                    return RTC.RTC_OK, ec
+                if e_.getProperties().getProperty("type") == ec_arg.getProperty("type") and \
+                        e_.getProperties().getProperty("name") == ec_arg.getProperty("name"):
+                    return RTC.RTC_OK, e_
 
         return RTC.RTC_ERROR, None
 
@@ -5151,7 +5151,7 @@ class RTObjectBase:
                                        (ec_type_, ec_name_))
             else:
                 # If EC's name is empty or no existing EC, create new EC.
-                if not ec_type_ in avail_ec_:
+                if ec_type_ not in avail_ec_:
                     self._rtcout.RTC_WARN("EC %s is not available.", ec_type_)
                     self._rtcout.RTC_DEBUG("Available ECs: %s",
                                            OpenRTM_aist.flatten(avail_ec_))
@@ -5182,7 +5182,7 @@ class RTObjectBase:
 
             ec_ = [None]
             ec_type_ = default_prop.getProperty("exec_cxt.periodic.type")
-            if not ec_type_ in avail_ec_:
+            if ec_type_ not in avail_ec_:
                 self._rtcout.RTC_WARN("EC %s is not available.", ec_type_)
                 self._rtcout.RTC_DEBUG("Available ECs: %s",
                                        OpenRTM_aist.flatten(avail_ec_))

--- a/OpenRTM_aist/__init__.py
+++ b/OpenRTM_aist/__init__.py
@@ -128,7 +128,6 @@ from InPortDSProvider import *
 from FsmObject import *
 from FiniteStateMachineComponent import *
 import Macho
-from Timestamp import *
 from MultilayerCompositeEC import *
 #from MultilayerCompositeChildEC import *
 from ByteDataStreamBase import *

--- a/OpenRTM_aist/ext/sdo/observer/ComponentObserverConsumer.py
+++ b/OpenRTM_aist/ext/sdo/observer/ComponentObserverConsumer.py
@@ -1005,7 +1005,7 @@ class ComponentObserverConsumer(OpenRTM_aist.SdoServiceConsumerBase):
             self._portname = portname
 
         def onBufferWrite(self, info, cdrdata):
-            param = self._portname + ":" + info
+            msg_ = self._portname + ":" + info
             self._coc.updateStatus(OpenRTM.CONFIGURATION, msg_)
             return
 

--- a/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceInPort.py
+++ b/OpenRTM_aist/ext/transport/OpenSplice/OpenSpliceInPort.py
@@ -214,7 +214,7 @@ class OpenSpliceInPort(OpenRTM_aist.InPortProvider):
             self._rtcout.RTC_PARANOID("OpenSpliceInPort.put()")
             if not self._connector:
                 self.onReceiverError(data)
-                return OpenRTM.PORT_ERROR
+                return
 
             data = self.onReceived(data)
 

--- a/OpenRTM_aist/ext/transport/ROS2Transport/ROS2InPort.py
+++ b/OpenRTM_aist/ext/transport/ROS2Transport/ROS2InPort.py
@@ -245,7 +245,7 @@ class ROS2InPort(OpenRTM_aist.InPortProvider):
             self._rtcout.RTC_PARANOID("ROS2InPort.put()")
             if not self._connector:
                 self.onReceiverError(data)
-                return OpenRTM.PORT_ERROR
+                return
 
             data = self.onReceived(data)
 

--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSOutPort.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSOutPort.py
@@ -36,7 +36,6 @@ import time
 import sys
 import threading
 import os
-import time
 
 
 ##


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

flake8の静的解析の結果、以下の警告、エラーが発生した。

```
OpenRTM_aist/CORBA_CdrMemoryStream.py:188:1: W391 blank line at end of file
OpenRTM_aist/CORBA_IORUtil.py:226:5: F405 'cdrUnmarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:237:12: F405 'cdrMarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:256:10: E231 missing whitespace after ','
OpenRTM_aist/CORBA_IORUtil.py:283:8: F405 'sys' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:293:8: F405 'sys' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:294:15: F405 'cdrUnmarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:297:15: F405 'cdrUnmarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:308:16: F405 'sys' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:309:25: F405 'cdrUnmarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:312:25: F405 'cdrUnmarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:319:16: F405 'sys' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:320:28: F405 'cdrUnmarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:323:28: F405 'cdrUnmarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:337:16: F405 'sys' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:338:24: F405 'cdrUnmarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:340:27: F405 'cdrUnmarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:343:24: F405 'cdrUnmarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:345:27: F405 'cdrUnmarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:349:16: F405 'sys' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:350:24: F405 'cdrUnmarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:352:28: F405 'cdrUnmarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:355:24: F405 'cdrUnmarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:357:28: F405 'cdrUnmarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:388:16: F405 'sys' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:389:25: F405 'cdrUnmarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:392:25: F405 'cdrUnmarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_IORUtil.py:396:30: F405 'cdrMarshal' may be undefined, or defined from star imports: IORProfile_idl, omniORB
OpenRTM_aist/CORBA_SeqUtil.py:87:10: E231 missing whitespace after ','
OpenRTM_aist/CSPInPort.py:341:17: W291 trailing whitespace
OpenRTM_aist/CSPInPort.py:342:19: W291 trailing whitespace
OpenRTM_aist/CSPInPort.py:352:45: F821 undefined name 'value'
OpenRTM_aist/CSPInPort.py:1243:23: W291 trailing whitespace
OpenRTM_aist/ConfigAdmin.py:512:13: E741 ambiguous variable name 'l'
OpenRTM_aist/ConnectorListener.py:787:12: F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
OpenRTM_aist/EventPort_pyfsm.py:81:55: F821 undefined name 'data_'
OpenRTM_aist/ExecutionContextBase.py:421:9: E704 multiple statements on one line (def)
OpenRTM_aist/ExecutionContextBase.py:761:64: W504 line break after binary operator
OpenRTM_aist/ExecutionContextBase.py:850:55: W504 line break after binary operator
OpenRTM_aist/ExecutionContextBase.py:935:59: W504 line break after binary operator
OpenRTM_aist/ExecutionContextBase.py:1506:9: E704 multiple statements on one line (def)
OpenRTM_aist/ExecutionContextWorker.py:487:9: E704 multiple statements on one line (def)
OpenRTM_aist/ExecutionContextWorker.py:537:17: F821 undefined name 'guard'
OpenRTM_aist/ExecutionContextWorker.py:542:26: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
OpenRTM_aist/ExecutionContextWorker.py:638:26: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
OpenRTM_aist/ExtTrigExecutionContext.py:123:9: E704 multiple statements on one line (def)
OpenRTM_aist/ExtTrigExecutionContext.py:413:39: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
OpenRTM_aist/ExtTrigExecutionContext.py:419:39: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
OpenRTM_aist/FiniteStateMachineComponent.py:76:15: F821 undefined name 'RTC'
OpenRTM_aist/FiniteStateMachineComponent.py:82:19: F821 undefined name 'RTC'
OpenRTM_aist/FiniteStateMachineComponentBase.py:285:5: F811 redefinition of unused 'get_owned_contexts' from line 253
OpenRTM_aist/FsmActionListener.py:1790:17: W291 trailing whitespace
OpenRTM_aist/GlobalFactory.py:37:12: E713 test for membership should be 'not in'
OpenRTM_aist/GlobalFactory.py:67:12: E713 test for membership should be 'not in'
OpenRTM_aist/GlobalFactory.py:76:12: E713 test for membership should be 'not in'
OpenRTM_aist/InPort.py:155:32: E712 comparison to True should be 'if cond is True:' or 'if cond:'
OpenRTM_aist/InPort.py:229:32: E712 comparison to True should be 'if cond is True:' or 'if cond:'
OpenRTM_aist/InPort.py:350:32: E712 comparison to True should be 'if cond is True:' or 'if cond:'
OpenRTM_aist/InPortCSPProvider.py:148:5: E301 expected 1 blank line, found 0
OpenRTM_aist/InPortDuplexConnector.py:473:5: E303 too many blank lines (2)
OpenRTM_aist/InPortPullConnector.py:415:5: E303 too many blank lines (2)
OpenRTM_aist/InPortPullConnector.py:417:117: W292 no newline at end of file
OpenRTM_aist/InPortPushConnector.py:349:48: E712 comparison to True should be 'if cond is True:' or 'if cond:'
OpenRTM_aist/Macho.py:186:31: F821 undefined name 'self'
OpenRTM_aist/Macho.py:235:29: F821 undefined name 'self'
OpenRTM_aist/Macho.py:446:5: F811 redefinition of unused 'name' from line 434
OpenRTM_aist/Macho.py:1008:27: F821 undefined name 'key'
OpenRTM_aist/Macho.py:1179:5: F811 redefinition of unused '_current_state' from line 1177
OpenRTM_aist/Manager.py:101:1: E303 too many blank lines (4)
OpenRTM_aist/Manager.py:116:1: E302 expected 2 blank lines, found 4
OpenRTM_aist/Manager.py:452:1: W293 blank line contains whitespace
OpenRTM_aist/Manager.py:492:21: E126 continuation line over-indented for hanging indent
OpenRTM_aist/Manager.py:533:1: W293 blank line contains whitespace
OpenRTM_aist/Manager.py:535:5: E303 too many blank lines (2)
OpenRTM_aist/Manager.py:568:5: E301 expected 1 blank line, found 0
OpenRTM_aist/Manager.py:902:18: E231 missing whitespace after ','
OpenRTM_aist/Manager.py:1163:12: E713 test for membership should be 'not in'
OpenRTM_aist/Manager.py:1421:17: E126 continuation line over-indented for hanging indent
OpenRTM_aist/Manager.py:1424:9: E303 too many blank lines (2)
OpenRTM_aist/Manager.py:1425:36: E127 continuation line over-indented for visual indent
OpenRTM_aist/Manager.py:1634:13: E741 ambiguous variable name 'l'
OpenRTM_aist/Manager.py:2101:20: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
OpenRTM_aist/Manager.py:2334:36: E127 continuation line over-indented for visual indent
OpenRTM_aist/Manager.py:3356:5: E303 too many blank lines (2)
OpenRTM_aist/Manager.py:3386:5: E301 expected 1 blank line, found 0
OpenRTM_aist/Manager.py:3455:13: W291 trailing whitespace
OpenRTM_aist/Manager.py:3481:13: W291 trailing whitespace
OpenRTM_aist/Manager.py:3486:14: W291 trailing whitespace
OpenRTM_aist/Manager.py:3506:13: W291 trailing whitespace
OpenRTM_aist/Manager.py:3510:14: W291 trailing whitespace
OpenRTM_aist/Manager.py:3518:5: E303 too many blank lines (2)
OpenRTM_aist/Manager.py:3529:5: E301 expected 1 blank line, found 0
OpenRTM_aist/Manager.py:3649:13: E117 over-indented (comment)
OpenRTM_aist/Manager.py:3678:5: E303 too many blank lines (4)
OpenRTM_aist/ManagerActionListener.py:790:9: F723 syntax error in type comment ''
OpenRTM_aist/ManagerActionListener.py:809:9: F723 syntax error in type comment ''
OpenRTM_aist/ManagerActionListener.py:828:9: F723 syntax error in type comment ''
OpenRTM_aist/ManagerConfig.py:345:44: W504 line break after binary operator
OpenRTM_aist/ManagerConfig.py:346:38: W504 line break after binary operator
OpenRTM_aist/ManagerServant.py:1391:36: W504 line break after binary operator
OpenRTM_aist/ManagerServant.py:1392:39: W504 line break after binary operator
OpenRTM_aist/ManagerServant.py:1398:40: W504 line break after binary operator
OpenRTM_aist/ManagerServant.py:1399:26: W504 line break after binary operator
OpenRTM_aist/ManagerServant.py:1546:36: W504 line break after binary operator
OpenRTM_aist/ManagerServant.py:1547:39: W504 line break after binary operator
OpenRTM_aist/ManagerServant.py:1552:40: W504 line break after binary operator
OpenRTM_aist/ManagerServant.py:1553:26: W504 line break after binary operator
OpenRTM_aist/ModuleManager.py:540:9: E741 ambiguous variable name 'l'
OpenRTM_aist/ModuleManager.py:624:9: E741 ambiguous variable name 'l'
OpenRTM_aist/ModuleManager.py:845:35: E226 missing whitespace around arithmetic operator
OpenRTM_aist/ModuleManager.py:845:57: E226 missing whitespace around arithmetic operator
OpenRTM_aist/ModuleManager.py:879:31: E226 missing whitespace around arithmetic operator
OpenRTM_aist/ModuleManager.py:879:53: E226 missing whitespace around arithmetic operator
OpenRTM_aist/OutPortConnector.py:281:30: W292 no newline at end of file
OpenRTM_aist/OutPortDuplexConnector.py:433:40: F821 undefined name 'cdr_data'
OpenRTM_aist/OutPortDuplexConnector.py:462:5: E303 too many blank lines (2)
OpenRTM_aist/PeriodicECSharedComposite.py:474:16: E713 test for membership should be 'not in'
OpenRTM_aist/PeriodicECSharedComposite.py:512:16: E713 test for membership should be 'not in'
OpenRTM_aist/PeriodicECSharedComposite.py:971:23: F821 undefined name 'rtc'
OpenRTM_aist/PeriodicExecutionContext.py:152:20: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
OpenRTM_aist/PeriodicExecutionContext.py:154:1: W293 blank line contains whitespace
OpenRTM_aist/PeriodicExecutionContext.py:634:40: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
OpenRTM_aist/PeriodicExecutionContext.py:640:40: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
OpenRTM_aist/PeriodicExecutionContext.py:655:44: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
OpenRTM_aist/PeriodicExecutionContext.py:680:44: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
OpenRTM_aist/PeriodicExecutionContext.py:699:44: E712 comparison to True should be 'if cond is True:' or 'if cond:'
OpenRTM_aist/PeriodicExecutionContext.py:717:44: E712 comparison to True should be 'if cond is True:' or 'if cond:'
OpenRTM_aist/PeriodicExecutionContext.py:735:44: E712 comparison to True should be 'if cond is True:' or 'if cond:'
OpenRTM_aist/PeriodicExecutionContext.py:753:44: E712 comparison to True should be 'if cond is True:' or 'if cond:'
OpenRTM_aist/PortBase.py:2431:32: E226 missing whitespace around arithmetic operator
OpenRTM_aist/PortBase.py:2465:14: W605 invalid escape sequence '\p'
OpenRTM_aist/PortBase.py:2471:14: W605 invalid escape sequence '\p'
OpenRTM_aist/PortBase.py:2485:14: W605 invalid escape sequence '\p'
OpenRTM_aist/PortBase.py:2491:14: W605 invalid escape sequence '\p'
OpenRTM_aist/PortBase.py:2505:14: W605 invalid escape sequence '\p'
OpenRTM_aist/PortBase.py:2506:14: W605 invalid escape sequence '\p'
OpenRTM_aist/PortBase.py:2514:14: W605 invalid escape sequence '\p'
OpenRTM_aist/PortBase.py:2531:14: W605 invalid escape sequence '\p'
OpenRTM_aist/PortBase.py:2532:14: W605 invalid escape sequence '\p'
OpenRTM_aist/PortBase.py:2540:14: W605 invalid escape sequence '\p'
OpenRTM_aist/PortBase.py:2557:14: W605 invalid escape sequence '\p'
OpenRTM_aist/PortBase.py:2564:14: W605 invalid escape sequence '\p'
OpenRTM_aist/PortBase.py:2580:14: W605 invalid escape sequence '\p'
OpenRTM_aist/PortBase.py:2581:14: W605 invalid escape sequence '\p'
OpenRTM_aist/PortBase.py:2588:14: W605 invalid escape sequence '\p'
OpenRTM_aist/Properties.py:1144:43: W504 line break after binary operator
OpenRTM_aist/Properties.py:1250:17: E741 ambiguous variable name 'l'
OpenRTM_aist/Properties.py:1275:17: E741 ambiguous variable name 'l'
OpenRTM_aist/Properties.py:1349:13: E741 ambiguous variable name 'l'
OpenRTM_aist/PublisherNew.py:124:5: E303 too many blank lines (2)
OpenRTM_aist/PublisherNew.py:132:5: E301 expected 1 blank line, found 0
OpenRTM_aist/PublisherPeriodic.py:110:13: W291 trailing whitespace
OpenRTM_aist/RTCUtil.py:145:23: E111 indentation is not a multiple of 4
OpenRTM_aist/RTCUtil.py:145:23: E117 over-indented
OpenRTM_aist/RTCUtil.py:151:23: E111 indentation is not a multiple of 4
OpenRTM_aist/RTCUtil.py:151:23: E117 over-indented
OpenRTM_aist/RTCUtil.py:156:23: E111 indentation is not a multiple of 4
OpenRTM_aist/RTCUtil.py:156:23: E117 over-indented
OpenRTM_aist/RTCUtil.py:163:23: E111 indentation is not a multiple of 4
OpenRTM_aist/RTCUtil.py:163:23: E117 over-indented
OpenRTM_aist/RTObject.py:525:9: E704 multiple statements on one line (def)
OpenRTM_aist/RTObject.py:4366:5: F811 redefinition of unused 'removeConfigurationSetNameListener' from line 4334
OpenRTM_aist/RTObject.py:5218:20: E713 test for membership should be 'not in'
OpenRTM_aist/RTObject.py:5248:16: E713 test for membership should be 'not in'
OpenRTM_aist/RTObject.py:5286:1: W293 blank line contains whitespace
OpenRTM_aist/RTObject.py:5290:37: E128 continuation line under-indented for visual indent
OpenRTM_aist/RTObjectBase.py:522:9: E704 multiple statements on one line (def)
OpenRTM_aist/RTObjectBase.py:600:15: E114 indentation is not a multiple of 4 (comment)
OpenRTM_aist/RTObjectBase.py:600:15: E117 over-indented (comment)
OpenRTM_aist/RTObjectBase.py:678:19: E114 indentation is not a multiple of 4 (comment)
OpenRTM_aist/RTObjectBase.py:5129:20: F821 undefined name 'ec'
OpenRTM_aist/RTObjectBase.py:5130:25: F821 undefined name 'ec'
OpenRTM_aist/RTObjectBase.py:5131:40: F821 undefined name 'ec'
OpenRTM_aist/RTObjectBase.py:5154:20: E713 test for membership should be 'not in'
OpenRTM_aist/RTObjectBase.py:5185:16: E713 test for membership should be 'not in'
OpenRTM_aist/RTObjectBase.py:5226:41: E127 continuation line over-indented for visual indent
OpenRTM_aist/SharedMemory.py:178:41: W504 line break after binary operator
OpenRTM_aist/SharedMemory.py:179:34: W504 line break after binary operator
OpenRTM_aist/SharedMemory.py:180:33: W504 line break after binary operator
OpenRTM_aist/SharedMemory.py:235:35: W504 line break after binary operator
OpenRTM_aist/SharedMemory.py:236:30: W504 line break after binary operator
OpenRTM_aist/SharedMemory.py:237:29: W504 line break after binary operator
OpenRTM_aist/StringUtil.py:281:40: W504 line break after binary operator
OpenRTM_aist/TimeValue.py:76:60: W504 line break after binary operator
OpenRTM_aist/TimeValue.py:194:57: W504 line break after binary operator
OpenRTM_aist/TimeValue.py:213:56: W504 line break after binary operator
OpenRTM_aist/TimeValue.py:232:47: W504 line break after binary operator
OpenRTM_aist/Timer.py:182:1: E302 expected 2 blank lines, found 1
OpenRTM_aist/__init__.py:2:11: E401 multiple imports on one line
OpenRTM_aist/__init__.py:2:11: E231 missing whitespace after ','
OpenRTM_aist/__init__.py:131:1: F811 redefinition of unused 'Timestamp.*' from line 123
```


## Description of the Change

以下の警告、エラーについては修正した。

- 変数名の間違い、モジュールのimport漏れによる未定義エラー(F405、F821)
- 比較演算子の警告修正
  - `a == False` -> `a is False`
  -  `not a in b` -> `a not in b`
  - `a is 0` -> `a == 0`
- 同じ関数が2回定義されている箇所があったため片方を削除



この他にも空白、インデント等の警告が発生しているが、今回は修正しない。

## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
