### PR TITLE
ROSTransportでSubscriber側のRTCが異常終了すると、Publisher側のRTCがエラー状態になる問題

### DIFF
--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSOutPort.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSOutPort.py
@@ -352,7 +352,7 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
                     
                 # connector.shutdown(socket.SHUT_RDWR)
 
-                ret = self.CONNECTION_LOST
+                #ret = self.CONNECTION_LOST
                 self._tcp_connecters.remove(connector)
         return ret
 

--- a/OpenRTM_aist/ext/transport/ROSTransport/ROSOutPort.py
+++ b/OpenRTM_aist/ext/transport/ROSTransport/ROSOutPort.py
@@ -344,7 +344,12 @@ class ROSOutPort(OpenRTM_aist.InPortConsumer):
                 connector.sendall(data)
             except BaseException:
                 self._rtcout.RTC_ERROR("send error")
-                self._topicmgr.removeSubscriberLink(connector.getConnection())
+                try:
+                    self._topicmgr.removeSubscriberLink(connector.getConnection())
+                except OSError as e:
+                    self._rtcout.RTC_ERROR(e)
+                    
+                    
                 # connector.shutdown(socket.SHUT_RDWR)
 
                 ret = self.CONNECTION_LOST


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

ConsoleInとConsoleOutを起動して、ROSTransportで接続する。
ConsoleOutをkillコマンドで終了させた後、ConsoleInでデータを送信しようとすると、ConsoleInがエラー状態になる。


```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/OpenRTM_aist/DataFlowComponentBase.py", line 123, in on_execute
    ret = self.onExecute(ec_id)
  File "/usr/local/share/openrtm-2.0/components/python3/SimpleIO/ConsoleIn.py", line 101, in onExecute
    self._outport.write()
  File "/usr/local/lib/python3.8/dist-packages/OpenRTM_aist/OutPort.py", line 195, in write
    ret = con.write(value)
  File "/usr/local/lib/python3.8/dist-packages/OpenRTM_aist/OutPortPushConnector.py", line 283, in write
    return self._publisher.write(cdr_data, -1, 0)
  File "/usr/local/lib/python3.8/dist-packages/OpenRTM_aist/PublisherFlush.py", line 288, in write
    self._retcode = self._consumer.put(data)
  File "/home/n-miyamoto2/rtcrostest/./ext/ROSTransport/ROSOutPort.py", line 324, in put
    self._topicmgr.removeSubscriberLink(connector.getConnection())
  File "/home/n-miyamoto2/rtcrostest/./ext/ROSTransport/ROSTopicManager.py", line 835, in removeSubscriberLink
    con.exit()
  File "/home/n-miyamoto2/rtcrostest/./ext/ROSTransport/ROSTopicManager.py", line 1336, in exit
    self._conn.shutdown(socket.SHUT_RDWR)
OSError: [Errno 107] Transport endpoint is not connected
```


## Description of the Change

ROSTransportで例外が発生する箇所について、ROSTransportの中で例外処理するように修正した。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
