### PR TITLE
rtc.confのバックスラッシュの後にスペースがある場合、urlparam2mapで空白のパラメータがある場合に設定を無視する

### DIFF
--- a/OpenRTM_aist/Properties.py
+++ b/OpenRTM_aist/Properties.py
@@ -761,6 +761,7 @@ class Properties:
 
             _str = _str.rstrip('\r\n')
             _str = _str.rstrip('\n')
+            _str = _str.strip()
 
             if not _str:
                 continue

--- a/OpenRTM_aist/Properties.py
+++ b/OpenRTM_aist/Properties.py
@@ -382,6 +382,8 @@ class Properties:
     # @endif
 
     def getProperty(self, key, default=None):
+        if not key.strip():
+            return self.empty
         if default is None:
             keys = []
             #keys = str.split(key, ".")
@@ -419,6 +421,8 @@ class Properties:
     # @endif
 
     def getDefault(self, key):
+        if not key.strip():
+            return self.empty
         keys = []
         #keys = str.split(key, ".")
         self.split(key, ".", keys)
@@ -459,6 +463,8 @@ class Properties:
     # @endif
 
     def setProperty(self, key, value=None):
+        if not key.strip():
+            return value
         if value is not None:
             keys = []
             #keys = str.split(key, ".")
@@ -965,7 +971,7 @@ class Properties:
     # Properties* const Properties::findNode(const std::string& key) const
 
     def findNode(self, key):
-        if not key:
+        if not key.strip():
             return None
 
         keys = []
@@ -988,7 +994,7 @@ class Properties:
     # @endif
 
     def getNode(self, key):
-        if not key:
+        if not key.strip():
             return self
 
         leaf = self.findNode(key)
@@ -1016,7 +1022,7 @@ class Properties:
     # @endif
 
     def createNode(self, key):
-        if not key:
+        if not key.strip():
             return False
 
         if self.findNode(key):
@@ -1183,7 +1189,7 @@ class Properties:
     # @endif
 
     def split(self, _str, delim, value):
-        if _str == "":
+        if not _str.strip():
             return False
 
         begin_it = end_it = 0

--- a/OpenRTM_aist/StringUtil.py
+++ b/OpenRTM_aist/StringUtil.py
@@ -695,6 +695,8 @@ def urlparam2map(_str):
     tmp = _str[qpos:].split("&")
     retmap = {}
     for v in tmp:
+        if not v.strip():
+            continue
         pos = v.find("=")
         if pos != -1:
             retmap[v[0:pos]] = v[pos + 1:]


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

rtc.confで改行する場合のバックスラッシュの後にスペースがある場合に以下のエラーが発生する。

```
  File "C:\Python37\lib\site-packages\OpenRTM_aist\Properties.py", line 390, in getProperty
    node = self._getNode(keys, 0, self)
  File "C:\Python37\lib\site-packages\OpenRTM_aist\Properties.py", line 1224, in _getNode
    next = curr.hasKey(keys[index])
IndexError: list index out of range
```

```
manager.components.preconnect: ConsoleIn0.out?port=ConsoleOut0.in& \ <-ここにスペースがある
                                                    dataflow_type=push&interface_type=corba_cdr
```

またurlparam2map関数でパラメータが空白の場合にも同様のエラーが発生する。


```
manager.components.preconnect: ConsoleIn0.out?port=ConsoleOut0.in& \ 
                                                    dataflow_type=push&interface_type=corba_cdr&<-&だけ記述してパラメータを空白にする。
```

## Description of the Change

- Propertiesでキーの先頭、末尾の空白文字を削除して空文字だったら設定や取得の処理を行わない。
- urlparam2map関数で入力文字列が空白の場合、`=`の左辺が空白の場合はパラメータを設定しないようにした。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
