### PR TITLE
dataport.marshaling_types、dataport.subscription_typeの文字列の修正

### DIFF
--- a/OpenRTM_aist/InPort.py
+++ b/OpenRTM_aist/InPort.py
@@ -95,8 +95,8 @@ class InPort(OpenRTM_aist.InPortBase):
         self._valueMutex = threading.RLock()
 
         marshaling_types = OpenRTM_aist.SerializerFactories.instance().getSerializerList(value)
-        marshaling_types = OpenRTM_aist.flatten(marshaling_types).lstrip()
-        self.addProperty("dataport.marshaling_types", marshaling_types)
+        marshaling_types_str = ",".join([x.strip() for x in marshaling_types])
+        self.addProperty("dataport.marshaling_types", marshaling_types_str)
 
         self._listeners.setDataType(copy.deepcopy(value))
         self._listeners.setPortType(OpenRTM_aist.PortType.InPortType)

--- a/OpenRTM_aist/Manager.py
+++ b/OpenRTM_aist/Manager.py
@@ -405,7 +405,7 @@ class Manager:
 
         sdofactory_ = OpenRTM_aist.SdoServiceConsumerFactory.instance()
         self._config.setProperty("sdo.service.consumer.available_services",
-                                 OpenRTM_aist.flatten(sdofactory_.getIdentifiers()))
+                                 ",".join([x.strip() for x in sdofactory_.getIdentifiers()]))
 
         self.invokeInitProc()
         self.initPreCreation()
@@ -2657,10 +2657,8 @@ class Manager:
         naming_formats = self._config.getProperty("naming.formats")
         if comp_prop.findNode("naming.formats"):
             naming_formats = comp_prop.getProperty("naming.formats")
-        naming_formats = OpenRTM_aist.flatten(
-            OpenRTM_aist.unique_sv(
-                OpenRTM_aist.split(
-                    naming_formats, ",")))
+        naming_formats = ",".join([x.strip() for x in OpenRTM_aist.unique_sv(
+            OpenRTM_aist.split(naming_formats, ","))])
 
         naming_names = self.formatString(naming_formats, comp.getProperties())
         comp.getProperties().setProperty("naming.formats", naming_formats)
@@ -3161,7 +3159,7 @@ class Manager:
 
             tmp = port0_str.split(".")
             tmp.pop()
-            comp0_name = OpenRTM_aist.flatten(tmp, ".")
+            comp0_name = ".".join([x.strip() for x in tmp])
 
             port0_name = port0_str
 
@@ -3203,7 +3201,7 @@ class Manager:
 
                 tmp = port_str.split(".")
                 tmp.pop()
-                comp_name = OpenRTM_aist.flatten(tmp, ".")
+                comp_name = ".".join([x.strip() for x in tmp])
                 port_name = port_str
 
                 if comp_name.find("://") == -1:

--- a/OpenRTM_aist/OutPort.py
+++ b/OpenRTM_aist/OutPort.py
@@ -103,8 +103,8 @@ class OutPort(OpenRTM_aist.OutPortBase):
         #self._OnDisconnect   = None
 
         marshaling_types = OpenRTM_aist.SerializerFactories.instance().getSerializerList(value)
-        marshaling_types = OpenRTM_aist.flatten(marshaling_types).lstrip()
-        self.addProperty("dataport.marshaling_types", marshaling_types)
+        marshaling_types_str = ",".join([x.strip() for x in marshaling_types])
+        self.addProperty("dataport.marshaling_types", marshaling_types_str)
 
         self._listeners.setDataType(copy.deepcopy(value))
         self._listeners.setPortType(OpenRTM_aist.PortType.OutPortType)

--- a/OpenRTM_aist/OutPortBase.py
+++ b/OpenRTM_aist/OutPortBase.py
@@ -254,10 +254,7 @@ class OutPortBase(OpenRTM_aist.PortBase, OpenRTM_aist.DataPortStatus):
 
         # publisher list
         factory = OpenRTM_aist.PublisherFactory.instance()
-        pubs = OpenRTM_aist.flatten(factory.getIdentifiers())
-
-        # blank characters are deleted for RTSE's bug
-        pubs = pubs.lstrip()
+        pubs = ",".join([x.strip() for x in factory.getIdentifiers()])
 
         self._rtcout.RTC_DEBUG("available subscription_type: %s", pubs)
         self.addProperty("dataport.subscription_type", pubs)

--- a/OpenRTM_aist/PeriodicECSharedComposite.py
+++ b/OpenRTM_aist/PeriodicECSharedComposite.py
@@ -232,8 +232,7 @@ class PeriodicECOrganization(OpenRTM_aist.Organization_impl):
             self.removePort(member, self._expPorts)
             self._rtobj.getProperties().setProperty(
                 "conf.default.exported_ports",
-                OpenRTM_aist.flatten(
-                    self._expPorts))
+                ",".join([x.strip() for x in self._expPorts]))
             self.removeParticipantFromEC(member)
             self.removeOrganizationFromTarget(member)
             self.startOwnedEC(member)

--- a/OpenRTM_aist/SdoServiceAdmin.py
+++ b/OpenRTM_aist/SdoServiceAdmin.py
@@ -178,7 +178,7 @@ class SdoServiceAdmin:
 
         availableProviderTypes = OpenRTM_aist.SdoServiceProviderFactory.instance().getIdentifiers()
         prop.setProperty("sdo.service.provider.available_services",
-                         str(OpenRTM_aist.flatten(availableProviderTypes)))
+                         ",".join([x.strip() for x in availableProviderTypes]))
         self._rtcout.RTC_DEBUG("sdo.service.provider.available_services: %s",
                                prop.getProperty("sdo.service.provider.available_services"))
 
@@ -223,7 +223,7 @@ class SdoServiceAdmin:
                                str(constypes))
 
         prop.setProperty("sdo.service.consumer.available_services",
-                         str(OpenRTM_aist.flatten(OpenRTM_aist.SdoServiceConsumerFactory.instance().getIdentifiers())))
+                         ",".join([x.strip() for x in OpenRTM_aist.SdoServiceConsumerFactory.instance().getIdentifiers()]))
         self._rtcout.RTC_DEBUG("sdo.service.consumer.available_services: %s",
                                prop.getProperty("sdo.service.consumer.available_services"))
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

- #296 


## Description of the Change

コンマ区切りの文字列を設定するプロパティについて、C++と仕様が違う部分について修正した。

以下の項目についても空白の削除をしていないが、これはC++でも削除していないため修正していない。

https://github.com/OpenRTM/OpenRTM-aist-Python/blob/f35041af5898d504855b16c3bc5d5f47a40a8ad1/OpenRTM_aist/Manager.py#L407-L408
https://github.com/OpenRTM/OpenRTM-aist-Python/blob/f35041af5898d504855b16c3bc5d5f47a40a8ad1/OpenRTM_aist/Manager.py#L2650-L2652
https://github.com/OpenRTM/OpenRTM-aist-Python/blob/f35041af5898d504855b16c3bc5d5f47a40a8ad1/OpenRTM_aist/Manager.py#L2660-L2663
https://github.com/OpenRTM/OpenRTM-aist-Python/blob/f35041af5898d504855b16c3bc5d5f47a40a8ad1/OpenRTM_aist/Manager.py#L3164
https://github.com/OpenRTM/OpenRTM-aist-Python/blob/f35041af5898d504855b16c3bc5d5f47a40a8ad1/OpenRTM_aist/Manager.py#L3206
https://github.com/OpenRTM/OpenRTM-aist-Python/blob/f35041af5898d504855b16c3bc5d5f47a40a8ad1/OpenRTM_aist/SdoServiceAdmin.py#L180-L181
https://github.com/OpenRTM/OpenRTM-aist-Python/blob/f35041af5898d504855b16c3bc5d5f47a40a8ad1/OpenRTM_aist/SdoServiceAdmin.py#L225-L226
https://github.com/OpenRTM/OpenRTM-aist-Python/blob/f35041af5898d504855b16c3bc5d5f47a40a8ad1/OpenRTM_aist/PeriodicECSharedComposite.py#L233-L236


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
