### PR TITLE
RTM-Python-build-idlリポジトリでの変更に対応

### DIFF
--- a/packages/deb/debian/rules
+++ b/packages/deb/debian/rules
@@ -49,7 +49,7 @@ install: build
 	(mkdir -p $(TARGET)/lib/python3/dist-packages)
 	(cp -r $(CURDIR)/OpenRTM_aist $(TARGET)/lib/python3/dist-packages)
 	(cp -r $(CURDIR)/OpenRTM_aist*.dist-info $(TARGET)/lib/python3/dist-packages)
-	(cp $(CURDIR)/bin/OpenRTM-aist.pth $(TARGET)/lib/python3/dist-packages)
+	(cp $(CURDIR)/OpenRTM-aist.pth $(TARGET)/lib/python3/dist-packages)
 
 	# for openrtm2-python3-example package
 	(mkdir -p $(TARGET_example))

--- a/packages/deb/dpkg_build.sh
+++ b/packages/deb/dpkg_build.sh
@@ -117,6 +117,7 @@ extract_source()
   mkdir ${BUILD_ROOT}
   cp -r ../../examples ${BUILD_ROOT}/
   cp -r ../../OpenRTM_aist* ${BUILD_ROOT}/
+  cp ../../OpenRTM-aist.pth ${BUILD_ROOT}/
   find ${BUILD_ROOT}/examples | grep -E "(/__pycache__$|\.pyc$|\.pyo$)" | xargs rm -rf
   find ${BUILD_ROOT}/examples -name "*.bat" | xargs rm -f
   rm ${BUILD_ROOT}/examples/rtc.conf.sample
@@ -142,7 +143,6 @@ extract_source()
   rm ${BUILD_ROOT}/OpenRTM_aist/utils/rtcprof/*.bat
   rm ${BUILD_ROOT}/OpenRTM_aist/utils/rtcprof/rtcprof2_python3
   cp -r ../../local/bin ${BUILD_ROOT}/
-  chmod -x ${BUILD_ROOT}/bin/*.pth
 }
 
 create_files()

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,5 +16,4 @@ include_package_data = True
 scripts =
     OpenRTM_aist/utils/rtcd/rtcd2_python3
     OpenRTM_aist/utils/rtcprof/rtcprof2_python3
-    OpenRTM-aist.pth
 


### PR DESCRIPTION

<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #311 
## Identify the Bug

Link to #311


## Description of the Change
- これまでは　python3 -m build で生成されたwhlファイルを使ってインストールした場合、OpenRTM-aist.pthが /usr/bin下にインストールされていたが、今回の修正で、/usr/lib/python3/dist-packages下にインストールされるようになった
- debパッケージ作成処理でこの変更に対応し、合わせて setup.cfg での指定も不要なので削除した

## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->
- debパッケージを生成し、OpenRTM-aist.pthのインストール先を確認した
- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
