### PR TITLE
appendStringValue関数でスペースが入らないように修正

### DIFF
--- a/OpenRTM_aist/NVUtil.py
+++ b/OpenRTM_aist/NVUtil.py
@@ -355,7 +355,7 @@ def appendStringValue(nv, name, value):
                 find_flag = True
 
         if not find_flag:
-            tmp_str += ", "
+            tmp_str += ","
             tmp_str += value
             nv[index].value = any.to_any(tmp_str)
     else:


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

OpenRTM-aist Python版のNVUtil.appendStringValue関数で``,``区切りの文字列を生成すると、以下のように文字列の先頭にスペースが入るようになっている。

```
corba_cdr, csp_channel, data_service, direct, shared_memory
```

これがRT System Editor側で空白を削除する処理がないため、先頭のcorba_cdr以外の接続時にエラーが発生して接続できない問題が発生する。

## Description of the Change

C++版と同様にスペースが入らないように修正した。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
