### PR TITLE
debパッケージビルド時のwhlファイル名小文字表記への対応

### DIFF
--- a/packages/deb/debian/rules
+++ b/packages/deb/debian/rules
@@ -48,7 +48,7 @@ install: build
 	(cp $(CURDIR)/bin/rtc*2_python $(TARGET)/bin)
 	(mkdir -p $(TARGET)/lib/python3/dist-packages)
 	(cp -r $(CURDIR)/OpenRTM_aist $(TARGET)/lib/python3/dist-packages)
-	(cp -r $(CURDIR)/OpenRTM_aist*.dist-info $(TARGET)/lib/python3/dist-packages)
+	(cp -r $(CURDIR)/openrtm_aist*.dist-info $(TARGET)/lib/python3/dist-packages)
 	(cp $(CURDIR)/OpenRTM-aist.pth $(TARGET)/lib/python3/dist-packages)
 
 	# for openrtm2-python3-example package

--- a/packages/deb/dpkg_build.sh
+++ b/packages/deb/dpkg_build.sh
@@ -117,6 +117,7 @@ extract_source()
   mkdir ${BUILD_ROOT}
   cp -r ../../examples ${BUILD_ROOT}/
   cp -r ../../OpenRTM_aist* ${BUILD_ROOT}/
+  cp -r ../../openrtm_aist* ${BUILD_ROOT}/
   cp ../../OpenRTM-aist.pth ${BUILD_ROOT}/
   find ${BUILD_ROOT}/examples | grep -E "(/__pycache__$|\.pyc$|\.pyo$)" | xargs rm -rf
   find ${BUILD_ROOT}/examples -name "*.bat" | xargs rm -f


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #321 

## Identify the Bug

Link to #321 


## Description of the Change

- 今回の修正はdebパッケージ生成用定義で、OpenRTM_aist_Python と表記していてエラーになった部分だけ小文字に変更した
- whlファイルだけでなく、.dist-info ファイル名も小文字表記に変更されていたので対応した

## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->
- 修正ソースを使い、Ubuntu22.04, 24.04 それぞれの環境でdebパッケージを生成できることを確認した
- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
