### PR TITLE
ネームサーバー接続失敗時、オブジェクト取得時のエラーメッセージを出力しないようにする

### DIFF
--- a/OpenRTM_aist/CorbaNaming.py
+++ b/OpenRTM_aist/CorbaNaming.py
@@ -86,15 +86,11 @@ class CorbaNaming:
 
         if name_server:
             self._nameServer = "corbaloc::" + name_server + "/NameService"
-            try:
-                obj = orb.string_to_object(self._nameServer)
-                self._rootContext = obj._narrow(CosNaming.NamingContext)
-                if CORBA.is_nil(self._rootContext):
-                    print("CorbaNaming: Failed to narrow the root naming context.")
-
-            except CORBA.ORB.InvalidName:
-                self.__print_exception()
-                print("Service required is invalid [does not exist].")
+            obj = orb.string_to_object(self._nameServer)
+            self._rootContext = obj._narrow(CosNaming.NamingContext)
+            if CORBA.is_nil(self._rootContext):
+                print("CorbaNaming: Failed to narrow the root naming context.")
+                raise MemoryError
 
         return
 
@@ -346,14 +342,12 @@ class CorbaNaming:
             if force:
                 self.rebindRecursive(self._rootContext, name_list, obj)
             else:
-                self.__print_exception()
                 raise
 
         except CosNaming.NamingContext.CannotProceed as err:
             if force:
                 self.rebindRecursive(err.cxt, err.rest_of_name, obj)
             else:
-                self.__print_exception()
                 raise
 
     ##
@@ -570,12 +564,8 @@ class CorbaNaming:
         else:
             name_ = name
 
-        try:
-            obj = self._rootContext.resolve(name_)
-            return obj
-        except CosNaming.NamingContext.NotFound:
-            self.__print_exception()
-            return None
+        obj = self._rootContext.resolve(name_)
+        return obj
 
     ##
     # @if jp
@@ -614,7 +604,7 @@ class CorbaNaming:
         try:
             self._rootContext.unbind(name_)
         except BaseException:
-            self.__print_exception()
+            raise
 
         return
 
@@ -679,14 +669,12 @@ class CorbaNaming:
             if force:
                 self.bindRecursive(self._rootContext, name_, self.newContext())
             else:
-                self.__print_exception()
                 raise
         except CosNaming.NamingContext.CannotProceed as err:
             if force:
                 self.bindRecursive(
                     err.cxt, err.rest_of_name, self.newContext())
             else:
-                self.__print_exception()
                 raise
         return None
 

--- a/OpenRTM_aist/CorbaNaming.py
+++ b/OpenRTM_aist/CorbaNaming.py
@@ -601,10 +601,7 @@ class CorbaNaming:
         else:
             name_ = name
 
-        try:
-            self._rootContext.unbind(name_)
-        except BaseException:
-            raise
+        self._rootContext.unbind(name_)
 
         return
 

--- a/OpenRTM_aist/NamingManager.py
+++ b/OpenRTM_aist/NamingManager.py
@@ -353,6 +353,8 @@ class NamingOnCorba(NamingBase):
                             rtc_list.append(obj)
                             return rtc_list
                     except BaseException:
+                        self._rtcout.RTC_ERROR(
+                            OpenRTM_aist.Logger.print_exception())
                         return []
 
         return rtc_list
@@ -672,6 +674,8 @@ class NamingManager:
                 try:
                     n.ns.bindObject(name, rtobj)
                 except BaseException:
+                    self._rtcout.RTC_DEBUG(
+                        OpenRTM_aist.Logger.print_exception())
                     del n.ns
                     n.ns = None
 
@@ -685,6 +689,8 @@ class NamingManager:
                 try:
                     n.ns.bindObject(name, mgr)
                 except BaseException:
+                    self._rtcout.RTC_DEBUG(
+                        OpenRTM_aist.Logger.print_exception())
                     del n.ns
                     n.ns = None
 
@@ -715,6 +721,8 @@ class NamingManager:
                 try:
                     n.ns.bindPortObject(name, port)
                 except BaseException:
+                    self._rtcout.RTC_DEBUG(
+                        OpenRTM_aist.Logger.print_exception())
                     del n.ns
                     n.ns = None
         self.registerPortName(name, port)
@@ -756,6 +764,8 @@ class NamingManager:
                         del name.ns
                         name.ns = None
                 except BaseException:
+                    self._rtcout.RTC_DEBUG(
+                        OpenRTM_aist.Logger.print_exception())
                     self._rtcout.RTC_INFO("Name server: %s (%s) disappeared.",
                                           (name.nsname,
                                            name.method))
@@ -873,6 +883,7 @@ class NamingManager:
                                       (method, name_server))
                 return name
             except BaseException:
+                self._rtcout.RTC_DEBUG(OpenRTM_aist.Logger.print_exception())
                 self._rtcout.RTC_INFO("NameServer connection failed: %s/%s",
                                       (method, name_server))
                 return None
@@ -1052,6 +1063,7 @@ class NamingManager:
                                        (ns.method, ns.nsname))
 
         except BaseException:
+            self._rtcout.RTC_DEBUG(OpenRTM_aist.Logger.print_exception())
             self._rtcout.RTC_DEBUG("Name server: %s/%s disappeared again.",
                                    (ns.method, ns.nsname))
             if nsobj is not None:


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug


## Description of the Change

CorbaNamingでルートコンテキストの取得失敗時(`_narrow(CosNaming.NamingContext)`)、オブジェクト取得失敗時(`self._rootContext.resolve(name_)`)等にエラーメッセージを標準出力するが、C++版と同様にこれを出力せずにNamingManagerで例外処理するように変更した。

以下の関数については動作が変わっている。

- CorbaNaming.__init__関数：ルートコンテキストがnilの場合は例外を投げる。以前はそのまま関数が終了していた。
- CorbaNaming.resolve関数：self._rootContext.resolve関数が例外を投げた場合にresolve関数内で例外処理しない。以前はresolve関数内で例外処理してNoneを返していた。
- 


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
