### PR TITLE
SliderコンポーネントがPython 3.10環境で実行できない問題の修正

### DIFF
--- a/OpenRTM_aist/examples/Slider_and_Motor/slider.py
+++ b/OpenRTM_aist/examples/Slider_and_Motor/slider.py
@@ -5,7 +5,7 @@
 from __future__ import print_function
 
 import time
-import dummy_threading
+import threading
 import sys
 if sys.version_info[0] == 2:
     from Tkinter import *
@@ -28,7 +28,7 @@ class SliderMulti(Frame):
 
         i = 0
         for channel in self._channels:
-            self.var.append(DoubleVar(0))
+            self.var.append(DoubleVar(value=0))
             self.scales.append(
                 Scale(self, label=channel[0], variable=self.var[i],
                       to=channel[1], orient=VERTICAL))
@@ -57,7 +57,7 @@ class SliderMulti(Frame):
 def test():
     channels = (("angle", 0, 360, 0.1, 200), ("velocity", -100, 100, 0.1, 200))
     slider = SliderMulti(channels)
-    sth = dummy_threading.Thread(target=slider.mainloop, args=())
+    sth = threading.Thread(target=slider.mainloop, args=())
     sth.start()
 #	thread.start_new_thread(slider.mainloop, ())
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

SliderコンポーネントをPython 3.10環境で実行すると、dummy_threadingの廃止とtkinterの仕様変更によりエラーになる。


## Description of the Change

- dummy_threadingをthreadingに変更した
- tkinter.DoubleVarの仕様変更に対応した


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
