### PR TITLE
openrtm2-python3のdebパッケージ作成に関する修正

### DIFF
--- a/packages/deb/debian/changelog
+++ b/packages/deb/debian/changelog
@@ -1,53 +1,6 @@
-openrtm-aist-python (2.0.0-0) experimental; urgency=low
+openrtm2-python3 (2.0.0-0) experimental; urgency=low
 
   * 2.0.0-0 (2.0.0-RELEASE). OpenRTM-aist-2.0.0-RELEASE
 
  -- Noriaki Ando <n-ando@aist.go.jp>  Thu, 29 Jul 2021 12:39:34 +0900
 
-openrtm-aist-python (1.2.2-0) experimental; urgency=low
-
-  * 1.2.2-0 (1.2.2-RELEASE). OpenRTM-aist-1.2.2-RELEASE
-
- -- Noriaki Ando <n-ando@aist.go.jp>  Mon, 23 Mar 2020 16:22:17 +0900
-
-openrtm-aist-python (1.2.1-0) experimental; urgency=low
-
-  * 1.2.1-0 (1.2.1-RELEASE). OpenRTM-aist-1.2.1-RELEASE
-
- -- Noriaki Ando <n-ando@aist.go.jp>  Fri, 24 May 2019 11:05:32 +0900
-
-openrtm-aist-python (1.2.0-0) experimental; urgency=low
-
-  * 1.2.0-0 (1.2.0-RELEASE). OpenRTM-aist-1.2.0-RELEASE
-
- -- Noriaki Ando <n-ando@aist.go.jp>  Wed, 16 Nov 2016 18:12:17 +0900
-
-openrtm-aist-python (1.1.2-0) experimental; urgency=low
-
-  * 1.1.2-0 (1.1.2-RELEASE). OpenRTM-aist-1.1.2-RELEASE
-
- -- Noriaki Ando <n-ando@aist.go.jp>  Tue, 23 Feb 2016 15:35:39 +0900
-
-openrtm-aist-python (1.1.1-0) precise; urgency=low
-
-  * 1.1.1-0 (1.1.1-RELEASE). OpenRTM-aist-1.1.1-RELEASE
-
- -- Noriaki Ando <n-ando@aist.go.jp>  Wed, 21 Oct 2015 15:40:25 +0900
-
-openrtm-aist-python (1.1.0-2) experimental; urgency=low
-
-  * 1.1.0-2 (1.1.0-RELEASE). OpenRTM-aist-1.1.0-RELEASE
-
- -- Noriaki Ando <n-ando@aist.go.jp>  Fri, 26 Apr 2013 03:00:00 +0900
- 
-openrtm-aist-python (1.1.0-1) experimental; urgency=low
-
-  * 1.1.0-1 (1.1.0-RELEASE). OpenRTM-aist-1.1.0-RELEASE
-
- -- Noriaki Ando <n-ando@aist.go.jp>  Fri, 26 Apr 2013 02:00:00 +0900
- 
-openrtm-aist-python (1.1.0-0) experimental; urgency=low
-
-  * 1.1.0-0 (1.1.0-RELEASE). OpenRTM-aist-1.1.0-RELEASE
-
- -- Noriaki Ando <n-ando@aist.go.jp>  Fri, 26 Apr 2013 01:36:44 +0900

--- a/packages/deb/debian/control
+++ b/packages/deb/debian/control
@@ -1,4 +1,4 @@
-Source: openrtm-aist-python
+Source: openrtm2-python3
 Section: main
 Priority: extra
 Maintainer: Noriaki Ando <n-ando@aist.go.jp>
@@ -6,7 +6,7 @@ Build-Depends: debhelper, python3-all-dev, python3-omniorb
 Standards-Version: 3.8.4
 Homepage: http://www.openrtm.org
 
-Package: openrtm-aist-python3
+Package: openrtm2-python3
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, python3-omniorb, omniorb-nameserver
 Description: OpenRTM-aist, RT-Middleware distributed by AIST
@@ -20,13 +20,13 @@ Description: OpenRTM-aist, RT-Middleware distributed by AIST
  National Institute of Advanced Industrial Science and Technology
  (AIST), Japan. Please see http://www.openrtm.org/ for more detail.
 
-Package: openrtm-aist-python3-example
+Package: openrtm2-python3-example
 Architecture: any
-Depends: openrtm-aist-python3
+Depends: openrtm2-python3
 Description: OpenRTM-aist-Python examples
  Example components and sources of OpenRTM-aist.
 
-Package: openrtm-aist-python3-doc
+Package: openrtm2-python3-doc
 Architecture: all
 Description: Documentation for openrtm-aist-python
  Class reference manual of OpenRTM-aist.

--- a/packages/deb/debian/copyright
+++ b/packages/deb/debian/copyright
@@ -9,7 +9,7 @@ Upstream Author(s):
 
 Copyright: 
 
-    Copyright (C) 2003-2017
+    Copyright (C) 2003-2022
     Noriaki Ando and the OpenRTM-aist Project team
     National Institute of Advanced Industrial Science and Technology (AIST),
     Tsukuba, Japan, All rights reserved.

--- a/packages/deb/debian/rules
+++ b/packages/deb/debian/rules
@@ -39,13 +39,13 @@ install: build
 	dh_installdirs
 
 	# installing core
-	python3 setup.py install_core --prefix=$(CURDIR)/debian/openrtm-aist-python3/usr --install-layout=deb
+	python3 setup.py install_core --prefix=$(CURDIR)/debian/openrtm2-python3/usr --install-layout=deb
 	# installing examples
-	(mkdir $(CURDIR)/debian/openrtm-aist-python3-example/usr/)
-	python3 setup.py install_example --install-dir=$(CURDIR)/debian/openrtm-aist-python3-example/usr/
+	(mkdir $(CURDIR)/debian/openrtm2-python3-example/usr/)
+	python3 setup.py install_example --install-dir=$(CURDIR)/debian/openrtm2-python3-example/usr/
 	# installing examples
-	(mkdir $(CURDIR)/debian/openrtm-aist-python3-doc/usr/)
-	python3 setup.py install_doc --install-dir=$(CURDIR)/debian/openrtm-aist-python3-doc/usr/
+	(mkdir $(CURDIR)/debian/openrtm2-python3-doc/usr/)
+	python3 setup.py install_doc --install-dir=$(CURDIR)/debian/openrtm2-python3-doc/usr/
 	dh_install -s
 
 # Build architecture-independent files here.

--- a/packages/deb/dpkg_build.sh
+++ b/packages/deb/dpkg_build.sh
@@ -37,10 +37,10 @@ BUILD_ROOT=""
 cleanup_files()
 {
   get_version_info
-  rm -f ../openrtm-aist*.deb
-  rm -f ../openrtm-aist*.dsc
-  rm -f ../openrtm-aist*.changes
-  rm -f ../openrtm-aist*.tar.gz
+  rm -f ../openrtm*.deb
+  rm -f ../openrtm*.dsc
+  rm -f ../openrtm*.changes
+  rm -f ../openrtm*.tar.gz
   rm -rf ${BUILD_ROOT}
 }
 
@@ -133,9 +133,9 @@ create_files()
   ARCH=$DEB_HOST_ARCH
   PKG_VERSION=`dpkg-parsechangelog | sed -n 's/^Version: //p'`
 cat << EOF >> debian/files
-openrtm-aist-python3_${PKG_VERSION}_${ARCH}.deb main extra
-openrtm-aist-python3-example_${PKG_VERSION}_${ARCH}.deb main extra
-openrtm-aist-python3-doc_${PKG_VERSION}_all.deb main extra
+openrtm2-python3_${PKG_VERSION}_${ARCH}.deb main extra
+openrtm2-python3-example_${PKG_VERSION}_${ARCH}.deb main extra
+openrtm2-python3-doc_${PKG_VERSION}_all.deb main extra
 EOF
 }
 
@@ -163,10 +163,10 @@ build_package()
 
 copy_debfiles()
 {
-  mv ./openrtm-aist*.deb ..
-  mv ./openrtm-aist*.dsc ..
-  mv ./openrtm-aist*.changes ..
-  mv ./openrtm-aist*.tar.gz ..
+  mv ./openrtm2*.deb ..
+  mv ./openrtm2*.dsc ..
+  mv ./openrtm2*.changes ..
+  mv ./openrtm2*.tar.gz ..
 }
 
 #==============================


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #286 
## Identify the Bug

Link to #286 


## Description of the Change

- Issueに記載した修正を加えた


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->
- 下記debパッケージの生成を確認
```
openrtm2-python3-doc_2.0.0-0_all.deb  openrtm2-python3-example_2.0.0-0_amd64.deb  
openrtm2-python3_2.0.0-0_amd64.deb
```
- マネージャー経由でのRTC起動動作確認
  - この動作確認では、PythonのPR285をマージしたソースを使用
  - rtc.confで下記を定義
  - rtcd_python3 -d を実行し、マネージャー経由でC++とJavaの各RTCを起動できることを確認
```
manager.modules.load_path:
manager.modules.Java.load_paths: /usr/share/openrtm-2.0/components/java/RTMExamples/SimpleIO
manager.modules.C++.load_paths: /usr/share/openrtm-2.0/components/c++/examples/rtc
```
- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
